### PR TITLE
Add common save method for Eta Omega maps

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -45,7 +45,6 @@ from scipy.linalg.matfuncs import logm
 
 from hexrd.gridutil import cellIndices, make_tolerance_grid
 from hexrd import matrixutil as mutil
-from hexrd.valunits import valWUnit
 from hexrd.transforms.xfcapi import \
     anglesToGVec, \
     angularDifference, \
@@ -3016,26 +3015,5 @@ class GenerateEtaOmeMaps(object):
         return self._omegas
 
     def save(self, filename):
-        """
-        self.dataStore
-        self.planeData
-        self.iHKLList
-        self.etaEdges
-        self.omeEdges
-        self.etas
-        self.omegas
-        """
-        args = np.array(self.planeData.getParams())[:4]
-        args[2] = valWUnit('wavelength', 'length', args[2], 'angstrom')
-        hkls = self.planeData.hkls
-        save_dict = {'dataStore': self.dataStore,
-                     'etas': self.etas,
-                     'etaEdges': self.etaEdges,
-                     'iHKLList': self.iHKLList,
-                     'omegas': self.omegas,
-                     'omeEdges': self.omeEdges,
-                     'planeData_args': args,
-                     'planeData_hkls': hkls}
-        np.savez_compressed(filename, **save_dict)
-        return
+        xrdutil.EtaOmeMaps.save_eta_ome_maps(self, filename)
     pass  # end of class: GenerateEtaOmeMaps

--- a/hexrd/xrdutil.py
+++ b/hexrd/xrdutil.py
@@ -37,6 +37,8 @@ from hexrd.crystallography import processWavelength, PlaneData
 from hexrd.transforms import xf
 from hexrd.transforms import xfcapi
 
+from hexrd.valunits import valWUnit
+
 from hexrd import distortion as distortion_module
 
 from hexrd.constants import USE_NUMBA
@@ -80,6 +82,33 @@ class EtaOmeMaps(object):
         self.omeEdges = ome_eta['omeEdges']
         self.etas = ome_eta['etas']
         self.omegas = ome_eta['omegas']
+
+    def save(self, filename):
+        self.save_eta_ome_maps(self, filename)
+
+    @staticmethod
+    def save_eta_ome_maps(eta_ome, filename):
+        """
+        eta_ome.dataStore
+        eta_ome.planeData
+        eta_ome.iHKLList
+        eta_ome.etaEdges
+        eta_ome.omeEdges
+        eta_ome.etas
+        eta_ome.omegas
+        """
+        args = np.array(eta_ome.planeData.getParams())[:4]
+        args[2] = valWUnit('wavelength', 'length', args[2], 'angstrom')
+        hkls = eta_ome.planeData.hkls
+        save_dict = {'dataStore': eta_ome.dataStore,
+                     'etas': eta_ome.etas,
+                     'etaEdges': eta_ome.etaEdges,
+                     'iHKLList': eta_ome.iHKLList,
+                     'omegas': eta_ome.omegas,
+                     'omeEdges': eta_ome.omeEdges,
+                     'planeData_args': args,
+                     'planeData_hkls': hkls}
+        np.savez_compressed(filename, **save_dict)
     pass  # end of class: EtaOmeMaps
 
 


### PR DESCRIPTION
This adds a static save method on `hexrd.xrdutil.EtaOmeMaps` (copied
directory from `hexrd.instrument.GenerateEtaOmeMaps.save()`), that
is used both by `EtaOmeMaps` and `GenerateEtaOmeMaps` to save their
data.

This is mostly done so that `EtaOmeMaps` can have a `save()` method
too, which is helpful for the GUI...