### PR TITLE
Fix logger error for filtering eta omega maps

### DIFF
--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -464,7 +464,7 @@ def filter_maps_if_requested(eta_ome, cfg):
                 filter_stdev=sigm
             )
         else:
-            logger.info("filtering eta/ome maps", filter_maps)
+            logger.info("filtering eta/ome maps")
             _filter_eta_ome_maps(eta_ome)
 
 


### PR DESCRIPTION
The "filter_maps" argument was not being converted during string
formatting, and this was raising an exception.

It doesn't really need to be there anyways, since the logging
statement implies that "filter_maps" is `True`.