### PR TITLE
Remove unused variable

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1901,8 +1901,6 @@ class PlanarDetector(object):
 
             if delta_tth is not None:
                 pd.tThWidth = np.radians(delta_tth)
-            else:
-                delta_tth = np.degrees(pd.tThWidth)
 
             # conversions, meh...
             del_eta = np.radians(delta_eta)


### PR DESCRIPTION
In PlanarDetector.make_powder_rings(), if the material's plane data
has a tThWidth of None, and no delta_tth is passed to the function,
an exception occurs when `np.degrees(pd.tThWidth)` is attempted.

Upon looking further, though, it appears that the `delta_tth`
variable is not used beyond that point, so it seems to be not
necessary to set it.

Remove the variable so that the exception goes away.