### PR TITLE
Downgrade scikit-learn to try Windows package fix

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install build requirements
       run: |
           conda activate hexrd
-          conda install anaconda conda-build
+          conda install anaconda conda-build scikit-learn==0.24.1
 
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - python {{PY_VER}}
     - pyyaml
     - scikit-image
-    - scikit-learn
+    - scikit-learn 0.24.1
     - scipy
 
 test:


### PR DESCRIPTION
The Windows packaging is failing during the install of anaconda
due to a failure in the post-link script of scikit-learn.

Perhaps this is being caused by some changes they made in 0.24.2,
which just came out 28 days ago.

Try downgrading scikit-learn to 0.24.1 to see if that fixes the
Windows packaging issues.

The full error is pasted below.

```bash
LinkError: post-link script failed for package defaults::scikit-learn-0.24.2-py38hf11a4ad_0
location of failed script: C:\Miniconda\envs\hexrd\Scripts\.scikit-learn-post-link.bat
==> script messages <==
<None>
==> script output <==
stdout:
stderr: find: �/I�: No such file or directory
find: �win-64�: No such file or directory
--- Logging error ---

Traceback (most recent call last):

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\gateways\logging.py", line 149, in emit

    self.flush()

  File "C:\Miniconda\envs\hexrd\lib\logging\__init__.py", line 1069, in flush

    self.stream.flush()

OSError: [Errno 22] Invalid argument

Call stack:

  File "C:\Miniconda\envs\hexrd\Scripts\conda-script.py", line 12, in <module>

    sys.exit(main())

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\cli\main.py", line 152, in main

    return conda_exception_handler(_main, *args, **kwargs)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\exceptions.py", line 1371, in conda_exception_handler

    return_value = exception_handler(func, *args, **kwargs)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\exceptions.py", line 1079, in __call__

    return func(*args, **kwargs)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\cli\main.py", line 84, in _main

    exit_code = do_call(args, p)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\cli\conda_argparse.py", line 83, in do_call

    return getattr(module, func_name)(args, parser)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\cli\main_config.py", line 30, in execute

    execute_config(args, parser)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\cli\main_config.py", line 176, in execute_config

    stdout_write('\n'.join(format_dict(d)))

  File "C:\Miniconda\envs\hexrd\lib\logging\__init__.py", line 1446, in info

    self._log(INFO, msg, args, **kwargs)

  File "C:\Miniconda\envs\hexrd\lib\logging\__init__.py", line 1589, in _log

    self.handle(record)

  File "C:\Miniconda\envs\hexrd\lib\logging\__init__.py", line 1599, in handle

    self.callHandlers(record)

  File "C:\Miniconda\envs\hexrd\lib\logging\__init__.py", line 1661, in callHandlers

    hdlr.handle(record)

  File "C:\Miniconda\envs\hexrd\lib\logging\__init__.py", line 954, in handle

    self.emit(record)

  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda\gateways\logging.py", line 154, in emit

    self.handleError(record)

Message: 'subdir: win-64'

Arguments: ()

Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>

OSError: [Errno 22] Invalid argument
```

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>