### PR TITLE
WIP: Simple MPI implementation using gather

### DIFF
--- a/hexrd/xrdutil/nf-hedm/nf-HEDM_test.py
+++ b/hexrd/xrdutil/nf-hedm/nf-HEDM_test.py
@@ -387,12 +387,12 @@ def mockup_experiment():
 # =============================================================================
 
 # Some basic 3d algebra =======================================================
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _v3_dot(a, b):
     return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
 
 
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _m33_v3_multiply(m, v, dst):
     v0 = v[0]
     v1 = v[1]
@@ -404,7 +404,7 @@ def _m33_v3_multiply(m, v, dst):
     return dst
 
 
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _v3_normalized(src, dst):
     v0 = src[0]
     v1 = src[1]
@@ -419,7 +419,7 @@ def _v3_normalized(src, dst):
     return dst
 
 
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _make_binary_rot_mat(src, dst):
     v0 = src[0]
     v1 = src[1]
@@ -442,7 +442,7 @@ def _make_binary_rot_mat(src, dst):
 
 # This is equivalent to the transform module anglesToGVec, but written in
 # numba. This should end in a module to share with other scripts
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _anglesToGVec(angs, rMat_ss, rMat_c):
     """From a set of angles return them in crystal space"""
     result = np.empty_like(angs)
@@ -484,7 +484,7 @@ def _anglesToGVec(angs, rMat_ss, rMat_c):
 # gvec_cs, rSm varies per grain
 #
 # gvec_cs
-@numba.jit()
+@numba.njit(nogil=True, cache=True)
 def _gvec_to_detector_array(vG_sn, rD, rSn, rC, tD, tS, tC):
     """ beamVec is the beam vector: (0, 0, -1) in this case """
     ztol = xrdutil.epsf
@@ -536,7 +536,7 @@ def _gvec_to_detector_array(vG_sn, rD, rSn, rC, tD, tS, tC):
     return result
 
 
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _quant_and_clip_confidence(coords, angles, image,
                                base, inv_deltas, clip_vals):
     """quantize and clip the parametric coordinates in coords + angles
@@ -670,7 +670,7 @@ def simulate_diffractions(grain_params, experiment, controller):
 #       booleans, an array of uint8 could be used so the image is stored
 #       with a bit per pixel.
 
-@numba.njit
+@numba.njit(nogil=True, cache=True)
 def _write_pixels(coords, angles, image, base, inv_deltas, clip_vals):
     count = len(coords)
     for i in range(count):

--- a/hexrd/xrdutil/nf-hedm/nf-HEDM_test.py
+++ b/hexrd/xrdutil/nf-hedm/nf-HEDM_test.py
@@ -54,7 +54,7 @@ vInv_ref = constants.identity_6x1
 # ==============================================================================
 
 
-class ProcessController(object):
+class ProcessController:
     """This is a 'controller' that provides the necessary hooks to
     track the results of the process as well as to provide clues of
     the progress of the process"""
@@ -120,7 +120,7 @@ class ProcessController(object):
 
 
 def null_progress_observer():
-    class NullProgressObserver(object):
+    class NullProgressObserver:
         def start(self, name, count):
             pass
 
@@ -135,7 +135,7 @@ def null_progress_observer():
 
 def progressbar_progress_observer():
 
-    class ProgressBarProgressObserver(object):
+    class ProgressBarProgressObserver:
         def start(self, name, count):
             self.pbar = ProgressBar(widgets=[name, Percentage(), Bar()],
                                     maxval=count)
@@ -151,7 +151,7 @@ def progressbar_progress_observer():
 
 
 def forgetful_result_handler():
-    class ForgetfulResultHandler(object):
+    class ForgetfulResultHandler:
         def handle_result(self, key, value):
             pass  # do nothing
 
@@ -161,7 +161,7 @@ def forgetful_result_handler():
 def saving_result_handler(filename):
     """returns a result handler that saves the resulting arrays into a file
     with name filename"""
-    class SavingResultHandler(object):
+    class SavingResultHandler:
         def __init__(self, file_name):
             self.filename = file_name
             self.arrays = {}
@@ -190,7 +190,7 @@ def checking_result_handler(filename):
     match. A FULL PASS will happen when all existing results match
 
     """
-    class CheckingResultHandler(object):
+    class CheckingResultHandler:
         def __init__(self, reference_file):
             """Checks the result against those save in 'reference_file'"""
             logging.info("Loading reference results from '%s'", reference_file)

--- a/hexrd/xrdutil/nf-hedm/nf-HEDM_test.py
+++ b/hexrd/xrdutil/nf-hedm/nf-HEDM_test.py
@@ -1186,9 +1186,15 @@ def build_controller(args):
 _multiprocessing_start_method = 'fork' if hasattr(os, 'fork') else 'spawn'
 
 if __name__ == '__main__':
+    LOG_LEVEL = logging.INFO
     FORMAT="%(relativeCreated)12d [%(process)6d/%(thread)6d] %(levelname)8s: %(message)s"
-    logging.basicConfig(level=logging.INFO,
-                        format=FORMAT)
+
+    logging.basicConfig(level=LOG_LEVEL, format=FORMAT)
+
+    # Setting the root log level via logging.basicConfig() doesn't always work.
+    # The next line ensures that it will get set.
+    logging.getLogger().setLevel(LOG_LEVEL)
+
     args = parse_args()
 
     if len(args.inst_profile) > 0:


### PR DESCRIPTION
This is a less naive implementation. That doesn't ship around a bunch of data. It basically partitions the coordinates across the ranks and then uses multiprocessing on each rank ( rather than multiple MPI processes per rank ). The image stack is loading and dilated on each rank to avoid have to ship it around. By making the MPI calls ourselves we can also take advantage of direct memory access to numpy arrays, so removes the overhead of pickling.

Note: If we go down this route we still need to work out what todo with the controller, currently progress monitoring is a little confusing with multiple ranks!