### PR TITLE
return structure factors filtered by exclusions.

### DIFF
--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -787,7 +787,7 @@ class PlaneData(object):
     wavelength = property(get_wavelength, set_wavelength, None)
 
     def get_structFact(self):
-        return self.__structFact
+        return self.__structFact[~self.exclusions]
 
     def set_structFact(self, structFact):
         self.__structFact = structFact

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -256,7 +256,7 @@ class Material(object):
         for i, g in enumerate(hkls):
             sf[i] = self.unitcell.CalcXRSF(g)
 
-        self.planeData.set_structFact(sf[~self.planeData.exclusions])
+        self.planeData.set_structFact(sf)
 
     def _readCif(self, fcif=DFLT_NAME+'.cif'):
         """


### PR DESCRIPTION
The structure factors were not getting filtered by exclusions after the exclusions were updated. This fixes it.
The `planeData.get_structFact()` subroutine now returns `planeData.__structFact[~planeData.exclusions]` in place of just `planeData.__structFact` .