### PR TITLE
dmin and kev float conversion in load_materials_hdf5

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -60,7 +60,7 @@ __all__ = ['Material', 'loadMaterialList']
 
 
 def _angstroms(x):
-    return valWUnit('xrayenergy', 'energy',  x, 'keV')
+    return valWUnit('lp', 'length',  x, 'angstrom')
 
 
 def _degrees(x):
@@ -68,7 +68,7 @@ def _degrees(x):
 
 
 def _kev(x):
-    return valWUnit('lp', 'length',  x, 'angstrom')
+    return valWUnit('xrayenergy', 'energy',  x, 'keV')
 
 def _key(x):
     return x.name
@@ -1065,9 +1065,9 @@ def load_materials_hdf5(f, dmin=Material.DFLT_DMIN, kev=Material.DFLT_KEV,
     if isinstance(dmin, float):
         dmin = _angstroms(dmin)
 
-    if instance(kev, float):
+    if isinstance(kev, float):
         kev = _kev(kev)
-        
+
     return {
         name: Material(name, f, dmin=dmin, kev=kev, sgsetting=sgsetting)
         for name in names


### PR DESCRIPTION
Check if `dmin` and `Kev` are floats and convert them to `valunits` in the `herd.material.load_materials_hdf5` function. 
It is assumed that `dmin` is in Angstrom and `Kev` is in kilo ev. This fixes #154.