### PR TITLE
Ensure GE_41RT params get converted to numpy array

### DIFF
--- a/hexrd/distortion/ge_41rt.py
+++ b/hexrd/distortion/ge_41rt.py
@@ -188,7 +188,7 @@ class GE_41RT(DistortionABC, metaclass=_RegisterDistortionClass):
     maptype = "GE_41RT"
 
     def __init__(self, params, **kwargs):
-        self._params = params
+        self.params = params
 
     @property
     def params(self):


### PR DESCRIPTION
Before, if a list was passed in, the params would remain as a list.

Using the setter ensures it is the correct shape and that it gets
converted to a numpy array.

This fixes cases where numpy array functions are called on the params.

This fixes the issue seen in #84 and in hexrd/hexrdgui#490

@joelvbernier @cjh1 