### PR TITLE
using _hkls_changed() instead of _newPData()

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -746,7 +746,7 @@ class Material(object):
             lp.append(_degrees(v[i]))
         self._lparms = lp
         self._newUnitcell()
-        self._newPdata()
+        self._hkls_changed()
         return
 
     lpdoc = r"""Lattice parameters


### PR DESCRIPTION
avoid initializing planedata if hkls don't change. update structure factors regardless.