### PR TITLE
Update PlaneData laue and lparms simultaneously

### DIFF
--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -872,6 +872,18 @@ class PlaneData(object):
 
     laueGroup = property(getLaueGroup, setLaueGroup, None)
 
+    def set_laue_and_lparms(self, laueGroup, lparms):
+        """Set the Laue group and lattice parameters simultaneously
+
+        When the Laue group changes, the lattice parameters may be
+        incompatible, and cause an error in self.__calc(). This function
+        allows us to update both the Laue group and lattice parameters
+        simultaneously to avoid this issue.
+        """
+        self.__laueGroup = laueGroup
+        self.__lparms = self.__parseLParms(lparms)
+        self.__calc()
+
     def getQSym(self):
         return self.__qsym  # rotations.quatOfLaueGroup(self.__laueGroup)
 

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -229,12 +229,11 @@ class Material(object):
         else:
             self._unitcell.stiffness = Material.DFLT_STIFFNESS
 
-        if hasattr(self, '_pData'):
-            if self.planeData.lparms != self.reduced_lattice_parameters:
-                self.planeData.lparms = self.reduced_lattice_parameters
-
-            if self.planeData.laueGroup != self.unitcell._laueGroup:
-                self.planeData.laueGroup = self.unitcell._laueGroup
+        if pdata := getattr(self, '_pData', None):
+            laue = self.unitcell._laueGroup
+            reduced_lparms = self.reduced_lattice_parameters
+            if pdata.laueGroup != laue or pdata.lparms != reduced_lparms:
+                pdata.set_laue_and_lparms(laue, reduced_lparms)
 
     def _hkls_changed(self):
         # Call this when something happens that changes the hkls...


### PR DESCRIPTION
When the Laue group changes, the lattice parameters may be incompatible,
and cause an error in PlaneData.__calc().

This commit adds a function to allow us to update both the Laue group
and lattice parameters simultaneously to avoid this issue.

Fixes: hexrd/hexrdgui#821