### PR TITLE
Use conda-forge instead of anaconda channels

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -7,6 +7,6 @@ chmod a+x Miniconda3-latest-Linux-x86_64.sh
 ${HOME}/miniconda3/bin/conda create -y -n hexrd python=3.8
 ${HOME}/miniconda3/bin/activate hexrd
 ${HOME}/miniconda3/bin/conda activate hexrd
-${HOME}/miniconda3/bin/conda install conda-build -y
+${HOME}/miniconda3/bin/conda install --override-channels -c conda-forge conda-build -y
 mkdir output
-${HOME}/miniconda3/bin/conda build -c defaults -c conda-forge --output-folder output/ conda.recipe/
+${HOME}/miniconda3/bin/conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install build requirements
       run: |
           conda activate hexrd
-          conda install anaconda conda-build scikit-learn==0.24.1
+          conda install --override-channels -c conda-forge anaconda-client conda-build
 
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
@@ -57,7 +57,7 @@ jobs:
       run: |
           conda activate hexrd
           mkdir output
-          conda build -c defaults -c conda-forge --output-folder output/ conda.recipe/
+          conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![conda-package](https://github.com/HEXRD/hexrd/workflows/conda-package/badge.svg)  ![test](https://github.com/HEXRD/hexrd/workflows/test/badge.svg)
 # HEXRD
-The HEXRD project is developing a cross-platform, open-source library for the general analysis of X-ray diffraction data.  This includes powder diffraction, Laue diffraction, and High Energy Diffraction Microscopy (_a.k.a._ 3DXRD, multi-grain rotation method) modalities.  At its core, HEXRD provides an abstraction of a generic diffraction instrument with support for multiple detectors.  This includes optimized transforms from the direct and reciprocal crystal lattices to the local detector coordinates, harnesses for interpolating image data into scattering angle coordinates, and sophisticated calibration routines.  
+The HEXRD project is developing a cross-platform, open-source library for the general analysis of X-ray diffraction data.  This includes powder diffraction, Laue diffraction, and High Energy Diffraction Microscopy (_a.k.a._ 3DXRD, multi-grain rotation method) modalities.  At its core, HEXRD provides an abstraction of a generic diffraction instrument with support for multiple detectors.  This includes optimized transforms from the direct and reciprocal crystal lattices to the local detector coordinates, harnesses for interpolating image data into scattering angle coordinates, and sophisticated calibration routines.
 
 # Installing
 
@@ -22,7 +22,7 @@ OS X 11 does not work with the Python from conda-forge. Please install a the ver
 from the HEXRD channel
 
 ```bash
-conda install -c HEXRD python=3.8.4
+conda install -c hexrd python=3.8.4
 ```
 
 ## conda (release)
@@ -30,14 +30,14 @@ conda install -c HEXRD python=3.8.4
 To install the latest stable release
 
 ```bash
-conda install -c hexrd -c anaconda -c conda-forge hexrd
+conda install -c hexrd -c conda-forge hexrd
 ```
 
 ## conda (prerelease)
 To install the latest changes on master, do the following.  Note that this release may be unstable.
 
 ```bash
-conda install -c hexrd/label/hexrd-prerelease -c hexrd -c anaconda -c conda-forge hexrd
+conda install -c hexrd/label/hexrd-prerelease -c hexrd -c conda-forge hexrd
 ```
 
 # Run
@@ -75,9 +75,9 @@ conda activate hexrd
 ```bash
 # First, make sure python3.8+ is installed in your target env.
 # If it is not, run the following command:
-conda install -c anaconda python=3.8
+conda install -c conda-forge python=3.8
 # Install deps using conda package
-conda install -c hexrd -c anaconda -c conda-forge hexrd
+conda install -c hexrd -c conda-forge hexrd
 # Now using pip to link repo's into environment for development
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 ```
@@ -89,7 +89,7 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 # See the following issue for more details: https://github.com/HEXRD/hexrdgui/issues/505
 conda install -c conda-forge python=3.8
 # Install deps using conda package
-conda install -c hexrd -c anaconda -c conda-forge hexrd
+conda install -c hexrd -c conda-forge hexrd
 # Now using pip to link repo's into environment for development
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 ```
@@ -98,9 +98,9 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 ```bash
 # First, make sure python3.8+ is installed in your target env.
 # If it is not, run the following command:
-conda install -c anaconda python=3.8
+conda install -c conda-forge python=3.8
 # Install deps using conda package
-conda install -c hexrd -c anaconda -c conda-forge hexrd
+conda install -c hexrd -c conda-forge hexrd
 # Now using pip to link repo's into environment for development
 set CONDA_BUILD=1
 pip install --no-build-isolation --no-deps -U -e hexrd

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,7 +8,6 @@ source:
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   detect_binary_files_with_prefix: true
-  osx_is_app: yes
   entry_points:
     - hexrd = hexrd.cli.main:main
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - python=3.8
     - pyyaml
     - scikit-image
-    - scikit-learn 0.24.1
+    - scikit-learn
     - scipy
 
 test:


### PR DESCRIPTION
This is an attempt to use the `conda-forge` channel instead of the
`defaults` and `anaconda` channels, for all packages.
    
This will hopefully fix the issue where we had to downgrade scikit-learn
because it would fail to install on Github Actions on Windows. This will
hopefully also fix a current issue for the Windows packaging where
the llvmlite dll cannot be loaded by numba. It makes more sense for us
to install these packages from conda-forge since the respective project
developers actually maintain the packages on conda-forge (whereas their
packages on the anaconda/defaults channels are maintained by anaconda).
    
We will first need to make sure the packaging and tests pass, and then
move on to test the packages manually.
    
If we run into crashing issues on Mac with openblas, as we have in the
past, we may be able to resolve it by setting the environment variable
`OPENBLAS_NUM_THREADS=1`.