### PR TITLE
Material fix

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -780,11 +780,33 @@ The values have units attached, i.e. they are valWunit instances.
         else:
             print("Improper syntax, array must be n x 4")
 
+        self.update_structure_factor()
         return
 
     atominfo = property(
         _get_atominfo, _set_atominfo, None,
         "Information about atomic positions and electron number")
+
+    # # property: "atominfo"
+    # def _get_atomtype(self):
+    #     """Set method for name"""
+    #     return self._atomtype
+
+    # def _set_atomtype(self, v):
+    #     """Set method for atomtype"""
+    #     if v.shape[1] == 4:
+    #         self._atominfo = v
+    #         if hasattr(self, 'unitcell'):
+    #             self.unitcell.atom_pos = v
+    #     else:
+    #         print("Improper syntax, array must be n x 4")
+
+    #     self.update_structure_factor()
+    #     return
+
+    # atominfo = property(
+    #     _get_atomtype, _set_atomtype, None,
+    #     "Information about atomic positions and electron number")
 
     #
     #  ========== Methods

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -775,6 +775,8 @@ The values have units attached, i.e. they are valWunit instances.
         """Set method for name"""
         if v.shape[1] == 4:
             self._atominfo = v
+            if hasattr(self, 'unitcell'):
+                self.unitcell.atom_pos = v
         else:
             print("Improper syntax, array must be n x 4")
 

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -200,6 +200,7 @@ class Material(object):
         """
         lparms = [x.value for x in self._lparms]
         ltype = symmetry.latticeType(self.sgnum)
+        lparms = [lparms[i] for i in unitcell._rqpDict[ltype][0]]
         lparms = unitcell._rqpDict[ltype][1](lparms)
         lparms_vu = []
         for i in range(6):
@@ -240,8 +241,9 @@ class Material(object):
         from hdf5 file using a hkl list
         '''
         hkls = self.unitcell.getHKLs(self._dmin.getVal('nm')).T
+        ltype = self.unitcell.latticeType
         lprm = [self._lparms[i]
-                for i in unitcell._rqpDict[self.unitcell.latticeType][0]]
+                for i in unitcell._rqpDict[ltype][0]]
         laue = self.unitcell._laueGroup
         self._pData = PData(hkls, lprm, laue,
                             self._beamEnergy, Material.DFLT_STR,

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1481,7 +1481,7 @@ class unitcell:
         if(len(inp_Cvals) != len(_StiffnessDict[self._laueGroup][0])):
             x = len(_StiffnessDict[self._laueGroup][0])
             msg = (f"number of constants entered is not correct."
-                   f"need a total of {x} independent constants")
+                   f" need a total of {x} independent constants.")
             raise IOError(msg)
 
         # initialize all zeros and fill the supplied values
@@ -1991,9 +1991,9 @@ class unitcell:
         if hasattr(self, 'atom_type'):
             if self.atom_ntype != val.shape[0]:
                 msg = (f"incorrect number of atom positions."
-                       f"number of atom type = {self.atom_ntype} "
-                       f"and number of"
-                       f"atom positions = {val.shape[0]}.")
+                       f" number of atom type = {self.atom_ntype} "
+                       f" and number of"
+                       f" atom positions = {val.shape[0]}.")
                 raise ValueError(msg)
 
         self._atom_pos = val

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -33,7 +33,6 @@ class unitcell:
         self._tstart = time.time()
         self.pref = 0.4178214
 
-        self.atom_ntype = atomtypes.shape[0]
         self.atom_type = atomtypes
         self.atom_pos = atominfo
         self.U = U
@@ -1480,9 +1479,10 @@ class unitcell:
 
     def MakeStiffnessMatrix(self, inp_Cvals):
         if(len(inp_Cvals) != len(_StiffnessDict[self._laueGroup][0])):
-            raise IOError('number of constants entered is not correct.\
-            need a total of ', len(_StiffnessDict[self._laueGroup][0]),
-                          'independent constants')
+            x = len(_StiffnessDict[self._laueGroup][0])
+            msg = f"number of constants entered is not correct."
+            "need a total of {x} independent constants"
+            raise IOError(msg)
 
         # initialize all zeros and fill the supplied values
         C = np.zeros([6, 6])
@@ -1988,6 +1988,12 @@ class unitcell:
         updating atominfo
         fixing 
         """
+        if hasattr(self, 'atom_type'):
+            if self.atom_ntype != val.shape[0]:
+                raise ValueError(f"incorrect number of atom positions."
+                "number of atom type = {self.atom_ntype} and number of"
+                "atom positions = {val.shape[0]}.")
+
         self._atom_pos = val
         """
         update only if its not the first time
@@ -1998,16 +2004,19 @@ class unitcell:
         if hasattr(self, 'density'):
             self.CalcDensity()
 
-
     @property
-    def B_factor(self):
-        return self._atom_pos[:, 4]
+    def atom_ntype(self):
+        return self.atom_type.shape[0]
 
-    @B_factor.setter
-    def B_factor(self, val):
-        if (val.shape[0] != self.atom_ntype):
-            raise ValueError('Incorrect shape for B factor')
-        self._atom_pos[:, 4] = val
+    # @property
+    # def B_factor(self):
+    #     return self._atom_pos[:, 4]
+
+    # @B_factor.setter
+    # def B_factor(self, val):
+    #     if (val.shape[0] != self.atom_ntype):
+    #         raise ValueError('Incorrect shape for B factor')
+    #     self._atom_pos[:, 4] = val
 
     # asymmetric positions in unit cell
     @property

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1481,7 +1481,7 @@ class unitcell:
         if(len(inp_Cvals) != len(_StiffnessDict[self._laueGroup][0])):
             x = len(_StiffnessDict[self._laueGroup][0])
             msg = (f"number of constants entered is not correct."
-                   "need a total of {x} independent constants")
+                   f"need a total of {x} independent constants")
             raise IOError(msg)
 
         # initialize all zeros and fill the supplied values
@@ -1991,9 +1991,9 @@ class unitcell:
         if hasattr(self, 'atom_type'):
             if self.atom_ntype != val.shape[0]:
                 msg = (f"incorrect number of atom positions."
-                        "number of atom type = {self.atom_ntype} "
-                        "and number of"
-                        "atom positions = {val.shape[0]}.")
+                       f"number of atom type = {self.atom_ntype} "
+                       f"and number of"
+                       f"atom positions = {val.shape[0]}.")
                 raise ValueError(msg)
 
         self._atom_pos = val

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1480,8 +1480,8 @@ class unitcell:
     def MakeStiffnessMatrix(self, inp_Cvals):
         if(len(inp_Cvals) != len(_StiffnessDict[self._laueGroup][0])):
             x = len(_StiffnessDict[self._laueGroup][0])
-            msg = f"number of constants entered is not correct."
-            "need a total of {x} independent constants"
+            msg = (f"number of constants entered is not correct."
+                   "need a total of {x} independent constants")
             raise IOError(msg)
 
         # initialize all zeros and fill the supplied values
@@ -1990,10 +1990,11 @@ class unitcell:
         """
         if hasattr(self, 'atom_type'):
             if self.atom_ntype != val.shape[0]:
-                raise ValueError(f"incorrect number of atom positions."
-                                 "number of atom type = {self.atom_ntype} "
-                                 "and number of"
-                                 "atom positions = {val.shape[0]}.")
+                msg = (f"incorrect number of atom positions."
+                        "number of atom type = {self.atom_ntype} "
+                        "and number of"
+                        "atom positions = {val.shape[0]}.")
+                raise ValueError(msg)
 
         self._atom_pos = val
         """
@@ -2129,6 +2130,7 @@ supergroup_11 = 'oh'
 
 
 def _sgrange(min, max): return tuple(range(min, max + 1))  # inclusive range
+
 
 '''
 11/20/2020 SS added supergroup to the list which is used

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1982,7 +1982,22 @@ class unitcell:
 
     @atom_pos.setter
     def atom_pos(self, val):
+        """
+        SS 03/08/2021 fixing some issues with
+        updating asymmetric positions after 
+        updating atominfo
+        fixing 
+        """
         self._atom_pos = val
+        """
+        update only if its not the first time
+        """
+        if hasattr(self, 'asym_pos'):
+            self.CalcPositions()
+
+        if hasattr(self, 'density'):
+            self.CalcDensity()
+
 
     @property
     def B_factor(self):

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1991,8 +1991,9 @@ class unitcell:
         if hasattr(self, 'atom_type'):
             if self.atom_ntype != val.shape[0]:
                 raise ValueError(f"incorrect number of atom positions."
-                "number of atom type = {self.atom_ntype} and number of"
-                "atom positions = {val.shape[0]}.")
+                                 "number of atom type = {self.atom_ntype} "
+                                 "and number of"
+                                 "atom positions = {val.shape[0]}.")
 
         self._atom_pos = val
         """
@@ -2078,6 +2079,7 @@ class unitcell:
         # vol per atom in A^3
         return 1e3*self.vol/self.num_atom
 
+
 _rqpDict = {
     'triclinic': (tuple(range(6)), lambda p: p),  # all 6
     # note beta
@@ -2127,7 +2129,6 @@ supergroup_11 = 'oh'
 
 
 def _sgrange(min, max): return tuple(range(min, max + 1))  # inclusive range
-
 
 '''
 11/20/2020 SS added supergroup to the list which is used


### PR DESCRIPTION
fixing error introduced in last push to materials. A full 6 parameter list was being passed to `~rqpDict[self.unitcell.latticeType][1]` instead of the reduced set. This is a fix for issue #212 

Fixes: #212