### PR TITLE
Add pyproject.toml for easier development installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ jobs:
 
     - name: Install HEXRD
       run: |
-          pip install numpy
           pip install .
       working-directory: hexrd
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "setuptools_scm[toml]"]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_reqs = [
     'pycifrw',
     'lmfit',
     'numba',
+    'numpy',
     'psutil',
     'pyyaml',
     'scikit-learn',
@@ -82,7 +83,6 @@ entry_points = {
 
 setup(
     name='hexrd',
-    setup_requires=['setuptools-scm'],
     use_scm_version=True,
     description = 'hexrd X-ray diffraction data analysis tool',
     long_description = open('README.md').read(),


### PR DESCRIPTION
The pyproject.toml file can be used to specify dependencies needed
for pip to run setup.py. Pip will create a virtual environment and
install these dependencies, then run setup.py.

This simplifies the development setup process so that instead of:
```python
pip install numpy
pip install -e hexrd
```

The developer can simply do:
```python
pip install -e hexrd
```

We need to include numpy in "install_reqs" now as well because
dependencies specified in pyproject.toml are only installed in the
virtual environment used to run setup.py, and numpy also needs to
be installed for use at runtime.

Fixes: #180 