### PR TITLE
Fix charge species import in cif

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -558,12 +558,24 @@ class Material(object):
 
         satype = cifdata[atype]
         atomtype = []
-
+        charge = []
         for s in satype:
+            if "+" in s:
+                ss = s.split("+")
+                c  = f"{ss[1]}+"
+                s  = ss[0]
+            if "-" in s:
+                ss = s.split("-")
+                c  = f"{ss[1]}-"
+                s  = ss[0]
+            else:
+                c = "0"
+
             atomtype.append(ptable[s])
+            charge.append(c)
 
         self._atomtype = numpy.asarray(atomtype).astype(numpy.int32)
-        self._charge = ['0']*self._atomtype.shape[0]
+        self._charge = charge
         self._sgsetting = 0
 
     def _readHDFxtal(self, fhdf=DFLT_NAME, xtal=DFLT_NAME):

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -736,7 +736,11 @@ class unitcell:
         if charge == '0':
             sfact = constants.scatfac[elem]
         else:
-            sfact = constants.scatfac[f"{elem}{charge}"]
+            cs = f"{elem}{charge}"
+            if cs in constants.scatfac:
+                sfact = constants.scatfac[f"{elem}{charge}"]
+            else:
+                sfact = constants.scatfac[elem]
         fe = sfact[5]
         fNT = constants.fNT[elem]
         frel = constants.frel[elem]


### PR DESCRIPTION
cif import was not using the charge information for each atomic species. This was raising some errors in the import. This has been fixed.

Additionally, it is checked if the scattering factors for charged species is present in the `herd.constants.scatfac` dictionary. If its not present, then the neutral atom scattering factors is used by default. This was introduced because the test case has `Te2-` which is not present in the international tables.
