### PR TITLE
Do not re-compute PlaneData if wavelength is same

### DIFF
--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -776,9 +776,14 @@ class PlaneData(object):
         return self.__wavelength
 
     def set_wavelength(self, wavelength):
-        self.__wavelength = processWavelength(wavelength)
+        wavelength = processWavelength(wavelength)
+        if np.isclose(self.__wavelength, wavelength):
+            # Do not re-compute if it is almost the same
+            return
+
+        self.__wavelength = wavelength
         self.__calc()
-        return
+
     wavelength = property(get_wavelength, set_wavelength, None)
 
     def get_structFact(self):


### PR DESCRIPTION
When the wavelength is set on the PlaneData object, do not re-compute
if the wavelength is the same.

Note that this checks for similarity with an absolute tolerance of `1.e-8` and a relative tolerance of `1.e-5`.