### PR TITLE
Cache config data from files. Allow setting the data.

### DIFF
--- a/hexrd/config/instrument.py
+++ b/hexrd/config/instrument.py
@@ -8,11 +8,8 @@ from hexrd import instrument
 class Instrument(Config):
     """Handle HEDM instrument config."""
 
-    def __init__(self, instr_file):
+    def __init__(self, instr_file=None):
         self._configuration = instr_file
-        with open(instr_file, 'r') as f:
-            icfg = yaml.safe_load(f)
-        self._hedm = instrument.HEDMInstrument(icfg)
 
     # Note: instrument is instantiated with a yaml dictionary; use self
     #       to instantiate classes based on this one
@@ -24,6 +21,10 @@ class Instrument(Config):
     @property
     def hedm(self):
         """Return the HEDMInstrument class."""
+        if not hasattr(self, '_hedm'):
+            with open(self.configuration, 'r') as f:
+                icfg = yaml.safe_load(f)
+            self._hedm = instrument.HEDMInstrument(icfg)
         return self._hedm
 
     @hedm.setter

--- a/hexrd/config/material.py
+++ b/hexrd/config/material.py
@@ -31,8 +31,19 @@ class MaterialConfig(Config):
     @property
     def plane_data(self):
         """Return the active material PlaneData class."""
-        with open(self.definitions, "rb") as matf:
-            mat_list = cpl.load(matf)
-        return dict(
-            zip([i.name for i in mat_list], mat_list)
-        )[self.active].planeData
+        return self.materials[self.active].planeData
+
+    @property
+    def materials(self):
+        """Return a dict of materials."""
+        if not hasattr(self, '_materials'):
+            with open(self.definitions, "rb") as matf:
+                mat_list = cpl.load(matf)
+            self._materials = dict(
+                zip([i.name for i in mat_list], mat_list)
+            )
+        return self._materials
+
+    @materials.setter
+    def materials(self, mats):
+        self._materials = mats

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -38,12 +38,24 @@ class RootConfig(Config):
 
     @property
     def instrument(self):
-        instr_file = self.get('instrument')
-        return Instrument(instr_file)
+        if not hasattr(self, '_instr_config'):
+            instr_file = self.get('instrument')
+            self._instr_config = Instrument(instr_file)
+        return self._instr_config
+
+    @instrument.setter
+    def instrument(self, instr_config):
+        self._instr_config = instr_config
 
     @property
     def material(self):
-        return MaterialConfig(self)
+        if not hasattr(self, '_material_config'):
+            self._material_config = MaterialConfig(self)
+        return self._material_config
+
+    @material.setter
+    def material(self, material_config):
+        self._material_config = material_config
 
     @property
     def analysis_id(self):
@@ -149,3 +161,7 @@ class RootConfig(Config):
                 self._image_dict[panel] = oms
 
         return self._image_dict
+
+    @image_series.setter
+    def image_series(self, ims_dict):
+        self._image_dict = ims_dict


### PR DESCRIPTION
When config data is loaded from a file for the first time, store
the data on a member variable so that if the data is requested a
second time, it doesn't need to be read from the file again.

This also allows applications, such as hexrdgui, to set the config
data if the data has already been loaded into the application,
so that the data doesn't need to be loaded from the files again.