### PR TITLE
pep 8: is not vs. !=

### DIFF
--- a/hexrd/imageseries/load/registry.py
+++ b/hexrd/imageseries/load/registry.py
@@ -7,7 +7,7 @@ class Registry(object):
     @classmethod
     def register(cls, acls):
         """Register adapter class"""
-        if acls.__name__ is not 'ImageSeriesAdapter':
+        if acls.__name__ != 'ImageSeriesAdapter':
             cls.adapter_registry[acls.format] = acls
 
     pass  # end class

--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -46,7 +46,7 @@ class _Registry(object):
     @classmethod
     def register(cls, wcls):
         """Register writer class"""
-        if wcls.__name__ is not 'Writer':
+        if wcls.__name__ != 'Writer':
             cls.writer_registry[wcls.fmt] = wcls
 
     @classmethod


### PR DESCRIPTION
Updated two files in imageseries package that used "is not" when it should be "!=". Unit tests still run, so this looks ok. 