### PR TITLE
Remove asterisk from python version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,14 +10,14 @@ build:
 
 requirements:
   build:
-    - python {{PY_VER}}*
+    - python {{PY_VER}}
     - numpy
     - python
     - setuptools
     - setuptools_scm
 
   run:
-    - python {{PY_VER}}*
+    - python {{PY_VER}}
     - h5py
     - numba
     - numpy


### PR DESCRIPTION
This cause issues when build the conda package on Windows.