### PR TITLE
Build package in container

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+cd /github/workspace/
+yum install -y wget git gcc
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+chmod a+x Miniconda3-latest-Linux-x86_64.sh
+./Miniconda3-latest-Linux-x86_64.sh -b
+${HOME}/miniconda3/bin/conda create -y -n hexrd
+${HOME}/miniconda3/bin/activate hexrd
+${HOME}/miniconda3/bin/conda activate hexrd
+${HOME}/miniconda3/bin/conda install conda-build
+mkdir output
+${HOME}/miniconda3/bin/conda build --output-folder output/ conda.recipe/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         fetch-depth: 0
 
+
     - name: Install conda
       uses: goanpeca/setup-miniconda@v1
       with:
@@ -52,7 +53,8 @@ jobs:
       # command works.
       shell: bash -l {0}
 
-    - name: Build the package
+    - name: Build the package (host)
+      if: ${{ matrix.config.name != 'Linux' }}
       run: |
           conda activate hexrd
           mkdir output
@@ -60,6 +62,12 @@ jobs:
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}
+
+    - name: Build the package (container)
+      if: ${{ matrix.config.name == 'Linux' }}
+      uses: docker://centos:6.10
+      with:
+        entrypoint: /github/workspace/.github/workflows/container_build.sh
 
     - name: Upload the package to anaconda channel ( tag push to master)
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,7 +35,6 @@ jobs:
       with:
         fetch-depth: 0
 
-
     - name: Install conda
       uses: goanpeca/setup-miniconda@v1
       with:
@@ -69,7 +68,7 @@ jobs:
       with:
         entrypoint: /github/workspace/.github/workflows/container_build.sh
 
-    - name: Upload the package to anaconda channel ( tag push to master)
+    - name: Upload the package to anaconda channel (tag push to master)
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       run: |
           conda activate hexrd
@@ -86,7 +85,6 @@ jobs:
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}
-
 
     - name: Get version for the artifact names
       id: describe


### PR DESCRIPTION
This PR moves the build of the package into a older Linux container. This ensure that we build with an old version of glibc so the package will work on older distros as well. @joelvbernier this should resolve the issue your collaborator is seeing.  