### PR TITLE
Specify Python version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,12 +10,14 @@ build:
 
 requirements:
   build:
+    - python {{PY_VER}}*
     - numpy
     - python
     - setuptools
     - setuptools_scm
 
   run:
+    - python {{PY_VER}}*
     - h5py
     - numba
     - numpy


### PR DESCRIPTION
This is needed so conda uses that same version of python for build
and test. Plus anytime we have numpy as a dep we are tied to a
particular python version.