### PR TITLE
Enable the first five hkls by default

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -309,10 +309,8 @@ class Material(object):
 
     def enable_hkls_below_index(self, index=5):
         # Enable hkls with indices less than @index
-        exclusions = self._pData.exclusions
-        for i in range(len(exclusions)):
-            exclusions[i] = i >= index
-
+        exclusions = np.ones_like(self._pData.exclusions, dtype=bool)
+        exclusions[:index] = False
         self._pData.exclusions = exclusions
 
     def enable_hkls_below_tth(self, tth_threshold=90.0):

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -304,10 +304,23 @@ class Material(object):
             self.set_default_exclusions()
 
     def set_default_exclusions(self):
+        # Enable only the first 5 by default
+        self.enable_hkls_below_index(5)
+
+    def enable_hkls_below_index(self, index=5):
+        # Enable hkls with indices less than @index
+        exclusions = self._pData.exclusions
+        for i in range(len(exclusions)):
+            exclusions[i] = i >= index
+
+        self._pData.exclusions = exclusions
+
+    def enable_hkls_below_tth(self, tth_threshold=90.0):
         '''
-          Set default exclusions
-          all reflections with two-theta smaller than 90 degrees
+          enable reflections with two-theta less than @tth_threshold degrees
         '''
+        tth_threshold = numpy.radians(tth_threshold)
+
         tth = numpy.array([hkldata['tTheta']
                            for hkldata in self._pData.hklDataList])
         dflt_excl = numpy.ones(tth.shape, dtype=numpy.bool)
@@ -324,14 +337,14 @@ class Material(object):
 
             dflt_excl2[~numpy.isnan(tth)] = \
                 ~((tth[~numpy.isnan(tth)] >= 0.0) &
-                  (tth[~numpy.isnan(tth)] <= numpy.pi/2.0))
+                  (tth[~numpy.isnan(tth)] <= tth_threshold))
 
             dflt_excl = numpy.logical_or(dflt_excl, dflt_excl2)
 
         else:
             dflt_excl[~numpy.isnan(tth)] = \
                 ~((tth[~numpy.isnan(tth)] >= 0.0) &
-                  (tth[~numpy.isnan(tth)] <= numpy.pi/2.0))
+                  (tth[~numpy.isnan(tth)] <= tth_threshold))
             dflt_excl[0] = False
 
         self._pData.exclusions = dflt_excl

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -304,12 +304,26 @@ class Material(object):
             self.set_default_exclusions()
 
     def set_default_exclusions(self):
-        # Enable only the first 5 by default
-        self.enable_hkls_below_index(5)
+        if hasattr(self, 'hkl_from_file'):
+            # If we loaded hkls from the file, use those
+            self.enable_hkls_from_file()
+        else:
+            # Otherwise, enable only the first 5 by default
+            self.enable_hkls_below_index(5)
+
+    def enable_hkls_from_file(self):
+        # Enable hkls from the file
+        # 'hkl_from_file' must be an attribute on `self`
+        exclusions = numpy.ones_like(self._pData.exclusions, dtype=bool)
+        for i, g in enumerate(self._pData.hklDataList):
+            if g['hkl'].tolist() in self.hkl_from_file.tolist():
+                exclusions[i] = False
+
+        self._pData.exclusions = exclusions
 
     def enable_hkls_below_index(self, index=5):
         # Enable hkls with indices less than @index
-        exclusions = np.ones_like(self._pData.exclusions, dtype=bool)
+        exclusions = numpy.ones_like(self._pData.exclusions, dtype=bool)
         exclusions[:index] = False
         self._pData.exclusions = exclusions
 


### PR DESCRIPTION
Rather than enabling all hkls with two theta less than 90 degrees
by default, we are now enabling the first five hkls by default.

This adds two utility functions, though, for automatically enabling
hkls: one for enabling all hkls below an index, and one for enabling
all hkls below a two theta value (which is copied from the previous
`set_default_exclusions()` function).

The first utility function gets called by default, which enables
only the first five hkls.

Fixes: #225