### PR TITLE
Lorentz Polarization factor for 2D detectors

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -2119,21 +2119,6 @@ class PlanarDetector(object):
         return _pixel_solid_angles(**kwargs)
 
     @property
-    def lorentz_polarization_factor(self, f_hor, f_vert):
-
-        """
-        f_hor is the fraction of horizontal polarization. for XFELs
-        this is close to 1
-        f_vert is the fraction of vertical polarization, which is
-        ~0 for XFELs
-        """
-
-        tth, eta = self.pixel_angles()
-        args = (tth, eta, f_hor, f_vert)
-
-        return _lorentz_polarization_factor(*args)
-
-    @property
     def calibration_parameters(self):
         #
         # set up calibration parameter list and refinement flags
@@ -2166,6 +2151,20 @@ class PlanarDetector(object):
     # =========================================================================
     # METHODS
     # =========================================================================
+
+    def lorentz_polarization_factor(self, f_hor, f_vert):
+
+        """
+        f_hor is the fraction of horizontal polarization. for XFELs
+        this is close to 1
+        f_vert is the fraction of vertical polarization, which is
+        ~0 for XFELs
+        """
+
+        tth, eta = self.pixel_angles()
+        args = (tth, eta, f_hor, f_vert)
+
+        return _lorentz_polarization_factor(*args)
 
     def config_dict(self, chi=0, tvec=ct.zeros_3,
                     beam_energy=beam_energy_DFLT, beam_vector=ct.beam_vec,
@@ -3654,7 +3653,7 @@ def _lorentz_polarization_factor(tth, eta, f_hor, f_vert):
     ceta2 = np.cos(eta)**2
 
     L = 1./(cth*sth2)
-    P = f_hor*(seta2+ceta2*ctth2) + 
+    P = f_hor*(seta2+ceta2*ctth2) + \
     f_vert*(ceta2+seta2*ctth2)
 
     return L*P

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -2167,6 +2167,11 @@ class PlanarDetector(object):
                 f"must be equal to 1.")
             raise RuntimeError(msg)
 
+        if f_hor < 0 or f_vert < 0:
+            msg = (f"fraction of polarization in horizontal "
+                f"or vertical directions can't be negative.")
+            raise RuntimeError(msg)
+
         tth, eta = self.pixel_angles()
         args = (tth, eta, f_hor, f_vert)
 

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -2160,6 +2160,12 @@ class PlanarDetector(object):
         f_vert is the fraction of vertical polarization, which is
         ~0 for XFELs
         """
+        s = f_hor+f_vert
+        if np.abs(s-1) > 1e-6:
+            msg = (f"sum of fraction of "
+                f"horizontal and vertical polarizations "
+                f"must be equal to 1.")
+            raise RuntimeError(msg)
 
         tth, eta = self.pixel_angles()
         args = (tth, eta, f_hor, f_vert)


### PR DESCRIPTION
computes the lorentz polarization factor for any 2D planar detector given the fraction of horizontal and vertical polarizations of the incident x-ray. 

Note that the factors **aren't** properties of the `PlanarDetector` class since it requires the inputs of the polarization fractions. 

The computed factors for a typical MEC configuration gives reasonable results shown below.

![Screen Shot 2021-06-14 at 7 37 13 PM](https://user-images.githubusercontent.com/15834451/121984510-ef886e80-cd47-11eb-9a7a-df279347b977.png)