### PR TITLE
Perform multiprocessing on pixel_solid_angles

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1991,7 +1991,7 @@ class PlanarDetector(object):
 
     @property
     def row_edge_vec(self):
-        return self.pixel_size_row*(0.5*self.rows-np.arange(self.rows+1))
+        return _row_edge_vec(self.rows, self.pixel_size_row)
 
     @property
     def col_pixel_vec(self):
@@ -1999,7 +1999,7 @@ class PlanarDetector(object):
 
     @property
     def col_edge_vec(self):
-        return self.pixel_size_col*(np.arange(self.cols+1)-0.5*self.cols)
+        return _col_edge_vec(self.cols, self.pixel_size_col)
 
     @property
     def corner_ul(self):

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -2116,11 +2116,12 @@ class PlanarDetector(object):
         solid_angs = np.empty(len(conn), dtype=float)
 
         # Assign ranges for each process
-        num_per_process = len(conn) // os.cpu_count()
-        remainder = len(conn) % os.cpu_count()
+        num_workers = os.cpu_count()
+        num_per_process = len(conn) // num_workers
+        remainder = len(conn) % num_workers
 
         ranges = []
-        for i in range(os.cpu_count()):
+        for i in range(num_workers):
             start = ranges[-1][1] if i != 0 else 0
 
             stop = start + num_per_process
@@ -2140,7 +2141,7 @@ class PlanarDetector(object):
             'tvec': self.tvec,
         }
         func = functools.partial(_generate_pixel_solid_angles, **kwargs)
-        with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
             results = executor.map(func, ranges)
 
         # Concatenate all the results together


### PR DESCRIPTION
Threading was attempted, but it appeared that all the threads would
either be fighting for the GIL or fighting for the compiler lock in
numba. Threading actually resulted in a large slowdown.

Multiprocessing seems to work well, since there is not a lot of
data to transmit back and forth. For 2048 rows by 2048 columns
and pixel sizes of 0.2, I was able to go from about 46 seconds
to about 6.8 seconds for running this property.