### PR TITLE
filter copy of maps instead of main object

### DIFF
--- a/hexrd/config/material.py
+++ b/hexrd/config/material.py
@@ -70,12 +70,11 @@ class MaterialConfig(Config):
         if self.fminr is not None:
             # !!! exclusions are all False upon generation; setting
             #     the tThMax attribute later won't affect these.
+            excl_full = np.array(pd.exclusions, dtype=bool)
+            pd.exclusions = None
             mod_f_sq = pd.structFact
             excl_these = mod_f_sq/np.max(mod_f_sq) < self.fminr
-            excl_full = pd.exclusions
-            active_refls_idx = np.where(~pd.exclusions)[0]
-            excl_full[active_refls_idx[excl_these]] = True
-            pd.exclusions = excl_full
+            pd.exclusions = np.logical_or(excl_full, excl_these)
         return pd
 
     @property

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -114,7 +114,7 @@ def generate_orientation_fibers(cfg, eta_ome):
     numSpots = []
     coms = []
     for i in seed_hkl_ids:
-        this_map = copy.copy(eta_ome.dataStore[i])
+        this_map = copy.deepcopy(eta_ome.dataStore[i])
         clean_map(this_map)  # !!! need to get rid of NaNs for blob detection
         numSpots_t, coms_t = find_peaks_2d(this_map, method, method_kwargs)
         numSpots.append(numSpots_t)


### PR DESCRIPTION
There was an oversight where the call to `clean_maps` to enable feature detection was modifying the underlying object and removing NaNs, which are critical for indexing cases where the detectors have gaps in eta coverage.