### PR TITLE
Use numba, if possible, in hexrd.symmetry.isnew

### DIFF
--- a/hexrd/symmetry.py
+++ b/hexrd/symmetry.py
@@ -373,7 +373,7 @@ def MakeGenerators(genstr, setting):
         mat = SYM_fillgen(t)
         genmat = np.concatenate((genmat, mat))
         centrosymmetric = True
-        
+
     n = int(genstr[1])
     if(n > 0):
         for i in range(n):
@@ -475,15 +475,15 @@ def GenerateSGSym(sgnum, setting=0):
     for s in SYM_PG_d:
         if(np.allclose(-np.eye(3),s)):
             centrosymmetric = True
-        
+
 
     return SYM_SG, SYM_PG_d, SYM_PG_d_laue, centrosymmetric, symmorphic
 
 def GeneratePGSym(SYM_SG):
     '''
-    calculate the direct space point group symmetries 
-    from the space group symmetry. the direct point 
-    group symmetries are merely the space group 
+    calculate the direct space point group symmetries
+    from the space group symmetry. the direct point
+    group symmetries are merely the space group
     symmetries with zero translation part. The reciprocal
     ones are calculated from the direct symmetries by
     using the metric tensors, but that is done in the unitcell
@@ -507,10 +507,10 @@ def GeneratePGSym(SYM_SG):
 
 def GeneratePGSym_Laue(SYM_PG_d):
     '''
-    generate the laue group symmetry for the given set of 
+    generate the laue group symmetry for the given set of
     point group symmetry matrices. this function just adds
     the inversion symmetry and goes through the group action
-    to generate the entire laue group for the direct point 
+    to generate the entire laue group for the direct point
     point group matrices
     '''
 
@@ -614,7 +614,7 @@ def GeneratePGSYM(pgsym):
     '''
     generate the powers of the group
     '''
-    
+
 
     '''
     now go through the group actions and see if its a new matrix

--- a/hexrd/symmetry.py
+++ b/hexrd/symmetry.py
@@ -29,6 +29,7 @@
 #
 # Module containing functions relevant to symmetries
 
+import numpy as np
 from numpy import array, sqrt, pi, \
      vstack, c_, dot, \
      argmax
@@ -36,7 +37,8 @@ from numpy import array, sqrt, pi, \
 # from hexrd.rotations import quatOfAngleAxis, quatProductMatrix, fixQuat
 from hexrd import rotations as rot
 from hexrd import constants
-import numpy as np
+from hexrd.utils.decorators import numba_njit_if_available
+
 
 # =============================================================================
 # Module vars
@@ -556,14 +558,14 @@ def GeneratePGSym_Laue(SYM_PG_d):
 
     return SYM_PG_d_laue
 
+
+@numba_njit_if_available(cache=True, nogil=True)
 def isnew(mat, sym_mats):
-    isnew = True
     for g in sym_mats:
-        diff = np.sum(np.abs(mat-g))
-        if(diff < 1E-5):
-            isnew = False
-            break
-    return isnew
+        diff = np.sum(np.abs(mat - g))
+        if diff < 1e-5:
+            return False
+    return True
 
 def latticeType(sgnum):
 

--- a/hexrd/utils/decorators.py
+++ b/hexrd/utils/decorators.py
@@ -8,6 +8,8 @@ go into another topical module in :mod:`hexrd.utils`.
 
 import collections
 
+from hexrd.constants import USE_NUMBA
+
 
 def undoc(func):
     """Mark a function or class as undocumented.
@@ -17,7 +19,7 @@ def undoc(func):
     return func
 
 
-class memoized(object):
+class memoized:
     """Decorator. Caches a function's return value each time it is called.
     If called later with the same arguments, the cached value is returned
     (not reevaluated).
@@ -25,6 +27,7 @@ class memoized(object):
     def __init__(self, func):
         self.func = func
         self.cache = {}
+
     def __call__(self, *args, **kw):
         if not isinstance(args, collections.Hashable):
             # uncacheable. a list, for instance.
@@ -37,3 +40,21 @@ class memoized(object):
             value = self.func(*args, **kw)
             self.cache[key] = value
             return value
+
+
+def numba_njit_if_available(func=None, *args, **kwargs):
+    # Forwards decorator to numba.njit if numba is available
+    # Otherwise, does nothing.
+
+    def decorator(func):
+        if USE_NUMBA:
+            import numba
+            return numba.njit(*args, **kwargs)(func)
+        else:
+            # Do nothing...
+            return func
+
+    if func is None:
+        return decorator
+    else:
+        return decorator(func)


### PR DESCRIPTION

Profiling hexrdgui indicated that the most time consuming function
on hexrdgui startup is hexrd.symmetry.isnew. Adding a numba
decorator provides a 20-40% speed-up for starting hexrdgui when
using numba.

This commit also adds and uses a decorator in hexrd.utils.decorators
called "numba_njit_if_available". Basically, if we are using numba,
it forwards the decorator arguments to numba.njit. And if we are not
using numba, it does nothing.

If we want to improve hexrdgui start-up time in the future, profiling
indicates that these are the next most time consuming functions (in
order):

```python
hexrd.unitcell.unitcell.CalcLength
hexrd.matrixutil.findDuplicateVectors
hexrd.unitcell.unitcell.CalcStar
```