### PR TITLE
Add lmfit to list of requirements for hexrd

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -9,4 +9,4 @@ ${HOME}/miniconda3/bin/activate hexrd
 ${HOME}/miniconda3/bin/conda activate hexrd
 ${HOME}/miniconda3/bin/conda install conda-build
 mkdir output
-${HOME}/miniconda3/bin/conda build --output-folder output/ conda.recipe/
+${HOME}/miniconda3/bin/conda build -c defaults -c conda-forge --output-folder output/ conda.recipe/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
           conda activate hexrd
           mkdir output
-          conda build --output-folder output/ conda.recipe/
+          conda build -c defaults -c conda-forge --output-folder output/ conda.recipe/
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - python {{PY_VER}}
     - h5py
+    - lmfit ==1.0.0
     - numba
     - numpy
     - psutil

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_reqs = [
     'psutil',
     'scipy',
     'pycifrw',
+    'lmfit==1.0.0',
     'numba',
     'psutil',
     'pyyaml',


### PR DESCRIPTION
It is required to use WPPF.

The version is set at 1.0.0 for reasons mentioned in hexrd/hexrd#99.

Fixes: #99

I think I might need to add it to the [meta.yaml](https://github.com/HEXRD/hexrd/blob/master/conda.recipe/meta.yaml) for conda as well.