### PR TITLE
Imageseries stats

### DIFF
--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -200,7 +200,7 @@ def _toarray(ims, nframes, rows=None, buffer=None):
     """
     nr, nc = ims.shape
     use_buffer = buffer is not None
-    if rows is None: # use all
+    if rows is None:  # use all
         use_buffer, nbf = False, 0
         r0, r1 = 0, nr
         ashp = (nframes, nr, nc)
@@ -230,6 +230,6 @@ def _alloc_buffer(ims, nf):
     shp, dt = ims.shape, ims.dtype
     framesize = shp[0]*shp[1]*dt.itemsize
     nf = np.minimum(nf, np.floor(STATS_BUFFER/framesize).astype(int))
-    bshp = (nf,) +  shp
+    bshp = (nf,) + shp
 
     return np.empty(bshp, dt)

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -201,7 +201,7 @@ def _toarray(ims, nframes, rows=None, buffer=None):
     nr, nc = ims.shape
     use_buffer = buffer is not None
     if rows is None:  # use all
-        use_buffer, nbf = False, 0
+        use_buffer = False
         r0, r1 = 0, nr
         ashp = (nframes, nr, nc)
     else:

--- a/hexrd/imageseries/stats.py
+++ b/hexrd/imageseries/stats.py
@@ -213,7 +213,6 @@ def _toarray(ims, nframes, rows=None, buffer=None):
         nbf = len(buffer)
         if r0 == 0:
             # copy as many frames as possible into buffer
-            print("copying images to buffer")
             for i in range(nbf):
                 buffer[i] = ims[i]
 
@@ -228,7 +227,6 @@ def _toarray(ims, nframes, rows=None, buffer=None):
 
 def _alloc_buffer(ims, nf):
     """Allocate buffer to save as many full frames as possible"""
-    print("allocating buffer")
     shp, dt = ims.shape, ims.dtype
     framesize = shp[0]*shp[1]*dt.itemsize
     nf = np.minimum(nf, np.floor(STATS_BUFFER/framesize).astype(int))

--- a/hexrd/imageseries/tests/common.py
+++ b/hexrd/imageseries/tests/common.py
@@ -32,17 +32,11 @@ random_array = np.array(
       [ 6,  4, 16,  2, 16,  9, 18]]]
 )
 
-def make_array():
-    #a = np.zeros(_NFXY)
-    #ind = np.array([0,1,2])
-    #a[ind, 1,2] = 1 + ind
-    return random_array
-
-
 def make_array_ims():
-    is_a = imageseries.open(None, 'array', data=make_array(),
-                            meta=make_meta())
-    return is_a
+    is_a = imageseries.open(
+        None, 'array', data=random_array, meta=make_meta()
+    )
+    return random_array, is_a
 
 
 def compare(ims1, ims2):

--- a/hexrd/imageseries/tests/common.py
+++ b/hexrd/imageseries/tests/common.py
@@ -10,11 +10,33 @@ class ImageSeriesTest(unittest.TestCase):
     pass
 
 
+# random array from randint
+# a = np.random.randint(20, size=(3, 5, 7))
+random_array = np.array(
+    [[[ 2,  4,  5,  0, 14, 16, 17],
+      [18, 17,  5, 19,  2,  8, 17],
+      [ 0, 16, 10, 18, 13, 16,  9],
+      [ 2, 15, 13, 14, 12, 19,  9],
+      [ 0,  3,  4, 11,  8,  8,  3]],
+
+     [[ 8, 17, 15,  0,  0,  5, 17],
+      [ 7,  4,  8, 17,  2,  5,  3],
+      [14,  1, 12,  4,  6, 19,  2],
+      [13,  7,  5,  6, 17, 17,  6],
+      [16,  4, 10,  3,  6,  0, 14]],
+
+     [[17,  3,  8,  3, 15,  6, 18],
+      [13,  1,  3,  5,  9, 11, 15],
+      [ 1, 11, 15,  1, 19,  2,  0],
+      [ 5,  0, 12, 11, 12, 10, 11],
+      [ 6,  4, 16,  2, 16,  9, 18]]]
+)
+
 def make_array():
-    a = np.zeros(_NFXY)
-    ind = np.array([0,1,2])
-    a[ind, 1,2] = 1 + ind
-    return a
+    #a = np.zeros(_NFXY)
+    #ind = np.array([0,1,2])
+    #a[ind, 1,2] = 1 + ind
+    return random_array
 
 
 def make_array_ims():

--- a/hexrd/imageseries/tests/common.py
+++ b/hexrd/imageseries/tests/common.py
@@ -13,24 +13,25 @@ class ImageSeriesTest(unittest.TestCase):
 # random array from randint
 # a = np.random.randint(20, size=(3, 5, 7))
 random_array = np.array(
-    [[[ 2,  4,  5,  0, 14, 16, 17],
+    [[[2,  4,  5,  0, 14, 16, 17],
       [18, 17,  5, 19,  2,  8, 17],
-      [ 0, 16, 10, 18, 13, 16,  9],
-      [ 2, 15, 13, 14, 12, 19,  9],
-      [ 0,  3,  4, 11,  8,  8,  3]],
+      [0, 16, 10, 18, 13, 16,  9],
+      [2, 15, 13, 14, 12, 19,  9],
+      [0,  3,  4, 11,  8,  8,  3]],
 
-     [[ 8, 17, 15,  0,  0,  5, 17],
-      [ 7,  4,  8, 17,  2,  5,  3],
+     [[8, 17, 15,  0,  0,  5, 17],
+      [7,  4,  8, 17,  2,  5,  3],
       [14,  1, 12,  4,  6, 19,  2],
       [13,  7,  5,  6, 17, 17,  6],
       [16,  4, 10,  3,  6,  0, 14]],
 
      [[17,  3,  8,  3, 15,  6, 18],
       [13,  1,  3,  5,  9, 11, 15],
-      [ 1, 11, 15,  1, 19,  2,  0],
-      [ 5,  0, 12, 11, 12, 10, 11],
-      [ 6,  4, 16,  2, 16,  9, 18]]]
+      [1, 11, 15,  1, 19,  2,  0],
+      [5,  0, 12, 11, 12, 10, 11],
+      [6,  4, 16,  2, 16,  9, 18]]]
 )
+
 
 def make_array_ims():
     is_a = imageseries.open(
@@ -45,8 +46,10 @@ def compare(ims1, ims2):
         raise ValueError("lengths do not match")
 
     if ims1.dtype != ims2.dtype:
-        raise ValueError("types do not match: %s is not %s" % (repr(ims1.dtype),
-                                                               repr(ims2.dtype)))
+        raise ValueError(
+            "types do not match: %s is not %s" %
+            (repr(ims1.dtype), repr(ims2.dtype))
+        )
 
     maxdiff = 0.0
     for i in range(len(ims1)):

--- a/hexrd/imageseries/tests/test_stats.py
+++ b/hexrd/imageseries/tests/test_stats.py
@@ -2,25 +2,25 @@ import numpy as np
 
 from hexrd import imageseries
 from hexrd.imageseries import stats
-
 from .common import ImageSeriesTest, make_array, make_array_ims
+from .common import random_array
 
 
 class TestImageSeriesStats(ImageSeriesTest):
 
 
     def test_stats_average(self):
-        """Processed imageseries: median"""
-        a = make_array()
+        """imageseries.stats: average"""
+        a = random_array
         is_a = imageseries.open(None, 'array', data=a)
         is_avg = stats.average(is_a)
-        np_avg = np.average(a, axis=0)
+        np_avg = np.average(a, axis=0).astype(np.float32)
         err = np.linalg.norm(np_avg - is_avg)
-        self.assertAlmostEqual(err, 0., msg="stats.median failed")
+        self.assertAlmostEqual(err, 0., msg="stats.average failed")
         self.assertEqual(is_avg.dtype, np.float32)
 
     def test_stats_median(self):
-        """Processed imageseries: median"""
+        """imageseries.stats: median"""
         a = make_array()
         is_a = imageseries.open(None, 'array', data=a)
         ismed = stats.median(is_a)
@@ -30,7 +30,7 @@ class TestImageSeriesStats(ImageSeriesTest):
         self.assertEqual(ismed.dtype, np.float32)
 
     def test_stats_max(self):
-        """Processed imageseries: median"""
+        """imageseries.stats: max"""
         a = make_array()
         is_a = imageseries.open(None, 'array', data=a)
         ismax = stats.max(is_a)
@@ -41,7 +41,7 @@ class TestImageSeriesStats(ImageSeriesTest):
 
 
     def test_stats_min(self):
-        """Processed imageseries: median"""
+        """imageseries.stats: min"""
         a = make_array()
         is_a = imageseries.open(None, 'array', data=a)
         ismin = stats.min(is_a)
@@ -52,31 +52,32 @@ class TestImageSeriesStats(ImageSeriesTest):
 
 
     def test_stats_percentile(self):
-        """Processed imageseries: median"""
+        """imageseries.stats: percentile"""
         a = make_array()
         is_a = imageseries.open(None, 'array', data=a)
         isp90 = stats.percentile(is_a, 90)
-        ap90 = np.percentile(a, 90, axis=0)
+        ap90 = np.percentile(a, 90, axis=0).astype(np.float32)
         err = np.linalg.norm(ap90 - isp90)
-        self.assertAlmostEqual(err, 0., msg="stats.min failed")
+        self.assertAlmostEqual(err, 0., msg="stats.percentile failed")
         self.assertEqual(isp90.dtype, np.float32)
 
 
     def test_stats_chunk(self):
-        """Processed imageseries: median"""
-        a = make_array()
+        """imageseries.stats: chunked average"""
+        a = random_array
         is_a = imageseries.open(None, 'array', data=a)
-        amed = np.median(a, axis=0)
+        amed = np.average(a, axis=0)
+        amed = stats.average(a)
 
         # Run with 1 chunk
         img = np.zeros(is_a.shape)
         for ismed1 in stats.average_iter(is_a, 1):
             pass
         err = np.linalg.norm(amed - ismed1)
-        self.assertAlmostEqual(err, 0., msg="stats.median failed")
+        self.assertAlmostEqual(err, 0., msg="stats.average failed")
 
         # Run with 2 chunks
         for ismed2 in stats.average_iter(is_a, 2):
             pass
         err = np.linalg.norm(amed - ismed2)
-        self.assertAlmostEqual(err, 0., msg="stats.median failed")
+        self.assertAlmostEqual(err, 0., msg="stats.average failed")

--- a/hexrd/imageseries/tests/test_stats.py
+++ b/hexrd/imageseries/tests/test_stats.py
@@ -2,17 +2,19 @@ import numpy as np
 
 from hexrd import imageseries
 from hexrd.imageseries import stats
-from .common import ImageSeriesTest, make_array, make_array_ims
-from .common import random_array
+from .common import ImageSeriesTest, make_array_ims
 
 
 class TestImageSeriesStats(ImageSeriesTest):
 
+    # These tests compare imageseries operations to numpy operations
 
     def test_stats_average(self):
-        """imageseries.stats: average"""
-        a = random_array
-        is_a = imageseries.open(None, 'array', data=a)
+        """imageseries.stats: average
+
+        Compares with numpy average
+        """
+        a, is_a = make_array_ims()
         is_avg = stats.average(is_a)
         np_avg = np.average(a, axis=0).astype(np.float32)
         err = np.linalg.norm(np_avg - is_avg)
@@ -21,8 +23,7 @@ class TestImageSeriesStats(ImageSeriesTest):
 
     def test_stats_median(self):
         """imageseries.stats: median"""
-        a = make_array()
-        is_a = imageseries.open(None, 'array', data=a)
+        a, is_a = make_array_ims()
         ismed = stats.median(is_a)
         amed = np.median(a, axis=0)
         err = np.linalg.norm(amed - ismed)
@@ -31,8 +32,7 @@ class TestImageSeriesStats(ImageSeriesTest):
 
     def test_stats_max(self):
         """imageseries.stats: max"""
-        a = make_array()
-        is_a = imageseries.open(None, 'array', data=a)
+        a, is_a = make_array_ims()
         ismax = stats.max(is_a)
         amax = np.max(a, axis=0)
         err = np.linalg.norm(amax - ismax)
@@ -42,8 +42,7 @@ class TestImageSeriesStats(ImageSeriesTest):
 
     def test_stats_min(self):
         """imageseries.stats: min"""
-        a = make_array()
-        is_a = imageseries.open(None, 'array', data=a)
+        a, is_a = make_array_ims()
         ismin = stats.min(is_a)
         amin = np.min(a, axis=0)
         err = np.linalg.norm(amin - ismin)
@@ -53,31 +52,63 @@ class TestImageSeriesStats(ImageSeriesTest):
 
     def test_stats_percentile(self):
         """imageseries.stats: percentile"""
-        a = make_array()
-        is_a = imageseries.open(None, 'array', data=a)
+        a, is_a = make_array_ims()
         isp90 = stats.percentile(is_a, 90)
         ap90 = np.percentile(a, 90, axis=0).astype(np.float32)
         err = np.linalg.norm(ap90 - isp90)
         self.assertAlmostEqual(err, 0., msg="stats.percentile failed")
         self.assertEqual(isp90.dtype, np.float32)
 
+    # These tests compare chunked operations (iterators) to non-chunked ops
 
-    def test_stats_chunk(self):
+    def test_stats_average_chunked(self):
         """imageseries.stats: chunked average"""
-        a = random_array
-        is_a = imageseries.open(None, 'array', data=a)
-        amed = np.average(a, axis=0)
-        amed = stats.average(a)
+        a, is_a = make_array_ims()
+        a_avg = stats.average(a)
 
         # Run with 1 chunk
         img = np.zeros(is_a.shape)
         for ismed1 in stats.average_iter(is_a, 1):
             pass
-        err = np.linalg.norm(amed - ismed1)
-        self.assertAlmostEqual(err, 0., msg="stats.average failed")
+        err = np.linalg.norm(a_avg - ismed1)
+        self.assertAlmostEqual(err, 0., msg="stats.average failed (1 chunk)")
 
         # Run with 2 chunks
         for ismed2 in stats.average_iter(is_a, 2):
             pass
-        err = np.linalg.norm(amed - ismed2)
+        err = np.linalg.norm(a_avg - ismed2)
         self.assertAlmostEqual(err, 0., msg="stats.average failed")
+
+    def test_stats_median_chunked(self):
+        """imageseries.stats: chunked median"""
+        a, is_a = make_array_ims()
+        a_med = stats.median(is_a)
+
+        # Run with 1 chunk
+        img = np.zeros(is_a.shape)
+        for ismed1 in stats.median_iter(is_a, 1):
+            pass
+        err = np.linalg.norm(a_med - ismed1)
+        self.assertAlmostEqual(err, 0., msg="stats.average failed (1 chunk)")
+
+        # Run with 2 chunks
+        for ismed2 in stats.median_iter(is_a, 2):
+            pass
+        err = np.linalg.norm(a_med - ismed2)
+        self.assertAlmostEqual(err, 0., msg="stats.average failed (2 chunks)")
+
+        # Run with 3 chunks, with buffer
+        for ismed3 in stats.median_iter(is_a, 3, use_buffer=True):
+            pass
+        err = np.linalg.norm(a_med - ismed3)
+        self.assertAlmostEqual(
+            err, 0., msg="stats.average failed (3 chunks, buffer)"
+        )
+
+        # Run with 3 chunks, no buffer
+        for ismed3 in stats.median_iter(is_a, 3, use_buffer=False):
+            pass
+        err = np.linalg.norm(a_med - ismed3)
+        self.assertAlmostEqual(
+            err, 0., msg="stats.average failed (3 chunks, no buffer)"
+        )


### PR DESCRIPTION
This addresses Issue #306. For percentile_iter and median_iter, a buffer is created to store as many frames as possible so as to avoid repeated imageseries frame copies in stats._toarray(). The size of the buffer is half of available memory when the stats module is loaded. 

Additionally,
* This fixes a bug in the percentile iterator that duplicates a row between chunks. It did not affect the result, but performed unnecessary computations.
* Unit tests were improved: old ones strengthened and new ones added.