### PR TITLE
Rescale pixel solid angle correction.

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -3693,8 +3693,12 @@ def _pixel_solid_angles(rows, cols, pixel_size_row, pixel_size_col,
 
     # Concatenate all the results together
     solid_angs[:] = np.concatenate(list(results))
+    solid_angs = solid_angs.reshape(rows, cols)
+    mi = solid_angs.min()
+    if mi > 0.:
+        solid_angs = solid_angs/mi
 
-    return solid_angs.reshape(rows, cols)
+    return solid_angs
 
 
 @memoize


### PR DESCRIPTION
The intensities in the image after the solid angle correction was applied grew very large. This was because the correction factors were small numbers and division by these numbers led to very large values. This PR rescales solid angle correction to range [1, infinity] and avoids that. Now the corrections together with the Lorentz polarization correction, agrees very well with Dave McGonegle's Matlab code.