### PR TITLE
hdf5 string error, and map normalization

### DIFF
--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -57,6 +57,9 @@ def _process_omegas(omegaimageseries_dict):
 
 
 def label_spots(this_map, method, method_kwargs):
+    # !!! need to remove NaNs from map in case of eta gaps?
+    this_map[np.isnan(this_map)] = 0.
+    this_map -= np.min(this_map)
     if method == 'label':
         # labeling mask
         structureNDI_label = ndimage.generate_binary_structure(2, 1)

--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -188,7 +188,13 @@ def fit_grain_FF_reduced(grain_id):
 
         # CAVEAT: completeness from pullspots only; incl saturated and overlaps
         # <JVB 2015-12-15>
-        completeness = num_refl_valid / float(num_refl_tot)
+        try:
+            completeness = num_refl_valid / float(num_refl_tot)
+        except(ZeroDivisionError):
+            raise RuntimeError(
+                "simulated number of relfections is 0; "
+                + "check instrument config or grain parameters"
+            )
 
         # ======= DO LEASTSQ FIT =======
 

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -3232,7 +3232,11 @@ def unwrap_dict_to_h5(grp, d, asattr=True):
             if asattr:
                 grp.attrs.create(key, item)
             else:
-                grp.create_dataset(key, data=np.atleast_1d(item))
+                try:
+                    grp.create_dataset(key, data=np.atleast_1d(item))
+                except(TypeError):
+                    # probably a string badness
+                    grp.create_dataset(key, data=item)
 
 
 class GenerateEtaOmeMaps(object):


### PR DESCRIPTION
- added NaN removal and DC offset for maps in findorientations
- added exception handling for case of 0 simulated reflections in fitgrains
- fixed HDF5 string handling bug in `unwrap_dict_to_h5()`