### PR TITLE
Fix python=3.8 for Linux packaging

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -4,9 +4,9 @@ yum install -y wget git gcc
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod a+x Miniconda3-latest-Linux-x86_64.sh
 ./Miniconda3-latest-Linux-x86_64.sh -b
-${HOME}/miniconda3/bin/conda create -y -n hexrd
+${HOME}/miniconda3/bin/conda create -y -n hexrd python=3.8
 ${HOME}/miniconda3/bin/activate hexrd
 ${HOME}/miniconda3/bin/conda activate hexrd
-${HOME}/miniconda3/bin/conda install conda-build
+${HOME}/miniconda3/bin/conda install conda-build -y
 mkdir output
 ${HOME}/miniconda3/bin/conda build -c defaults -c conda-forge --output-folder output/ conda.recipe/

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   build:
     - numpy
-    - python {{PY_VER}}
+    - python=3.8
     - setuptools
     - setuptools_scm
 
@@ -29,7 +29,7 @@ requirements:
     - numpy
     - psutil
     - pycifrw
-    - python {{PY_VER}}
+    - python=3.8
     - pyyaml
     - scikit-image
     - scikit-learn 0.24.1


### PR DESCRIPTION
Lately, the Linux packaging has been using python 3.9. Python 3.9 may
work, but hexrdgui is currently fixed to python 3.8. Fix python to 3.8
for the Linux packaging as well until we decide to upgrade python in
both hexrd and hexrdgui simultaneously.