### PR TITLE
Add __iter__ method to ProcessedImageSeries

### DIFF
--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -45,6 +45,12 @@ class ProcessedImageSeries(ImageSeries):
     def __len__(self):
         return len(self._frames) if self._hasframelist else len(self._imser)
 
+    def __iter__(self):
+        if self._hasframelist:
+            return (self._imser[i] for i in self._frames)
+
+        return self._imser.__iter__()
+
     def _process_frame(self, key):
         # note: key refers to original imageseries
         img = np.copy(self._imser[key])


### PR DESCRIPTION
This is required in order to run find_orientations with a
ProcessedImageSeries object.

If frames were specified, then a generator is returned which
yields the frames one at a time as they are iterated through.

Otherwise, the underlying image series' iterator is used.