### PR TITLE
Lmfit fix

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python {{PY_VER}}
     - h5py
-    - lmfit ==1.0.0
+    - lmfit
     - numba
     - numpy
     - psutil

--- a/hexrd/WPPF.py
+++ b/hexrd/WPPF.py
@@ -1571,7 +1571,7 @@ class LeBail:
     def chebyshevfit(self):
         degree = self.bkgmethod['chebyshev']
         p = np.polynomial.Chebyshev.fit(
-            self.tth_list, self.spectrum_expt._y, degree, w=self.weights**2)
+            self.tth_list, self.spectrum_expt._y, degree, w=self.weights**4)
         self.background = Spectrum(x=self.tth_list, y=p(self.tth_list))
 
     def selectpoints(self):
@@ -1951,7 +1951,7 @@ class LeBail:
         params = self.initialize_lmfit_parameters()
 
         fdict = {'ftol': 1e-4, 'xtol': 1e-4, 'gtol': 1e-4,
-                 'verbose': 0, 'max_nfev': 8}
+                 'verbose': 0, 'max_nfev': 100}
 
         fitter = lmfit.Minimizer(self.calcRwp, params)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_reqs = [
     'psutil',
     'scipy',
     'pycifrw',
-    'lmfit==1.0.0',
+    'lmfit',
     'numba',
     'psutil',
     'pyyaml',


### PR DESCRIPTION
There was a change in one of the keywords to the `lmfit.Minimizer` class in release `1.0.1`. 
Fixing the keyword seems to produce identical results to `v1.0.0`. 
This should resolve the conda package being broken in PR #105 