### PR TITLE
Eta omega map generation speedup

### DIFF
--- a/hexrd/config/instrument.py
+++ b/hexrd/config/instrument.py
@@ -9,8 +9,10 @@ from hexrd import instrument
 class Instrument(Config):
     """Handle HEDM instrument config."""
 
-    def __init__(self, instr_file=None):
+    def __init__(self, cfg, instr_file=None):
+        super().__init__(cfg)
         self._configuration = instr_file
+        self._max_workers = self._cfg.multiprocessing
 
     # Note: instrument is instantiated with a yaml dictionary; use self
     #       to instantiate classes based on this one
@@ -25,7 +27,12 @@ class Instrument(Config):
         if not hasattr(self, '_hedm'):
             with open(self.configuration, 'r') as f:
                 icfg = yaml.load(f, Loader=NumPyIncludeLoader)
-            self._hedm = instrument.HEDMInstrument(icfg)
+
+            kwargs = {
+                'instrument_config': icfg,
+                'max_workers': self._max_workers,
+            }
+            self._hedm = instrument.HEDMInstrument(**kwargs)
         return self._hedm
 
     @hedm.setter
@@ -33,7 +40,12 @@ class Instrument(Config):
         """Set the HEDMInstrument class."""
         with open(yml, 'r') as f:
             icfg = yaml.load(f, Loader=NumPyIncludeLoader)
-        self._hedm = instrument.HEDMInstrument(icfg)
+
+        kwargs = {
+            'instrument_config': icfg,
+            'max_workers': self._max_workers,
+        }
+        self._hedm = instrument.HEDMInstrument(**kwargs)
 
     @property
     def detector_dict(self):

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -41,7 +41,7 @@ class RootConfig(Config):
         if not hasattr(self, '_instr_config'):
             instr_file = self.get('instrument')
             instr_file = self.check_filename(instr_file, self.working_dir)
-            self._instr_config = Instrument(instr_file)
+            self._instr_config = Instrument(self, instr_file)
         return self._instr_config
 
     @instrument.setter

--- a/hexrd/utils/concurrent.py
+++ b/hexrd/utils/concurrent.py
@@ -1,0 +1,30 @@
+import os
+
+
+def distribute_tasks(num_tasks, max_workers=os.cpu_count()):
+    # Distribute tasks as evenly as possible to each worker.
+    # Returns a list of tuples, where each tuple in the list
+    # represents the [start, stop) task range for a worker.
+    result = []
+    num_assigned = 0
+
+    tasks_per_worker = num_tasks // max_workers
+    remainder = num_tasks % max_workers
+    for i in range(max_workers):
+        if num_assigned == num_tasks:
+            break
+
+        tasks = tasks_per_worker
+        if remainder != 0:
+            tasks += 1
+            remainder -= 1
+
+        if i == 0:
+            previous = 0
+        else:
+            previous = result[-1][1]
+
+        result.append((previous, previous + tasks))
+        num_assigned += tasks
+
+    return result

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -1,0 +1,65 @@
+from hexrd.utils.concurrent import distribute_tasks
+
+
+def test_distribute_tasks():
+    num_tasks = 4
+    max_workers = 4
+    expected_result = [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 4),
+    ]
+    result = distribute_tasks(num_tasks, max_workers)
+    assert result == expected_result
+
+    num_tasks = 3
+    max_workers = 5
+    expected_result = [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+    ]
+    result = distribute_tasks(num_tasks, max_workers)
+    assert result == expected_result
+
+    num_tasks = 5
+    max_workers = 3
+    expected_result = [
+        (0, 2),
+        (2, 4),
+        (4, 5),
+    ]
+    result = distribute_tasks(num_tasks, max_workers)
+    assert result == expected_result
+
+    num_tasks = 574
+    max_workers = 24
+    expected_result = [
+        (0, 24),
+        (24, 48),
+        (48, 72),
+        (72, 96),
+        (96, 120),
+        (120, 144),
+        (144, 168),
+        (168, 192),
+        (192, 216),
+        (216, 240),
+        (240, 264),
+        (264, 288),
+        (288, 312),
+        (312, 336),
+        (336, 360),
+        (360, 384),
+        (384, 408),
+        (408, 432),
+        (432, 456),
+        (456, 480),
+        (480, 504),
+        (504, 528),
+        (528, 551),
+        (551, 574),
+    ]
+    result = distribute_tasks(num_tasks, max_workers)
+    assert result == expected_result


### PR DESCRIPTION
Before, the multi-threading was a little too fine-grained, and the main thread was running a lot of code that the threads could have been running. Now, it's a little more coarse-grained, and a fair amount of time is being spent in the threads other than the main thread.

This resulted in nearly a 2x speed-up for the GE example.

Multiprocessing was attempted as well, but pickling and unpickling image series seems to be expensive, and makes it slow. Perhaps it's something we can pursue if we find a faster way to pickle/unpickle image series data.