### PR TITLE
Convert to strings for h5py string types

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -65,6 +65,7 @@ from hexrd.crystallography import PlaneData
 from hexrd import constants as ct
 from hexrd.rotations import angleAxisOfRotMat, RotMatEuler
 from hexrd import distortion as distortion_pkg
+from hexrd.utils.compatibility import h5py_read_string
 from hexrd.utils.concurrent import distribute_tasks
 from hexrd.utils.decorators import memoize
 from hexrd.valunits import valWUnit
@@ -3469,7 +3470,7 @@ def unwrap_h5_to_dict(f, d):
         except(AttributeError):
             # reached a dataset
             if np.dtype(val) == 'O':
-                d[key] = str(np.array(val))
+                d[key] = h5py_read_string(val)
             else:
                 tmp = np.array(val)
                 if tmp.ndim == 1 and len(tmp) == 1:

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -49,6 +49,7 @@ from warnings import warn
 from hexrd.mksupport import Write2H5File
 from hexrd.symbols import xtal_sys_dict
 from hexrd.symbols import Hall_to_sgnum, HM_to_sgnum
+from hexrd.utils.compatibility import h5py_read_string
 
 __all__ = ['Material', 'loadMaterialList']
 
@@ -591,7 +592,7 @@ class Material(object):
         # read atom types (by atomic number, Z)
         self._atomtype = numpy.array(gid.get('Atomtypes'), dtype=numpy.int32)
         if 'ChargeStates' in gid:
-            self._charge = numpy.array(gid.get('ChargeStates'))
+            self._charge = h5py_read_string(gid['ChargeStates'])
         else:
             self._charge = ['0']*self._atomtype.shape[0]
         self._atom_ntype = self._atomtype.shape[0]

--- a/hexrd/utils/compatibility.py
+++ b/hexrd/utils/compatibility.py
@@ -1,0 +1,14 @@
+from importlib.metadata import version
+
+import h5py
+
+
+def h5py_read_string(dataset):
+    if version('h5py') >= '3':
+        # In h5py >= 3.0.0, h5py no longer converts the data type to a
+        # string automatically, and we have to do it manually...
+        string_dtype = h5py.check_string_dtype(dataset.dtype)
+        if string_dtype is not None and string_dtype.encoding == 'utf-8':
+            dataset = dataset.asstr()
+
+    return dataset[()]


### PR DESCRIPTION
In h5py >= 3.0.0, h5py no longer automatically converts to string
data types, but always leaves string/byte data as bytes. Thus, we
need to add some compatibility to automatically convert to strings
when the underlying data is a string.

This fixes two specific cases that I currently know of: #273 and
loading in a distortion string in an instrument hdf5 file.

We should add this in more places if I missed any.

Fixes loading [this HDF5 instrument file](https://github.com/HEXRD/hexrd/files/6736675/ge.hexrd.zip).

Fixes: #273