### PR TITLE
Archiving performance improvements

### DIFF
--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -63,7 +63,19 @@ class ProcessedImageSeries(ImageSeries):
     def _subtract_dark(self, img, dark):
         # need to check for values below zero
         # !!! careful, truncation going on here;necessary to promote dtype?
-        return np.where(img > dark, img - dark, 0)
+
+        # This has been performance tested with the following:
+        # 1. return np.where(img > dark, img - dark, 0)
+        # 2. return np.clip(img - dark, a_min=0, a_max=None)
+        # 3. return (img - dark).clip(min=0)
+        # 4. ret = img - dark
+        #    ret[ret < 0] = 0
+        #    return ret
+        # Method 1 was the slowest, and method 4 was the fastest, perhaps
+        # because it creates fewer copies of the data.
+        ret = img - dark
+        ret[ret < 0] = 0
+        return ret
 
     def _rectangle(self, img, r):
         # restrict to rectangle

--- a/hexrd/matrixutil.py
+++ b/hexrd/matrixutil.py
@@ -852,7 +852,7 @@ def symmToVecds(A):
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(cache=True, nogil=True)
     def extract_ijv(in_array, threshold, out_i, out_j, out_v):
         n = 0
         w, h = in_array.shape


### PR DESCRIPTION
This has the following improvements:

1. Speeds up dark background subtraction (by about 2x)
2. Multi-thread when writing out the frame cache
3. Improve numba function speed with `cache` and `nogil`

For my archiving example with 4 detectors, and my 24 processor computer,
the amount of time it takes has gone from about 97 seconds to about 48 seconds.

The median computation runs for about the first 9 seconds, and that is only one
process per detector, so 4 processes. After the median finishes, each of the 4
detector processes runs 6 threads, and my CPUs all hang out at around 85%
usage until the end.

To use this: if other parallelism is going on, such as one process per detector, you should
limit the number of threads by passing the `max_workers` kwarg to `imageseries.write()`.

For instance, if you have 24 processors, and 4 detectors (one process each), `max_workers`
would be 6.

One of the current rate-limiting steps is that numba uses a lock for it's compiler, so that only
one thread can compile at a time. But my CPUs still ran at about 85% usage, so that is not
too bad.