### PR TITLE
Update Laue group on PlaneData when modified

### DIFF
--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -866,6 +866,12 @@ class PlaneData(object):
         """This is the Schoenflies tag"""
         return self.__laueGroup
 
+    def setLaueGroup(self, laueGroup):
+        self.__laueGroup = laueGroup
+        self.__calc()
+
+    laueGroup = property(getLaueGroup, setLaueGroup, None)
+
     def getQSym(self):
         return self.__qsym  # rotations.quatOfLaueGroup(self.__laueGroup)
 

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -229,6 +229,13 @@ class Material(object):
         else:
             self._unitcell.stiffness = Material.DFLT_STIFFNESS
 
+        if hasattr(self, '_pData'):
+            if self.planeData.lparms != self.reduced_lattice_parameters:
+                self.planeData.lparms = self.reduced_lattice_parameters
+
+            if self.planeData.laueGroup != self.unitcell._laueGroup:
+                self.planeData.laueGroup = self.unitcell._laueGroup
+
     def _hkls_changed(self):
         # Call this when something happens that changes the hkls...
         self._newPdata()
@@ -744,7 +751,6 @@ class Material(object):
             lp.append(_degrees(v[i]))
         self._lparms = lp
         self._newUnitcell()
-        self.planeData.lparms = self.reduced_lattice_parameters
         self._hkls_changed()
 
     @property


### PR DESCRIPTION
Previously, the Laue group wasn't getting updated, and this was causing
incorrect d-spacings and two theta to come out.

Update the Laue group when it is modified.

The reason this was causing issues is because, as of #204, when a new PlaneData object is created,
its properties are [copied from the old PlaneData object](https://github.com/HEXRD/hexrd/blob/b0d51d52c40002aa8bf1d18938c441e3adacda93/hexrd/material.py#L255), in
order to preserve things like `tThMax` and `tThWidth`. However, the `laueGroup` is also copied over,
which means that if we don't update the `laueGroup` on the original `PlaneData` object, the new `PlaneData`
will have an incorrect `laueGroup`. Thus, we need to update it.