### PR TITLE
Ensure setuptools_scm is present for conda dev version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ entry_points = {
 setup(
     name='hexrd',
     use_scm_version=True,
+    setup_requires=['setuptools-scm'],
     description = 'hexrd X-ray diffraction data analysis tool',
     long_description = open('README.md').read(),
     author='The hexrd Development Team',


### PR DESCRIPTION
Previously, if a conda development environment was set up, when
the `... pip install -e hexrd ...` was performed, the hexrd
version would come out as `0.0.0`.

Ensure setuptools_scm is present so that a correct version is
displayed in development environments.