### PR TITLE
change default values and lower bounds for HL and SL values.

### DIFF
--- a/hexrd/wppf/wppfsupport.py
+++ b/hexrd/wppf/wppfsupport.py
@@ -74,8 +74,8 @@ def _generate_default_parameters_pseudovoight(params):
                    vary=v[3])
 
 def _add_pvfcj_parameters(params):
-    p = {"HL":[1.60e-2,0.,1e-1,False],
-         "SL":[2.28e-2,0.,1e-1,False]
+    p = {"HL":[1e-3,1e-7,1e-1,False],
+         "SL":[1e-3,1e-7,1e-1,False]
          }
     for k, v in p.items():
         params.add(name=k,


### PR DESCRIPTION
This is so that no bad profiles are generated when angular range of data is very small. Usually <5 degrees. This will fix issue https://github.com/HEXRD/hexrdgui/issues/1026