### PR TITLE
Fix signal.fft() call to signal.fftconvolve()

### DIFF
--- a/hexrd/imageutil.py
+++ b/hexrd/imageutil.py
@@ -16,7 +16,7 @@ def fast_snip1d(y, w=4, numiter=2):
                 kernel = np.zeros(p*2 + 1)
                 kernel[0] = 0.5
                 kernel[-1] = 0.5
-                b = np.minimum(b, signal.fft    (z, kernel, mode='same'))
+                b = np.minimum(b, signal.fftconvolve(z, kernel, mode='same'))
             z = b
         bkg[k, :] = (np.exp(np.exp(b) - 1.) - 1.)**2 - 1.
     return bkg


### PR DESCRIPTION
It appears there was a bug injected as part of commit 55a797c0 (31-Jul-2020) for pep8 compliance. The PR changes the fast_snip1d() method back to calling signal.fftconvolve().