### PR TITLE
Use numba.njit(cache=True, nogil=True) for all

### DIFF
--- a/hexrd/distortion/dexela_2923.py
+++ b/hexrd/distortion/dexela_2923.py
@@ -70,7 +70,7 @@ def _find_quadrant(xy_in):
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _dexela_2923_distortion(out_, in_, params):
         for el in range(len(in_)):
             xi, yi = in_[el, :]
@@ -89,7 +89,7 @@ if USE_NUMBA:
                     # 1st quadrant
                     out_[el, :] = in_[el, :] + params[0:2]
 
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _dexela_2923_inverse_distortion(out_, in_, params):
         for el in range(len(in_)):
             xi, yi = in_[el, :]

--- a/hexrd/distortion/ge_41rt.py
+++ b/hexrd/distortion/ge_41rt.py
@@ -13,7 +13,7 @@ from .utils import newton
 RHO_MAX = 204.8  # max radius in mm for ge detector
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _ge_41rt_inverse_distortion(out, in_, rhoMax, params):
         maxiter = 100
         prec = cnst.epsf
@@ -56,7 +56,7 @@ if USE_NUMBA:
 
         return out
 
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _ge_41rt_distortion(out, in_, rhoMax, params):
         p0, p1, p2, p3, p4, p5 = params[0:6]
         rxi = 1.0/rhoMax

--- a/hexrd/gridutil.py
+++ b/hexrd/gridutil.py
@@ -104,7 +104,7 @@ def _fill_connectivity(out, m, n, p):
 
 
 if USE_NUMBA:
-    _fill_connectivity = numba.njit(_fill_connectivity)
+    _fill_connectivity = numba.njit(nogil=True, cache=True)(_fill_connectivity)
 
 
 def cellConnectivity(m, n, p=1, origin='ul'):
@@ -134,7 +134,7 @@ def cellConnectivity(m, n, p=1, origin='ul'):
 
 
 if USE_NUMBA:
-    @numba.jit  # relies on loop extraction
+    @numba.njit(nogil=True, cache=True)  # relies on loop extraction
     def cellCentroids(crd, con):
         nele, conn_count = con.shape
         dim = crd.shape[1]
@@ -148,7 +148,7 @@ if USE_NUMBA:
                 out[i, j] = acc * inv_conn
         return out
 
-    @numba.jit
+    @numba.njit(nogil=True, cache=True)
     def compute_areas(xy_eval_vtx, conn):
         areas = np.empty(len(conn))
         for i in range(len(conn)):

--- a/hexrd/indexer.py
+++ b/hexrd/indexer.py
@@ -510,7 +510,7 @@ if USE_NUMBA:
                                       etaOmeMaps, etaIndices, omeIndices,
                                       dpix_eta, dpix_ome, threshold)
 
-    @numba.jit
+    @numba.njit(nogil=True, cache=True)
     def _find_in_range(value, spans):
         """
         Find the index in spans where value >= spans[i] and value < spans[i].
@@ -541,7 +541,7 @@ if USE_NUMBA:
 
         return li
 
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _angle_is_hit(ang, eta_offset, ome_offset, hkl, valid_eta_spans,
                       valid_ome_spans, etaEdges, omeEdges, etaOmeMaps,
                       etaIndices, omeIndices, dpix_eta, dpix_ome, threshold):
@@ -601,7 +601,7 @@ if USE_NUMBA:
         else:
             return isHit, 1
 
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _filter_and_count_hits(angs_0, angs_1, symHKLs_ix, etaEdges,
                                valid_eta_spans, valid_ome_spans, omeEdges,
                                omePeriod, etaOmeMaps, etaIndices, omeIndices,
@@ -655,13 +655,13 @@ if USE_NUMBA:
 
         return float(hits)/float(total) if total != 0 else 0.0
 
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _map_angle(angle, offset):
         """Numba-firendly equivalent to xf.mapAngle."""
         return np.mod(angle-offset, 2*np.pi)+offset
 
     # use a jitted version of _check_dilated
-    _check_dilated = numba.njit(_check_dilated)
+    _check_dilated = numba.njit(nogil=True, cache=True)(_check_dilated)
 else:
     def paintGridThis(quat):
         """

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -331,7 +331,7 @@ def _fwhm_to_sigma(fwhm):
 
 # FIXME find a better place for this, and maybe include loop over pixels
 if ct.USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _solid_angle_of_triangle(vtx_list):
         norms = np.sqrt(np.sum(vtx_list*vtx_list, axis=1))
         norms_prod = norms[0] * norms[1] * norms[2]

--- a/hexrd/transforms/xf.py
+++ b/hexrd/transforms/xf.py
@@ -95,7 +95,7 @@ def makeGVector(hkl, bMat):
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _anglesToGVecHelper(angs, out):
         # gVec_e = np.vstack([[np.cos(0.5*angs[:, 0]) * np.cos(angs[:, 1])],
         #                     [np.cos(0.5*angs[:, 0]) * np.sin(angs[:, 1])],
@@ -898,7 +898,7 @@ def rowNorm(a):
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _unitVectorSingle(a, b):
         n = a.shape[0]
         nrm = 0.0
@@ -913,7 +913,7 @@ if USE_NUMBA:
             for i in range(n):
                 b[i] = a[i]
 
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _unitVectorMulti(a, b):
         n = a.shape[0]
         m = a.shape[1]
@@ -1067,7 +1067,7 @@ def makeBinaryRotMat(axis):
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _makeEtaFrameRotMat(bHat_l, eHat_l, out):
         # bHat_l and eHat_l CANNOT have 0 magnitude!
         # must catch this case as well as colinear bHat_l/eHat_l elsewhere...

--- a/hexrd/xrdutil.py
+++ b/hexrd/xrdutil.py
@@ -1339,7 +1339,7 @@ def simulateLauePattern(hkls, bMat,
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _expand_pixels(original, w, h, result):
         hw = 0.5 * w
         hh = 0.5 * h
@@ -1356,7 +1356,7 @@ if USE_NUMBA:
 
         return result
 
-    @numba.jit
+    @numba.njit(nogil=True, cache=True)
     def _compute_max(tth, eta, result):
         period = 2.0 * np.pi
         hperiod = np.pi
@@ -1462,7 +1462,7 @@ else:
 
 
 if USE_NUMBA:
-    @numba.njit
+    @numba.njit(nogil=True, cache=True)
     def _coo_build_window_jit(frame_row, frame_col, frame_data,
                               min_row, max_row, min_col, max_col,
                               result):


### PR DESCRIPTION
Using "njit" instead of "jit" means to use the "nopython" argument,
which can be faster. But it may not be allowed for some function
argument types.

Caching will get numba to cache the functions it compiles so that it
does not have to compile them again. This can provide a big speed-up
after the functions have been called once and saved.

Note that if you edit the file that contains the function, the cache
will automatically be re-generated the next time it is ran.

nogil tells numba to release the GIL. This is helpful in case the
function is used in any python multi-threading.

Caching is also helpful if the function is used in any python
multi-threading because numba can only compile on one thread at a time...

In any case, these changes all have the potential to be good, but we should
definitely test them all, and make sure that everything still works, gives
the same results, and takes at most the same amount of time that it did
previously.