### PR TITLE
Check if file is writable with 'r+' instead of 'w'

### DIFF
--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -157,11 +157,8 @@ def set_numba_cache():
     def is_writable_file(path):
         # Unfortunately, os.access(__file__, os.W_OK) doesn't work on Windows.
         # It always returns True.
-        if not os.path.exists(path):
-            return False
-
         try:
-            with open(path, 'w'):
+            with open(path, 'r+'):
                 return True
         except Exception:
             return False


### PR DESCRIPTION
On Windows, checking if a file is writable via
`os.access(path, os.W_OK)` unfortunately does not work. We have
had to resort to a more brutish method of trying to open the file, like
this:
```python
def is_writable_file(path):
    try:
        with open(path, 'w'):
            return True
    except Exception:
        return False
```

Unfortunately, just the act of opening a file with 'w' erases its
contents. We need to open with 'r+' instead to avoid this.

What the previous opening with 'w' resulted in:

1. Hexrd on Windows installed via a package would work correctly,
   because the user running "hexrd" doesn't have permissions to write
   to the file (since the package is installed with admin privileges).
2. Hexrd on Windows installed via conda/pip would cause a bug to occur,
   because the user running "hexrd" does have permissions to write to
   the file, and opening with "w" would erase its contents.

Opening with 'r+' also raises an exception if the file is not
writable, so this change fixes the bug and still checks if a file is
writable.

Fixes: hexrd/hexrdgui#757