### PR TITLE
Use option to return spot data from pull_spots()

### DIFF
--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -107,7 +107,7 @@ def fit_grain_FF_reduced(grain_id):
             eta_ranges=eta_ranges,
             ome_period=ome_period,
             dirname=analysis_dirname, filename=spots_filename,
-            save_spot_list=False,
+            return_spot_list=False,
             quiet=True, check_only=False, interp='nearest')
 
         # ======= DETERMINE VALID REFLECTIONS =======

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1406,7 +1406,7 @@ class HEDMInstrument(object):
                    eta_ranges=[(-np.pi, np.pi), ],
                    ome_period=(-np.pi, np.pi),
                    dirname='results', filename=None, output_format='text',
-                   save_spot_list=False,
+                   return_spot_list=False,
                    quiet=True, check_only=False,
                    interp='nearest'):
         """
@@ -1442,7 +1442,7 @@ class HEDMInstrument(object):
             DESCRIPTION. The default is None.
         output_format : TYPE, optional
             DESCRIPTION. The default is 'text'.
-        save_spot_list : TYPE, optional
+        return_spot_list : TYPE, optional
             DESCRIPTION. The default is False.
         quiet : TYPE, optional
             DESCRIPTION. The default is True.
@@ -1802,10 +1802,15 @@ class HEDMInstrument(object):
                                     meas_angs, meas_xy)
                             pass  # end conditional on write output
                         pass  # end conditional on check only
+
                         patch_output.append([
                                 peak_id, hkl_id, hkl, sum_int, max_int,
                                 ang_centers[i_pt], meas_angs, meas_xy,
                                 ])
+
+                        if return_spot_list:
+                            patch_output[-1].append(patch_data)
+
                         iRefl += 1
                     pass  # end patch conditional
                 pass  # end patch loop

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1803,14 +1803,25 @@ class HEDMInstrument(object):
                             pass  # end conditional on write output
                         pass  # end conditional on check only
 
-                        patch_output.append([
-                                peak_id, hkl_id, hkl, sum_int, max_int,
-                                ang_centers[i_pt], meas_angs, meas_xy,
-                                ])
-
                         if return_spot_list:
-                            patch_output[-1].append(patch_data)
-
+                            # Full output
+                            xyc_arr = xy_eval.reshape(
+                                prows, pcols, 2
+                            ).transpose(2, 0, 1)
+                            _patch_output = [
+                                detector_id, iRefl, peak_id, hkl_id, hkl,
+                                tth_edges, eta_edges, np.radians(ome_eval),
+                                xyc_arr, ijs, frame_indices, patch_data,
+                                ang_centers[i_pt], xy_centers[i_pt],
+                                meas_angs, meas_xy
+                            ]
+                        else:
+                            # Trimmed output
+                            _patch_output = [
+                                peak_id, hkl_id, hkl, sum_int, max_int,
+                                ang_centers[i_pt], meas_angs, meas_xy
+                            ]
+                        patch_output.append(_patch_output)
                         iRefl += 1
                     pass  # end patch conditional
                 pass  # end patch loop


### PR DESCRIPTION
The previous `save_spot_list` argument was intended to be used for
this purpose, but it was unused.

This was renamed to `return_spot_list` to emphasize that the spot
list will be returned (rather than some other form of saving such
as writing to disk). And now, if `return_spot_list` is `True`, all of
the data that is normally written out to the HDF5 file will be appended
to the output.

This data will be used for spot montages.