### PR TITLE
Make the compliance tensor a computed property

### DIFF
--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1233,7 +1233,17 @@ class unitcell:
                 C[i,j] = C[j,i]
 
         self.stiffness    = C
-        self.compliance  = np.linalg.inv(C)
+
+    @property
+    def compliance(self):
+        if not hasattr(self, 'stiffness'):
+            raise AttributeError('Stiffness not set on unit cell')
+
+        return np.linalg.inv(self.stiffness)
+
+    @compliance.setter
+    def compliance(self, v):
+        self.stiffness = np.linalg.inv(v)
 
     # lattice constants as properties
     @property


### PR DESCRIPTION
Rather than storing both the stiffness and compliance tensors, which
requires storing two tensors, and can run the risk of one being out of sync
with the other, make the compliance tensor a computed property.

This way, the only matrix that is stored is the stiffness tensor. If one
tries to get the compliance via `unitcell.compliance`, it will be computed
and returned. If one sets the compliance tensor via `unitcell.compliance = t`,
it will be converted to stiffness and stored as the stiffness tensor.

This simplifies some code in hexrdgui.