### PR TITLE
Copy old PlaneData attributes to new PlaneData

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -659,6 +659,7 @@ class Material(object):
         if hasattr(self, 'unitcell'):
             self._newUnitcell()
             self._hkls_changed()
+            self.update_structure_factor()
 
     sgnum = property(_get_sgnum, _set_sgnum, None,
                      "Space group number")
@@ -733,6 +734,7 @@ class Material(object):
         v2 = [lp[x].value for x in rq_lp]
         self.planeData.lparms = v2
         self._hkls_changed()
+        self.update_structure_factor()
 
         return
 
@@ -789,9 +791,9 @@ The values have units attached, i.e. they are valWunit instances.
         if v.shape[1] == 4:
             self._atominfo = v
         else:
-            print("Improper syntax, array must be n x 4")
+            raise ValueError("Improper syntax, array must be n x 4")
 
-        return
+        self.update_structure_factor()
 
     atominfo = property(
         _get_atominfo, _set_atominfo, None,

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -230,6 +230,7 @@ class Material(object):
     def _hkls_changed(self):
         # Call this when something happens that changes the hkls...
         self._newPdata()
+        self.update_structure_factor()
 
     def _newPdata(self):
         """Create a new plane data instance if the hkls have changed"""
@@ -659,7 +660,6 @@ class Material(object):
         if hasattr(self, 'unitcell'):
             self._newUnitcell()
             self._hkls_changed()
-            self.update_structure_factor()
 
     sgnum = property(_get_sgnum, _set_sgnum, None,
                      "Space group number")
@@ -690,9 +690,6 @@ class Material(object):
         self.unitcell.voltage = self.beamEnergy.value*1e3
         self.planeData.wavelength = keV
         self._hkls_changed()
-        self.update_structure_factor()
-
-        return
 
     beamEnergy = property(_get_beamEnergy, _set_beamEnergy, None,
                           "Beam energy in keV")
@@ -734,9 +731,6 @@ class Material(object):
         v2 = [lp[x].value for x in rq_lp]
         self.planeData.lparms = v2
         self._hkls_changed()
-        self.update_structure_factor()
-
-        return
 
     lpdoc = r"""Lattice parameters
 

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -180,6 +180,7 @@ class Material(object):
 
         self._newUnitcell()
         self._newPdata()
+        self.update_structure_factor()
 
     def __str__(self):
         """String representation"""
@@ -276,8 +277,6 @@ class Material(object):
                                 tThMax=Material.DFLT_TTHMAX)
 
             self.set_default_exclusions()
-
-        self.update_structure_factor()
 
     def set_default_exclusions(self):
         '''

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -765,7 +765,7 @@ The values have units attached, i.e. they are valWunit instances.
 
     @dmin.setter
     def dmin(self, v):
-        if self._dmin == v:
+        if self._dmin.getVal('angstrom') == v.getVal('angstrom'):
             return
 
         self._dmin = v

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -194,7 +194,7 @@ class Material(object):
         """
         @author Saransh Singh, Lawrence Livermore National Lab
         @date 03/11/2021 SS 1.0 original
-        @details correctly initialize lattice parameters based 
+        @details correctly initialize lattice parameters based
         on the space group number
         """
         lparms = [x.value for x in self._lparms]
@@ -226,6 +226,10 @@ class Material(object):
             self._unitcell.stiffness = self.stiffness
         else:
             self._unitcell.stiffness = Material.DFLT_STIFFNESS
+
+    def _hkls_changed(self):
+        # Call this when something happens that changes the hkls...
+        self._newPdata()
 
     def _newPdata(self):
         """Create a new plane data instance if the hkls have changed"""
@@ -637,7 +641,7 @@ class Material(object):
         # Update the unit cell if there is one
         if hasattr(self, 'unitcell'):
             self._newUnitcell()
-            self._newPdata()
+            self._hkls_changed()
 
     sgnum = property(_get_sgnum, _set_sgnum, None,
                      "Space group number")
@@ -673,23 +677,6 @@ class Material(object):
 
     beamEnergy = property(_get_beamEnergy, _set_beamEnergy, None,
                           "Beam energy in keV")
-
-    # >> @date 08/20/2020 removing dependence on hklmax
-    # property:  hklMax
-
-    # def _get_hklMax(self):
-    #     """Get method for hklMax"""
-    #     return self._hklMax
-
-    # def _set_hklMax(self, v):
-    #     """Set method for hklMax"""
-    #     self._hklMax = v
-    #     self._newPdata()  # update planeData
-    #     return
-
-    # hklMax = property(_get_hklMax, _set_hklMax, None,
-    #                   "Max sum of squares for HKLs")
-    # property:  planeData
 
     """
     03/11/2021 SS 1.0 original
@@ -771,7 +758,7 @@ The values have units attached, i.e. they are valWunit instances.
         # Update the unit cell
         self.unitcell.dmin = v.getVal('nm')
 
-        self._newPdata()
+        self._hkls_changed()
 
     # property: "atominfo"
     def _get_atominfo(self):

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -276,6 +276,8 @@ class Material(object):
 
             self.set_default_exclusions()
 
+        self.update_structure_factor()
+
     def set_default_exclusions(self):
         '''
           Set default exclusions
@@ -308,8 +310,6 @@ class Material(object):
             dflt_excl[0] = False
 
         self._pData.exclusions = dflt_excl
-
-        self.update_structure_factor()
 
     def update_structure_factor(self):
         hkls = self.planeData.getHKLs(allHKLs=True)

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -688,6 +688,7 @@ class Material(object):
         '''
         self.unitcell.voltage = self.beamEnergy.value*1e3
         self.planeData.wavelength = keV
+        self._hkls_changed()
         self.update_structure_factor()
 
         return
@@ -731,6 +732,7 @@ class Material(object):
             setattr(self.unitcell, unitcell._lpname[i], val)
         v2 = [lp[x].value for x in rq_lp]
         self.planeData.lparms = v2
+        self._hkls_changed()
 
         return
 


### PR DESCRIPTION
Because PlaneData objects have immutable HKLs, when something happens that causes the HKLs to change (such as a change in dmin or sgnum) , a new PlaneData object must be instantiated with the new HKLs.

This PR does two main things:
1. Skips creating a new PlaneData object if the HKLs match. So small dmin changes, for instance, won't create a new PlaneData object.
2. Copies over old PlaneData attributes to the new PlaneData, including exclusions.

The exclusions are copied over by creating a mapping between the old HKLs and the new HKLs, and using this to set the new exclusions based on the old ones.

You can see the exclusions persisting here in hexrdgui:

![example gif](https://user-images.githubusercontent.com/9558430/110664434-00e03e80-818d-11eb-927e-01bdeab12a3a.gif)

Notably as well, other attributes such as the tThWidth and tThMax get preserved when a new PlaneData object is created also.

This, along with hexrd/hexrdgui#791, will resolve hexrd/hexrdgui#774