### PR TITLE
Chunk stats

### DIFF
--- a/hexrd/imageseries/load/array.py
+++ b/hexrd/imageseries/load/array.py
@@ -52,7 +52,7 @@ class ArrayImageSeriesAdapter(ImageSeriesAdapter):
         return self._data.dtype
 
     def __getitem__(self, key):
-        return self._data[key]
+        return self._data[key].copy()
 
     def __iter__(self):
         return ImageSeriesIterator(self)

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -1,11 +1,31 @@
-"""Stats for imageseries
+"""aggregate statistics for imageseries
 
-runs in chunks:
-if chunks is None, chunks are determined here and all are run
-otherwise, chunks is tuple of (i, n, img) where
- i < n is the current chunk to compute,
- n is the total number of chunks,
- and img is the current image
+The functions here operate on the frames of an imageseries.
+Because there may be an large number of images, the images
+are processed in chunks, some number of rows at a time.
+All of the functions take a keyword arguments of "chunk" and "nframes".
+If "nframes" is greater than 0, it means use only that many frames of
+the imageseries; otherwise use all the frames.
+The "chunks" argument may be either None or a 3-tuple (i, n, img), where:
+
+ i is the current chunk to compute,
+ n is the total number of chunks, and
+ img is the current image with same shape as the imageseries
+
+If chunks is not None, then the the function needs to be called n times,
+and after each call an intermediate image is returned, the last being complete.
+
+If chunks is None, then only one call is needed, and the number of chunks is
+determined by the STATS_BUFFER variable.
+
+For example, to find the median image for an imageseries "ims" using "nchunk" chunks:
+
+    img = np.zeros(ims.shape)
+    for i in range(nchunk):
+        img = op(ims, chunk=(i, nchunk, img))
+        print("%d/%d" % (i, nchunk), img)
+    return img
+
 """
 
 
@@ -19,6 +39,7 @@ from hexrd.imageseries.process import ProcessedImageSeries as PIS
 # Default Buffer: half of available memory
 vmem = virtual_memory()
 STATS_BUFFER = int(0.5*vmem.available)
+del vmem
 
 
 def max(ims, chunk=None, nframes=0):

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -110,6 +110,27 @@ def _chunk_ranges(nrows, nchunk, chunk):
     return r0, r1
 
 
+def _chunk_op(op, ims, nf, chunk, *args):
+    """run operation on one chunk of image data
+    ims -- the imageseries
+    nf -- total number of frames to use
+    chunk -- tuple of (i, n, img)
+    args -- args to pass to op
+"""
+    nf = len(ims)
+    nrows, ncols = ims.shape
+    i = chunk[0]
+    nchunk = chunk[1]
+    img = chunk[2]
+    r0, r1 = _chunk_ranges(nrows, nchunk, i)
+    rect = np.array([[r0, r1], [0, ncols]])
+    pims = PIS(ims, [('rectangle', rect)])
+    a = _toarray(pims, nf)
+    img[r0:r1, :] = op(a, *args, axis=0)
+
+    return img
+
+
 def _row_ranges(n, m):
     """return row ranges, representing m rows or remainder, until exhausted"""
     i = 0

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -43,9 +43,9 @@ def max_iter(ims, nchunk, nframes=0):
     stop = stops[s0]
     img = ims[0]
     if stop == 0:
+        if nf > 1:
+            s0, stop = 1, stops[1]
         yield img
-        s0 += 1
-        stop = stops[s0]
 
     for i in range(1, nf):
         img = np.maximum(img, ims[i])
@@ -72,9 +72,10 @@ def min_iter(ims, nchunk, nframes=0):
     s0, stop = 0, stops[0]
     img = ims[0]
     if stop == 0:
+        if nf > 1:
+            s0, stop = 1, stops[1]
         yield img
-        s0 += 1
-        stop = stops[s0]
+
     for i in range(1, nf):
         img = np.minimum(img, ims[i])
         if i >= stop:
@@ -103,8 +104,10 @@ def average_iter(ims, nchunk, nframes=0):
     s0, stop = 0, stops[0]
     img = ims[0]
     if stop == 0:
-        s0, stop = 1, stops[1]
+        if nf > 1:
+            s0, stop = 1, stops[1]
         yield img
+
     for i in range(1, nf):
         img += ims[i]
         if i >= stop:

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -8,9 +8,7 @@ from psutil import virtual_memory
 
 from hexrd.imageseries.process import ProcessedImageSeries as PIS
 
-# Default Buffer: 100 MB
-#STATS_BUFFER = 419430400    # 50 GE frames
-#STATS_BUFFER = 838860800    # 100 GE frames
+# Default Buffer: half of available memory
 vmem = virtual_memory()
 STATS_BUFFER = int(0.5*vmem.available)
 

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -105,8 +105,6 @@ def _chunk_op(op, ims, nf, chunk, *args):
     nchunk = chunk[1]
     img = chunk[2]
     r0, r1 = _chunk_ranges(nrows, nchunk, i)
-    rect = np.array([[r0, r1], [0, ncols]])
-    # pims = PIS(ims, [('rectangle', rect)])
     a = _toarray(ims, nf, r0, r1)
     img[r0:r1, :] = op(a, *args, axis=0)
 

--- a/hexrd/imageseries/tests/test_stats.py
+++ b/hexrd/imageseries/tests/test_stats.py
@@ -8,6 +8,7 @@ from .common import ImageSeriesTest, make_array, make_array_ims
 
 class TestImageSeriesStats(ImageSeriesTest):
 
+
     def test_stats_median(self):
         """Processed imageseries: median"""
         a = make_array()
@@ -15,7 +16,8 @@ class TestImageSeriesStats(ImageSeriesTest):
         ismed = stats.median(is_a)
         amed = np.median(a, axis=0)
         err = np.linalg.norm(amed - ismed)
-        self.assertAlmostEqual(err, 0., msg="median image failed")
+        self.assertAlmostEqual(err, 0., msg="stats.median failed")
+
 
     def test_stats_max(self):
         """Processed imageseries: median"""
@@ -24,4 +26,44 @@ class TestImageSeriesStats(ImageSeriesTest):
         ismax = stats.max(is_a)
         amax = np.max(a, axis=0)
         err = np.linalg.norm(amax - ismax)
-        self.assertAlmostEqual(err, 0., msg="max image failed")
+        self.assertAlmostEqual(err, 0., msg="stats.max failed")
+
+
+    def test_stats_min(self):
+        """Processed imageseries: median"""
+        a = make_array()
+        is_a = imageseries.open(None, 'array', data=a)
+        ismin = stats.min(is_a)
+        amin = np.min(a, axis=0)
+        err = np.linalg.norm(amin - ismin)
+        self.assertAlmostEqual(err, 0., msg="stats.min failed")
+
+
+    def test_stats_percentile(self):
+        """Processed imageseries: median"""
+        a = make_array()
+        is_a = imageseries.open(None, 'array', data=a)
+        isp90 = stats.percentile(is_a, 90)
+        ap90 = np.percentile(a, 90, axis=0)
+        err = np.linalg.norm(ap90 - isp90)
+        self.assertAlmostEqual(err, 0., msg="stats.min failed")
+
+
+    def test_stats_chunk(self):
+        """Processed imageseries: median"""
+        a = make_array()
+        is_a = imageseries.open(None, 'array', data=a)
+        amed = np.median(a, axis=0)
+
+        # Run with 1 chunk
+        img = np.zeros(is_a.shape)
+        ismed1 = stats.median(is_a, chunk=(0, 1, img))
+        err = np.linalg.norm(amed - ismed1)
+        self.assertAlmostEqual(err, 0., msg="stats.median failed")
+
+        # Run with 2 chunks
+        img = np.zeros(is_a.shape)
+        img = stats.median(is_a, chunk=(0, 2, img))
+        ismed2 = stats.median(is_a, chunk=(1, 2, img))
+        err = np.linalg.norm(amed - ismed2)
+        self.assertAlmostEqual(err, 0., msg="stats.median failed")


### PR DESCRIPTION
This updates the imageseries.stats.median() function to use chunks and return an intermediate image at each point, allowing the calling function to update a progress bar. I will follow up with another request applying these changes to other functions such average, max or percentile. Here is an example of the usage:

```python
import numpy as np

from hexrd import imageseries


stats = imageseries.stats

a = np.ones((50, 10, 6))
for i in range(a.shape[1]): # set values by row
    a[:,i,:] = i
ims = imageseries.open(None, 'array', data=a)


def run_chunk(ims, nchunk):
    img = np.zeros(ims.shape)
    for i in range(nchunk):
        img = stats.median(ims, chunk=(i, nchunk, img))
        print("%d/%d\n" % (i, nchunk), img)
    return img
```