### PR TITLE
Force upload packages to anaconda

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -72,7 +72,7 @@ jobs:
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       run: |
           conda activate hexrd
-          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user HEXRD output/**/*.tar.bz2
+          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}
@@ -81,7 +81,7 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
           conda activate hexrd
-          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user HEXRD --label hexrd-prerelease output/**/*.tar.bz2
+          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD --label hexrd-prerelease output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}


### PR DESCRIPTION
Before this commit, if we re-run the GitHub actions workflow (which may
be done if a workflow failed for a network issue, for instance), the
workflow will fail when it tries to upload the anaconda package because
the anaconda package already exists on anaconda.

Force the upload so that this error does not happen, and so that the
packages on anaconda are generated from the latest workflow that was ran.