### PR TITLE
Update entrypoint for conda

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,7 +10,7 @@ build:
   detect_binary_files_with_prefix: true
   osx_is_app: yes
   entry_points:
-    - hexrd = hexrd.cli:main
+    - hexrd = hexrd.cli.main:main
 
 requirements:
   build:


### PR DESCRIPTION
Since [this import was removed](https://github.com/HEXRD/hexrd/blob/c19aaaf5e0ad6660475b13aad2b8f98424faf64a/hexrd/cli/__init__.py#L11), the entrypoint needed updating.

This now matches the [entrypoint in setup.py](https://github.com/HEXRD/hexrd/blob/c19aaaf5e0ad6660475b13aad2b8f98424faf64a/setup.py#L81), so should hopefully work.
