### PR TITLE
Don't reuse grains_filename variable

### DIFF
--- a/hexrd/cli/fit_grains.py
+++ b/hexrd/cli/fit_grains.py
@@ -232,7 +232,7 @@ def execute(args, parser):
 
         logger.info('*** end analysis "%s" ***', cfg.analysis_name)
 
-        write_results(fit_results, cfg, grains_filename)
+        write_results(fit_results, cfg)
 
     logger.info('=== end fit-grains ===')
     # stop logging to the console


### PR DESCRIPTION
`cli/fit_grains()` was using the same variable (`grains_filename`) to load the fit-grains estimate and write the fit-grains result.