### PR TITLE
Fix U type check and add update_structure_factor() to Material

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -170,14 +170,7 @@ class Material(object):
             self._sgsetting)
 
         self._newPdata()
-        hkls = self.planeData.getHKLs(allHKLs=True)
-        sf = numpy.zeros([hkls.shape[0],])
-        for i,g in enumerate(hkls):
-            sf[i] = self.unitcell.CalcXRSF(g)
-
-        self.planeData.set_structFact(sf[~self.planeData.exclusions])
-
-        return
+        self.update_structure_factor()
 
     def __str__(self):
         """String representation"""
@@ -215,6 +208,14 @@ class Material(object):
         self._pData.exclusions = dflt_excl
 
         return
+
+    def update_structure_factor(self):
+        hkls = self.planeData.getHKLs(allHKLs=True)
+        sf = numpy.zeros([hkls.shape[0],])
+        for i,g in enumerate(hkls):
+            sf[i] = self.unitcell.CalcXRSF(g)
+
+        self.planeData.set_structFact(sf[~self.planeData.exclusions])
 
     def _readCif(self, fcif=DFLT_NAME+'.cif'):
         """

--- a/hexrd/mksupport.py
+++ b/hexrd/mksupport.py
@@ -311,7 +311,7 @@ def GetAsymmetricPositions(aniU=0):
 				raise ValueError(" fractional coordinates only in the range [0,1) i.e. 1 excluded")
 
 	occ, dw = GetOccDW(aniU=aniU)
-	if(type(dw) == np.float):
+	if isinstance(dw, np.floating):
 		aniU = 1
 	else:
 		aniU = 2
@@ -446,7 +446,7 @@ def WriteH5Data(fid, AtomInfo, lat_param):
 		anisotropic debye waller factors
 	'''
 
-	if(type(AtomInfo['U'][0]) != np.float):
+	if not isinstance(AtomInfo['U'][0], np.floating):
 		did = gid.create_dataset("U", (6, len(AtomInfo['Z'])), dtype = np.float64)
 		arr = np.array(AtomInfo['U'], dtype = np.float32).transpose()
 		arr2 = arr.copy()

--- a/hexrd/mksupport.py
+++ b/hexrd/mksupport.py
@@ -19,7 +19,7 @@ def mk(filename, xtalname):
 
 	# get the space group number. legend will be printed above
 	space_group, iset = GetSpaceGroup(xtal_sys, bool_trigonal, bool_hexset)
-	
+
 	AtomInfo = GetAtomInfo()
 	AtomInfo.update({'file':filename, 'xtalname':xtalname, 'xtal_sys':xtal_sys, 'SG':space_group, 'SGsetting':iset})
 
@@ -82,7 +82,7 @@ def GetLatticeParameters(xtal_sys, bool_trigonal):
 		if(not c.replace('.','',1).isdigit()):
 			raise ValueError("Invalid floating point value.")
 		else:
-			c = float(c) 
+			c = float(c)
 
 		lat_param['c'] = c
 
@@ -98,7 +98,7 @@ def GetLatticeParameters(xtal_sys, bool_trigonal):
 		if(not c.replace('.','',1).isdigit()):
 			raise ValueError("Invalid floating point value.")
 		else:
-			c = float(c) 
+			c = float(c)
 
 		lat_param['b'] = c; lat_param['c'] = c
 
@@ -257,7 +257,7 @@ def SpaceGroupSetting(sgnum):
 				raise ValueError(" Value entered for setting must be 1 or 2 !")
 
 	return iset-1
-	    
+
 def GetAtomInfo():
 
 	print(pstr_Elements)
@@ -398,7 +398,7 @@ def Write2H5File(AtomInfo, lat_param):
 	# first check if file exists
 
 	fexist = os.path.isfile(AtomInfo['file'])
-	
+
 	if(fexist):
 		fid = h5py.File(AtomInfo['file'],'r+')
 	else:
@@ -473,4 +473,4 @@ def WriteH5Data(fid, AtomInfo, lat_param):
 	fid.close()
 
 
-		
+


### PR DESCRIPTION
The commit messages are pasted below

1. Use isinstance(var, np.floating) for numpy floats

`np.float` is an alias to Python's `float` type, thus
`type(var) == np.float` does not return True for numpy float types.
However, `isinstance(var, np.floating)` will work. For instance:

```python
>>> a = np.float64(1)
>>> type(a) == np.float
False
>>> isinstance(a, np.floating)
True
```

If we want to also check for the Python float in addition to numpy float,
we can do:

```python
isinstance(var, (np.floating, float))
```

This change fixes an issue where U was being interpreted as a tensor, when
it was actually a single float.

2. Add Material function to update structure factor

We will call this when certain unit cell parameters are modified.