### PR TITLE
Fix pickling for ProcessedImageSeries

### DIFF
--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -13,8 +13,6 @@ class ProcessedImageSeries(ImageSeries):
     RECT = 'rectangle'
     ADD = 'add'
 
-    _opdict = {}
-
     def __init__(self, imser, oplist, **kwargs):
         """imsageseries based on existing one with image processing options
 
@@ -32,6 +30,7 @@ class ProcessedImageSeries(ImageSeries):
         self._oplist = oplist
         self._frames = kwargs.pop('frame_list', None)
         self._hasframelist = (self._frames is not None)
+        self._opdict = {}
 
         self.addop(self.DARK, self._subtract_dark)
         self.addop(self.FLIP, self._flip)
@@ -121,14 +120,13 @@ class ProcessedImageSeries(ImageSeries):
         # this is a modifiable copy of metadata of the original imageseries
         return self._meta
 
-    @classmethod
-    def addop(cls, key, func):
+    def addop(self, key, func):
         """Add operation to processing options
 
         *key* - string to use to specify this op
         *func* - function to call for this op: f(data)
         """
-        cls._opdict[key] = func
+        self._opdict[key] = func
 
     @property
     def oplist(self):


### PR DESCRIPTION
From the [pickle documentation:](https://docs.python.org/3.8/library/pickle.html#what-can-be-pickled-and-unpickled)
```
Similarly, when class instances are pickled, their class’s code and data
are not pickled along with them. Only the instance data are pickled.
```

Class data does not get pickled, and the class's `__init__()` method
also does not get called when the object is unpickled. This causes
the `_opdict` class variable in `ProcessedImageSeries` to be empty
when it gets pickled and unpickled [here](https://github.com/HEXRD/hexrd/blob/408bea18f11f3ad968bbefa64518f530bf0882dd/hexrd/fitgrains.py#L83) for when
multiprocessing uses spawning rather than forking (and python 3.8
defaults to use forking only on Linux).

Thus, to make sure the `_opdict` gets pickled as well, we can make it
a member attribute rather than a class attribute.

Another alternative would be to add functions that get called any
time the `_opdict` is to be accessed that make sure it is populated
with the default opts, but I believe making `_opdict` a member
attribute is cleaner.

The issue of the `_opdict` being empty would specifically be
encountered during fit grains if the OS is not Linux, and there
are at least 2 grains (which results in multiprocessing being
used).
