### PR TITLE
Fix cases when the occupancy or the isotropic Debye waller factors are undefined

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -519,8 +519,8 @@ class Material(object):
                 else:
                     occ.append(p)
 
-            chkstr = np.asarray([isinstance(x,str) for x in occ])
-            occstr = n.array(occ)
+            chkstr = numpy.asarray([isinstance(x,str) for x in occ])
+            occstr = numpy.array(occ)
             occstr[chkstr] = 1.0
 
             atompos.append(numpy.asarray(occstr).astype(numpy.float64))
@@ -546,7 +546,13 @@ class Material(object):
                 else:
                     U.append(p)
 
-            self._U = numpy.asarray(U).astype(numpy.float64)
+            chkstr = numpy.asarray([isinstance(x,str) for x in U])
+            
+            for ii,x in enumerate(chkstr):
+                if x:
+                    U[ii] = 1.0/numpy.pi/2./numpy.sqrt(2.)
+    
+            self._U = numpy.asarray(U)
         '''
         format everything in the right shape etc.
         '''

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -519,7 +519,11 @@ class Material(object):
                 else:
                     occ.append(p)
 
-            atompos.append(numpy.asarray(occ).astype(numpy.float64))
+            chkstr = np.asarray([isinstance(x,str) for x in occ])
+            occstr = n.array(occ)
+            occstr[chkstr] = 1.0
+
+            atompos.append(numpy.asarray(occstr).astype(numpy.float64))
 
         if(not pU):
             warn('Debye-Waller factors not present. \


### PR DESCRIPTION
Check for cases where occupancy or the Debye Waller factors are present but undefined, most notably by a "?".
The update looks for strings and populates them with default values of 1.0 and 1/2sqrt(2)pi.