### PR TITLE
updated config to use working_dir consistently

### DIFF
--- a/hexrd/config/config.py
+++ b/hexrd/config/config.py
@@ -1,6 +1,7 @@
 """Base Config class"""
 
 import logging
+import os
 
 from .utils import null
 
@@ -51,10 +52,29 @@ class Config(object):
             temp[item] = val
             self._dirty = True
 
-
     def dump(self, filename):
         import yaml
 
         with open(filename, 'w') as f:
             yaml.dump(self._cfg, f)
         self._dirty = False
+
+    @staticmethod
+    def check_filename(fname, wdir):
+        """Check whether filename is valid relative to working directory
+
+        fname - the name of the file
+
+        Returns the absolute path of the filename if the file exists
+
+        If fname is an absolute path, use that; otherwise take it as a path relative
+        to the working directory.
+"""
+        temp = fname
+        if not os.path.isabs(fname):
+            temp = os.path.join(wdir, temp)
+        if os.path.exists(temp):
+            return temp
+        raise IOError(
+            'file: "%s" not found' % temp
+            )

--- a/hexrd/config/config.py
+++ b/hexrd/config/config.py
@@ -67,8 +67,8 @@ class Config(object):
 
         Returns the absolute path of the filename if the file exists
 
-        If fname is an absolute path, use that; otherwise take it as a path relative
-        to the working directory.
+        If fname is an absolute path, use that; otherwise take it as a path
+        relative to the working directory.
 """
         temp = fname
         if not os.path.isabs(fname):

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -40,6 +40,7 @@ class RootConfig(Config):
     def instrument(self):
         if not hasattr(self, '_instr_config'):
             instr_file = self.get('instrument')
+            instr_file = self.check_filename(instr_file, self.working_dir)
             self._instr_config = Instrument(instr_file)
         return self._instr_config
 
@@ -150,7 +151,7 @@ class RootConfig(Config):
             fmt = self.get('image_series:format')
             imsdata = self.get('image_series:data')
             for ispec in imsdata:
-                fname = ispec['file']
+                fname = self.check_filename(ispec['file'], self.working_dir)
                 args = ispec['args']
                 ims = imageseries.open(fname, fmt, **args)
                 oms = imageseries.omega.OmegaImageSeries(ims)


### PR DESCRIPTION
To address this, I added a static method in the base config class that checks filename "correctness." If the filename is an absolute path, that is what gets used. If it is a relative path, then the working_dir is prepended. Finally, if a file exists for that path, then that is returned. Otherwise, IOError is raised.

I applied this to instrument config file and to the imageseries files loaded in the image_dict.