### PR TITLE
check for zero length imageseries

### DIFF
--- a/hexrd/imageseries/__init__.py
+++ b/hexrd/imageseries/__init__.py
@@ -16,6 +16,9 @@ def open(filename, format=None, **kwargs):
     # find the appropriate adapter based on format specified
     reg = load.Registry.adapter_registry
     adapter = reg[format](filename, **kwargs)
-    return ImageSeries(adapter)
+    ims = ImageSeries(adapter)
+    if len(ims) == 0:
+        raise RuntimeError("zero length imageseries")
+    return ims
 
 write = save.write

--- a/hexrd/imageseries/load/trivial.py
+++ b/hexrd/imageseries/load/trivial.py
@@ -1,5 +1,13 @@
-"""Trivial adapter: just testing auto-import"""
+"""Trivial adapter: just for testing"""
 from . import ImageSeriesAdapter
 
 class TrivialAdapter(ImageSeriesAdapter):
-    pass
+
+    def __init__(self, fname):
+        pass
+
+    def __len__(self):
+        return 0
+
+    def __getitem__(self):
+        return None


### PR DESCRIPTION
This adds a check for zero-length imageseries in imageseries.open() and raises a RuntimeError in that case.I also updated the trivial imageseries (key=None) to return a 0-length imageseries.