### PR TITLE
CIF fix

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -264,9 +264,11 @@ class Material(object):
             sgnum = int(cifdata[sgkey[0]])
         elif (skey is sgkey[1]):
             HM = cifdata[sgkey[1]]
+            HM = HM.replace(" ","")
             sgnum = HM_to_sgnum[HM]
         elif (skey is sgkey[2]):
             hall = cifdata[sgkey[2]]
+            hall = hall.replace(" ","")
             sgnum = Hall_to_sgnum[HM]
 
         # lattice parameters

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -264,11 +264,11 @@ class Material(object):
             sgnum = int(cifdata[sgkey[0]])
         elif (skey is sgkey[1]):
             HM = cifdata[sgkey[1]]
-            HM = HM.replace(" ","")
+            HM = HM.replace(" ", "")
             sgnum = HM_to_sgnum[HM]
         elif (skey is sgkey[2]):
             hall = cifdata[sgkey[2]]
-            hall = hall.replace(" ","")
+            hall = hall.replace(" ", "")
             sgnum = Hall_to_sgnum[HM]
 
         # lattice parameters

--- a/hexrd/symbols.py
+++ b/hexrd/symbols.py
@@ -1255,6 +1255,7 @@ def _buildDict(hstr):
             nstr, hstr = li.split(None, 1)
             nstr = nstr.split(':', 1)[0]
             n = int(nstr)
+            hstr = hstr.replace(" ", "")
             if n not in d:
                 d[n] = hstr
                 pass


### PR DESCRIPTION
remove space from Herman Maguin and Hall symbol to space group number dictionary.
The spaces are also removed from the data read from the cif file.
This should resolve #106 