### PR TITLE
slight modification to the rwp function.

### DIFF
--- a/hexrd/wppf/peakfunctions.py
+++ b/hexrd/wppf/peakfunctions.py
@@ -855,7 +855,7 @@ def calc_rwp(spectrum_sim,
     (spectrum_sim[:,1] - \
     spectrum_expt[:,1])**2
 
-    weighted_expt = weights[:,1] * spectrum_sim[:,1] **2
+    weighted_expt = weights[:,1] * spectrum_expt[:,1] **2
 
     errvec = np.sqrt(err)
 


### PR DESCRIPTION
Minor adjustment in the `peakfunction.calcrwp` function. The weighted sum of squares had a small inaccuracy. 