### PR TITLE
Add missing del_eta to make_powder_rings

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -653,6 +653,8 @@ class PlanarDetector(object):
                                 delta_tth, -delta_eta,
                                 0.0, 0.0]), (len(tth), 1)
                 )
+            # Convert to radians as is done below
+            del_eta = np.radians(delta_eta)
         else:
             # Okay, we have a PlaneData object
             try:


### PR DESCRIPTION
This commit is the same as 42c3a0f0bcd525eb5b800a887e2468d00f9b30f0 (#3),
except this is for the new instrument class. This change is needed for the cartesian
viewer in hexrdgui.

The old commit message is pasted again below.

Most of the time, when a user would call make_powder_rings(),
they probably passed a PlaneData object. However, the function is
also designed to accept a list of two theta values. It appears,
though, that if you pass it a list of two theta values, it misses
the creation of del_eta that is normally done if a PlaneData object
is passed in.

This adds in the missing variable. The function seems to work properly
if this variable is included.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>