### PR TITLE
Exclusion of first hkl is always False by default.

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -207,6 +207,7 @@ class Material(object):
         dflt_excl = numpy.ones(tth.shape,dtype=numpy.bool)
         dflt_excl[~numpy.isnan(tth)] = ~( (tth[~numpy.isnan(tth)] >= 0.0) & \
                                      (tth[~numpy.isnan(tth)] <= numpy.pi/2.0) )
+        dflt_excl[0] = False
         self._pData.exclusions = dflt_excl
 
         return


### PR DESCRIPTION
changed the `Materials` class to always have the first `hkl` not be excluded even if it lies outside `2\theta' range or can't satisfy Bragg's conditions.