### PR TITLE
Don't remove 'v'

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: hexrd
   #version: {{ environ.get('GIT_DESCRIBE_TAG', environ['GIT_FULL_HASH'][:8]) }}
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '')[1:] }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
 
 source:
   path: ../


### PR DESCRIPTION
We are no longer prefixing our versions with 'v', so don't try to
remove it!