### PR TITLE
Check for empty presults before fitting attempt

### DIFF
--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -228,6 +228,10 @@ def fit_grain_FF_reduced(grain_id):
         for det_key in culled_results_r:
             presults = culled_results[det_key]
 
+            if not presults:
+                culled_results_r[det_key] = []
+                continue
+
             ims = imgser_dict[det_key]
             ome_step = sum(np.r_[-1, 1]*ims.metadata['omega'][0, :])
 


### PR DESCRIPTION
In some cases, presults may be empty for a specific detector. This would
lead to a numpy exception later when a vstack was attempted with an empty
list.

Check if presults is empty, and if so, set the culled results to empty as
well and continue.

@joelvbernier Is it reasonable for the `presults` variable to be empty? It looks like it is empty
sometimes for our 8-detector example, and that was causing the exception in https://github.com/HEXRD/hexrdgui/issues/643.

If it is not reasonable for `presults` to be empty, we may need to find a different fix.

Fixes: https://github.com/HEXRD/hexrdgui/issues/643