### PR TITLE
Powder simulator

### DIFF
--- a/hexrd/WPPF.py
+++ b/hexrd/WPPF.py
@@ -114,7 +114,8 @@ class Parameters:
             fid = file
 
         else:
-            raise RuntimeError('Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
+            raise RuntimeError(
+                'Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
 
         if("/Parameters" in fid):
             del(fid["Parameters"])
@@ -125,18 +126,17 @@ class Parameters:
             gid = gid_top.create_group(p)
 
             # write the value, lower and upper bounds and vary status
-            did = gid.create_dataset("value",(1, ), dtype = np.float64)
-            did.write_direct(np.array(param.value, dtype = np.float64))
+            did = gid.create_dataset("value", (1, ), dtype=np.float64)
+            did.write_direct(np.array(param.value, dtype=np.float64))
 
-            did = gid.create_dataset("lb",(1, ), dtype = np.float64)
-            did.write_direct(np.array(param.lb, dtype = np.float64))
+            did = gid.create_dataset("lb", (1, ), dtype=np.float64)
+            did.write_direct(np.array(param.lb, dtype=np.float64))
 
-            did = gid.create_dataset("ub",(1, ), dtype = np.float64)
-            did.write_direct(np.array(param.ub, dtype = np.float64))
+            did = gid.create_dataset("ub", (1, ), dtype=np.float64)
+            did.write_direct(np.array(param.ub, dtype=np.float64))
 
-            did = gid.create_dataset("vary",(1, ), dtype = np.bool)
-            did.write_direct(np.array(param.vary, dtype = np.bool))
-
+            did = gid.create_dataset("vary", (1, ), dtype=np.bool)
+            did.write_direct(np.array(param.vary, dtype=np.bool))
 
     # def pretty_print(self):
     #   '''
@@ -348,7 +348,8 @@ class Spectrum:
             fid = file
 
         else:
-            raise RuntimeError('Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
+            raise RuntimeError(
+                'Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
 
         name_spectrum = 'Spectrum/'+name
         if(name_spectrum in fid):
@@ -359,11 +360,11 @@ class Spectrum:
 
         # make sure these arrays are not zero sized
         if(tth.shape[0] > 0):
-            did = gid.create_dataset("tth", tth.shape, dtype = np.float64)
+            did = gid.create_dataset("tth", tth.shape, dtype=np.float64)
             did.write_direct(tth.astype(np.float64))
 
         if(I.shape[0] > 0):
-            did = gid.create_dataset("intensity", I.shape, dtype = np.float64)
+            did = gid.create_dataset("intensity", I.shape, dtype=np.float64)
             did.write_direct(I.astype(np.float64))
 
     @property
@@ -557,11 +558,11 @@ class Material_LeBail:
         ========================================================================================================
     '''
 
-    def __init__(self, 
-                fhdf=None, 
-                xtal=None, 
-                dmin=None, 
-                material_obj=None):
+    def __init__(self,
+                 fhdf=None,
+                 xtal=None,
+                 dmin=None,
+                 material_obj=None):
 
         if(material_obj is None):
             self.dmin = dmin.value
@@ -1411,7 +1412,6 @@ class Phases_LeBail:
         with open(fname, 'w') as f:
             data = yaml.dump(dic, f, sort_keys=False)
 
-
     def dump_hdf5(self, file):
         '''
         >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab, saransh1@llnl.gov
@@ -1430,7 +1430,8 @@ class Phases_LeBail:
             fid = file
 
         else:
-            raise RuntimeError('Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
+            raise RuntimeError(
+                'Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
 
         if("/Phases" in fid):
             del(fid["Phases"])
@@ -1439,24 +1440,26 @@ class Phases_LeBail:
         for p in self:
             mat = self[p]
 
-            sgnum       = mat.sgnum
-            sgsetting   = mat.sgsetting
-            lparms      = mat.lparms
-            dmin        = mat.dmin
-            hkls        = mat.hkls
+            sgnum = mat.sgnum
+            sgsetting = mat.sgsetting
+            lparms = mat.lparms
+            dmin = mat.dmin
+            hkls = mat.hkls
 
             gid = gid_top.create_group(p)
 
-            did = gid.create_dataset("SpaceGroupNumber", (1, ), dtype = np.int32)
+            did = gid.create_dataset("SpaceGroupNumber", (1, ), dtype=np.int32)
             did.write_direct(np.array(sgnum, dtype=np.int32))
 
-            did = gid.create_dataset("SpaceGroupSetting", (1, ), dtype = np.int32)
+            did = gid.create_dataset(
+                "SpaceGroupSetting", (1, ), dtype=np.int32)
             did.write_direct(np.array(sgsetting, dtype=np.int32))
 
-            did = gid.create_dataset("LatticeParameters", (6, ), dtype = np.float64)
+            did = gid.create_dataset(
+                "LatticeParameters", (6, ), dtype=np.float64)
             did.write_direct(np.array(lparms, dtype=np.float64))
 
-            did = gid.create_dataset("dmin", (1, ), dtype = np.float64)
+            did = gid.create_dataset("dmin", (1, ), dtype=np.float64)
             did.attrs["units"] = "nm"
             did.write_direct(np.array(dmin, dtype=np.float64))
 
@@ -1503,13 +1506,13 @@ class LeBail:
         return valWUnit('lp', 'length', x, 'nm')
 
     def __init__(self,
-                 expt_spectrum = None,
-                 params = None,
-                 phases = None,
-                 wavelength = {'kalpha1': _nm(
+                 expt_spectrum=None,
+                 params=None,
+                 phases=None,
+                 wavelength={'kalpha1': _nm(
                      0.15406), 'kalpha2': _nm(0.154443)},
-                 bkgmethod = {'spline': None},
-                 intensity_init = None):
+                 bkgmethod={'spline': None},
+                 intensity_init=None):
 
         self.bkgmethod = bkgmethod
         self.intensity_init = intensity_init
@@ -1685,14 +1688,14 @@ class LeBail:
             fid = file
 
         else:
-            raise RuntimeError('Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
+            raise RuntimeError(
+                'Parameters: dump_hdf5 Pass in a filename string or h5py.File object')
 
         self.phases.dump_hdf5(fid)
         self.params.dump_hdf5(fid)
         self.spectrum_expt.dump_hdf5(fid, 'experimental')
         self.spectrum_sim.dump_hdf5(fid, 'simulated')
         self.background.dump_hdf5(fid, 'background')
-
 
     def initialize_expt_spectrum(self, expt_spectrum):
         '''
@@ -1769,7 +1772,8 @@ class LeBail:
             user from the loop which is required for the spline type background.
         '''
         if(self.bkgmethod is None):
-            self.background = Spectrum(x=self.tth_list, y=np.zeros(self.tth_list.shape))
+            self.background = Spectrum(
+                x=self.tth_list, y=np.zeros(self.tth_list.shape))
 
         elif('spline' in self.bkgmethod.keys()):
             self.selectpoints()
@@ -1791,12 +1795,12 @@ class LeBail:
             self.background = Spectrum(x=self.tth_list, y=yy)
 
         elif('array' in self.bkgmethod.keys()):
-            x = self.bkgmethod['array'][:,0]
-            y = self.bkgmethod['array'][:,1]
+            x = self.bkgmethod['array'][:, 0]
+            y = self.bkgmethod['array'][:, 1]
             cs = CubicSpline(x, y)
 
             yy = cs(self.tth_list)
-            
+
             self.background = Spectrum(x=self.tth_list, y=yy)
 
     def chebyshevfit(self):
@@ -1895,7 +1899,6 @@ class LeBail:
                 self.tth[p][k] = t[limit]
 
     def initialize_Icalc(self):
-
         '''
         @DATE 01/22/2021 SS modified the function so Icalc can be initialized with
         a dictionary of structure factors
@@ -1910,7 +1913,8 @@ class LeBail:
                 self.Icalc[p] = {}
                 for k, l in self.phases.wavelength.items():
 
-                    self.Icalc[p][k] = (10**n10) * np.ones(self.tth[p][k].shape)
+                    self.Icalc[p][k] = (10**n10) * \
+                        np.ones(self.tth[p][k].shape)
 
         elif(isinstance(self.intensity_init, dict)):
             '''
@@ -1922,7 +1926,7 @@ class LeBail:
                     raise RuntimeError("LeBail: Intensity was initialized using custom values. \
                         However, initial values for one or more phases seem to be missing from \
                         the dictionary.")
-                self.Icalc[p] = {} 
+                self.Icalc[p] = {}
 
                 '''
                 now check that the size of the initial intensities provided is consistent
@@ -1942,7 +1946,8 @@ class LeBail:
                         self.Icalc[p][l] = self.intensity_init[p][l][0:self.tth[p][l].shape[0]]
 
         else:
-            raise RuntimeError("LeBail: Intensity_init must be either None or a dictionary")
+            raise RuntimeError(
+                "LeBail: Intensity_init must be either None or a dictionary")
 
     def CagliottiH(self, tth):
         '''

--- a/hexrd/WPPF.py
+++ b/hexrd/WPPF.py
@@ -1768,7 +1768,10 @@ class LeBail:
             basically automates the background determination and removes the
             user from the loop which is required for the spline type background.
         '''
-        if('spline' in self.bkgmethod.keys()):
+        if(self.bkgmethod is None):
+            self.background = Spectrum(x=self.tth_list, y=np.zeros(self.tth_list.shape))
+
+        elif('spline' in self.bkgmethod.keys()):
             self.selectpoints()
             x = self.points[:, 0]
             y = self.points[:, 1]
@@ -1795,9 +1798,6 @@ class LeBail:
             yy = cs(self.tth_list)
             
             self.background = Spectrum(x=self.tth_list, y=yy)
-
-        elif(self.bkgmethod is None):
-            self.background = Spectrum(x=self.tth_list, y=np.ones(self.tth_list.shape))
 
     def chebyshevfit(self):
         degree = self.bkgmethod['chebyshev']
@@ -1922,6 +1922,7 @@ class LeBail:
                     raise RuntimeError("LeBail: Intensity was initialized using custom values. \
                         However, initial values for one or more phases seem to be missing from \
                         the dictionary.")
+                self.Icalc[p] = {} 
 
                 '''
                 now check that the size of the initial intensities provided is consistent
@@ -1937,8 +1938,8 @@ class LeBail:
                         However, initial values for one or more wavelengths in spectrum seem to be \
                         missing from the dictionary.")
 
-                    if(self.tth[p][k].shape[0] <= self.intensity_init[p][l].shape[0]):
-                        self.Icalc[p][l] = self.intensity_init[p][l][0:self.tth[p][k].shape[0]]
+                    if(self.tth[p][l].shape[0] <= self.intensity_init[p][l].shape[0]):
+                        self.Icalc[p][l] = self.intensity_init[p][l][0:self.tth[p][l].shape[0]]
 
         else:
             raise RuntimeError("LeBail: Intensity_init must be either None or a dictionary")

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -64,8 +64,11 @@ from hexrd import constants as ct
 from hexrd.rotations import angleAxisOfRotMat, RotMatEuler
 from hexrd.config.dumper import NumPyIncludeDumper
 from hexrd import distortion as distortion_pkg
+from hexrd.valunits import valWUnit
+from hexrd.WPPF import LeBail
 
 from skimage.draw import polygon
+from skimage.util import random_noise
 
 try:
     from fast_histogram import histogram1d
@@ -1028,15 +1031,13 @@ class HEDMInstrument(object):
         return panel_data
 
     def simulate_powder_pattern(self, 
-                                plane_data_list,
-                                fwhm=2., 
-                                origin=None, 
-                                noise=None):
+                                mat_list,
+                                params = None, 
+                                bkgmethod = None,
+                                origin = None, 
+                                noise = None):
         """
         Generates simple powder diffraction images.
-
-        FIXME: noise isn't connected
-        TODO: add hooks to the Rietveld model
 
         >> @AUTHOR:     Saransh Singh, Lanwrence Livermore National Lab,
                         saransh1@llnl.gov
@@ -1044,7 +1045,7 @@ class HEDMInstrument(object):
         >> @DETAILS:    adding hook to WPPF class. this changes the input list
                         significantly
         >> @PARAMETERS  list of material objects
-                        dictionary of lebail parameter values
+                        dictionary or Parameter class of lebail parameter values
         ----------
         plane_data_list : list, (n,)
             List of n hexrd.crystallography.PlaneData objects.
@@ -1063,24 +1064,153 @@ class HEDMInstrument(object):
         assert len(origin) == 3, \
             "origin must be a 3-element sequence"
 
-        WPPFclass = 
+        '''
+        if params is none, fill in some sane default values
+        only the first value is used. the rest of the values are
+        the upper, lower bounds and vary flag for refinement which
+        are not used but required for interfacing with WPPF
 
-        # img_dict = dict.fromkeys(self.detectors)
-        # for det_key, panel in self.detectors.items():
-        #     ptth, peta = panel.pixel_angles(origin=origin)
-        #     gint = np.zeros_like(ptth)
-        #     sigm = np.radians(_fwhm_to_sigma(fwhm))
-        #     for plane_data in plane_data_list:
-        #         if isinstance(plane_data, PlaneData):
-        #             tths = plane_data.getTTh()
-        #             weights = np.ones_like(tths)
-        #         else:
-        #             tths = [i[0] for i in plane_data]
-        #             weights = [i[1] for i in plane_data]
-        #         for pk in zip(tths, weights):
-        #             gint += pk[1]*_gaussian_dist(ptth, pk[0], sigm)
-        #     img_dict[det_key] = gint
-        # return img_dict
+        zero_error : zero shift error
+        U, V, W : Cagliotti parameters
+        P, X, Y : Lorentzian parameters
+        eta1, eta2, eta3 : Mixing parameters
+        '''
+        if(params is None):
+            params = {'zero_error': [0.0, -1., 1., True],
+                      'U': [2e-1, -1., 1., True],
+                      'V': [2e-2, -1., 1., True],
+                      'W': [2e-2, -1., 1., True],
+                      'P': [0., -1., 1., True],
+                      'X': [2e-1, -1., 1., True],
+                      'Y': [2e-1, -1., 1., True],
+                      'eta1': [1e-2, -1., 1., True],
+                      'eta2': [1e-2, -1., 1., True],
+                      'eta3': [1e-2, -1., 1., True]
+                      }
+
+
+        '''
+        use the material list to obtain the dictionary of initial intensities
+        we need to make sure that the intensities are properly scaled by the 
+        lorentz polarization factor. since the calculation is done in the Lebail
+        class, all that means is the initial intensity needs that factor in there
+        '''
+
+        '''
+        go through the panels and figure out the min and max in the 2theta direction
+        '''
+        img_dict = dict.fromkeys(self.detectors)
+        tth_mi = 0.
+        tth_ma = 0.
+        for det_key, panel in self.detectors.items():
+            ptth, peta = panel.pixel_angles(origin=origin)
+            tth_ma = np.amax([tth_ma, ptth.max()])
+
+        ''' now make a list of two theta and dummy ones for the experimental spectrum
+            this is never really used so any values should be okay. We could also pass 
+            the integrated detector image if we would like to simulate some realistic
+            background. But thats for another day.
+        '''
+        # convert angles to degrees because thats what the WPPF expects
+        tth_mi = np.degrees(tth_mi)
+        tth_ma = np.degrees(tth_ma)
+
+        tth = np.linspace(tth_mi, tth_ma, 1000) # 1000 is arbitrary; shouldn't really matter
+
+        expt = np.ones([tth.shape[0], 2])
+        expt[:,0] = tth
+
+        wavelength = valWUnit('lp', 'length',  self.beam_wavelength, 'angstrom')
+
+        '''
+        now go through the material list and get the intensity dictionary
+        '''
+        intensity = {}
+        for mat in mat_list:
+
+            tth = mat.planeData.getTTh()
+
+            LP = (1 + np.cos(tth)**2) / \
+            np.cos(0.5*tth)/np.sin(0.5*tth)**2
+
+            intensity[mat.name] = {}
+            intensity[mat.name]['synchrotron'] = mat.planeData.get_structFact() * LP
+
+
+        kwargs = {
+            'expt_spectrum': expt,
+            'params': params,
+            'phases': mat_list,
+            'wavelength': {
+                'synchrotron': wavelength
+            },
+            'bkgmethod': bkgmethod,
+            'intensity_init': intensity
+        }
+
+        self.WPPFclass = LeBail(**kwargs)
+
+        self.simulated_spectrum = self.WPPFclass.spectrum_sim
+        self.background = self.WPPFclass.background
+
+        '''
+        now that we have the simulated intensities, its time to get the
+        two theta for the detector pixels and interpolate what the intensity 
+        for each pixel should be
+        '''
+
+        img_dict = dict.fromkeys(self.detectors)
+        for det_key, panel in self.detectors.items():
+            ptth, peta = panel.pixel_angles(origin=origin)
+            
+            img = np.interp(np.degrees(ptth), 
+                            self.simulated_spectrum.x,
+                            self.simulated_spectrum.y + self.background.y)
+
+            # normalize everything to 0-1
+            mi = img.min()
+            ma = img.max()
+
+            if(ma > mi):
+                img = (img - mi) / (ma - mi)
+
+            if(noise is None):
+                img_dict[det_key] = img
+
+            else:
+                if(noise.lower() == 'poisson'):
+                    im_noise = random_noise(img, 
+                                            mode='poisson', 
+                                            clip=True)
+                    mi = im_noise.min()
+                    ma = im_noise.max()
+                    if(ma > mi):
+                        im_noise = (im_noise - mi)/(ma - mi)
+
+                    img_dict[det_key] = im_noise
+
+                elif(noise.lower() == 'gaussian'):
+                    img_dict[det_key] = random_noise(img, 
+                                                     mode='gaussian', 
+                                                     clip=True)
+
+                elif(noise.lower() == 'salt'):
+                    img_dict[det_key] = random_noise(img, mode='salt')
+
+                elif(noise.lower() == 'pepper'):
+                    img_dict[det_key] = random_noise(img, mode='pepper')
+
+                elif(noise.lower() == 's&p'):
+                    img_dict[det_key] = random_noise(img, mode='s&p')
+
+                elif(noise.lower() == 'speckle'):
+                    img_dict[det_key] = random_noise(img, 
+                                                     mode='speckle', 
+                                                     clip=True)
+
+
+
+        return img_dict
 
 
     def simulate_laue_pattern(self, crystal_data,

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1027,15 +1027,24 @@ class HEDMInstrument(object):
             # pbar.finish()
         return panel_data
 
-    def simulate_powder_pattern(self, plane_data_list,
-                                fwhm=2., origin=None, noise=None):
+    def simulate_powder_pattern(self, 
+                                plane_data_list,
+                                fwhm=2., 
+                                origin=None, 
+                                noise=None):
         """
         Generates simple powder diffraction images.
 
         FIXME: noise isn't connected
         TODO: add hooks to the Rietveld model
 
-        Parameters
+        >> @AUTHOR:     Saransh Singh, Lanwrence Livermore National Lab,
+                        saransh1@llnl.gov
+        >> @DATE:       01/22/2021 SS 1.0 original
+        >> @DETAILS:    adding hook to WPPF class. this changes the input list
+                        significantly
+        >> @PARAMETERS  list of material objects
+                        dictionary of lebail parameter values
         ----------
         plane_data_list : list, (n,)
             List of n hexrd.crystallography.PlaneData objects.
@@ -1054,22 +1063,24 @@ class HEDMInstrument(object):
         assert len(origin) == 3, \
             "origin must be a 3-element sequence"
 
-        img_dict = dict.fromkeys(self.detectors)
-        for det_key, panel in self.detectors.items():
-            ptth, peta = panel.pixel_angles(origin=origin)
-            gint = np.zeros_like(ptth)
-            sigm = np.radians(_fwhm_to_sigma(fwhm))
-            for plane_data in plane_data_list:
-                if isinstance(plane_data, PlaneData):
-                    tths = plane_data.getTTh()
-                    weights = np.ones_like(tths)
-                else:
-                    tths = [i[0] for i in plane_data]
-                    weights = [i[1] for i in plane_data]
-                for pk in zip(tths, weights):
-                    gint += pk[1]*_gaussian_dist(ptth, pk[0], sigm)
-            img_dict[det_key] = gint
-        return img_dict
+        WPPFclass = 
+
+        # img_dict = dict.fromkeys(self.detectors)
+        # for det_key, panel in self.detectors.items():
+        #     ptth, peta = panel.pixel_angles(origin=origin)
+        #     gint = np.zeros_like(ptth)
+        #     sigm = np.radians(_fwhm_to_sigma(fwhm))
+        #     for plane_data in plane_data_list:
+        #         if isinstance(plane_data, PlaneData):
+        #             tths = plane_data.getTTh()
+        #             weights = np.ones_like(tths)
+        #         else:
+        #             tths = [i[0] for i in plane_data]
+        #             weights = [i[1] for i in plane_data]
+        #         for pk in zip(tths, weights):
+        #             gint += pk[1]*_gaussian_dist(ptth, pk[0], sigm)
+        #     img_dict[det_key] = gint
+        # return img_dict
 
 
     def simulate_laue_pattern(self, crystal_data,


### PR DESCRIPTION
Added powder simulator to instrument class. Hooks to `WPPF.LeBail` are used to simulate. 
Required argument is list of `Material` objects. 
The parameters for the simulation can be changed using the optional `params` keyword. If this is not provided, then some sane default values are chosen.
The background is specified by an array or a filename with two rows of 2theta and background intensity. Finally, optional noise can be added via the `noise` keyword. Options to add `poisson`, `gaussian`, `salt and pepper` noise etc. have been added. Tested with MEC configuration and Zirconium crystal