### PR TITLE
Wppf feature

### DIFF
--- a/hexrd/WPPF.py
+++ b/hexrd/WPPF.py
@@ -1126,7 +1126,7 @@ class Phases_LeBail:
         wavelength_nm = {}
         for k,v in wavelength.items():
             if(v.unit == 'angstrom'):
-                wavelength_nm[k] = _nm(v.value*10.)
+                wavelength_nm[k] = valWUnit('lp', 'length', v.value*10., 'nm')
             else:
                 wavelength_nm[k] = v
         self.wavelength = wavelength_nm
@@ -2764,7 +2764,7 @@ class Phases_Rietveld:
         wavelength_nm = {}
         for k,v in wavelength.items():
             if(v.unit == 'angstrom'):
-                wavelength_nm[k] = _nm(v.value*10.)
+                wavelength_nm[k] = valWUnit('lp', 'length', v.value*10., 'nm')
             else:
                 wavelength_nm[k] = v
         self.wavelength = wavelength_nm

--- a/hexrd/WPPF.py
+++ b/hexrd/WPPF.py
@@ -1118,7 +1118,19 @@ class Phases_LeBail:
 
         self.phase_dict = {}
         self.num_phases = 0
-        self.wavelength = wavelength
+
+        '''
+        set wavelength. check if wavelength is supplied in A, if it is
+        convert to nm since the rest of the code assumes those units
+        '''
+        wavelength_nm = {}
+        for k,v in wavelength.items():
+            if(v.unit == 'angstrom'):
+                wavelength_nm[k] = _nm(v.value*10.)
+            else:
+                wavelength_nm[k] = v
+        self.wavelength = wavelength_nm
+
         self.dmin = dmin
 
         if(material_file is not None):
@@ -2744,7 +2756,19 @@ class Phases_Rietveld:
 
         self.phase_dict = {}
         self.num_phases = 0
-        self.wavelength = wavelength
+
+        '''
+        set wavelength. check if wavelength is supplied in A, if it is
+        convert to nm since the rest of the code assumes those units
+        '''
+        wavelength_nm = {}
+        for k,v in wavelength.items():
+            if(v.unit == 'angstrom'):
+                wavelength_nm[k] = _nm(v.value*10.)
+            else:
+                wavelength_nm[k] = v
+        self.wavelength = wavelength_nm
+
         self.dmin = dmin
 
         if(material_file is not None):


### PR DESCRIPTION
Multiple different type of input is now supported for initializing the `LeBail` class.

1. Passing spectrum data as `numpy.ndarray`, as a text file name or as a `Spectrum` class.
2. Passing params as a `dict`, a yaml file or a `Parameters` class.
3. Passing phases as a `dict`, a yaml file or a `LeBail_phases` class.

All options were tested with the example ceria dataset uploaded to the HEXRD google drive.