### PR TITLE
revert to xrdutil func for now

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -2472,10 +2472,16 @@ class PlanarDetector(object):
             tVec_s = ct.zeros_3x1
         if tVec_c is None:
             tVec_c = ct.zeros_3x1
-        origin = np.dot(rMat_s, tVec_c).flatten() + tVec_s.flatten()
 
         # FIXME: perhaps not necessary, but safe...
         xy = np.atleast_2d(xy)
+
+        '''
+        # ---------------------------------------------------------------------
+        # TODO: needs testing and memoized gradient arrays!
+        # ---------------------------------------------------------------------
+        # need origin arg
+        origin = np.dot(rMat_s, tVec_c).flatten() + tVec_s.flatten()
 
         # get pixel indices
         i_crds = cellIndices(self.row_edge_vec, xy[:, 1])
@@ -2484,8 +2490,9 @@ class PlanarDetector(object):
         ptth_grad = self.pixel_tth_gradient(origin=origin)[i_crds, j_crds]
         peta_grad = self.pixel_eta_gradient(origin=origin)[i_crds, j_crds]
 
+        return np.vstack([ptth_grad, peta_grad]).T
         '''
-        # call function
+        # call xrdutil function
         ang_ps = xrdutil.angularPixelSize(
             xy, (self.pixel_size_row, self.pixel_size_col),
             self.rmat, rMat_s,
@@ -2493,8 +2500,6 @@ class PlanarDetector(object):
             distortion=self.distortion,
             beamVec=self.bvec, etaVec=self.evec)
         return ang_ps
-        '''
-        return np.vstack([ptth_grad, peta_grad]).T
 
     def clip_to_panel(self, xy, buffer_edges=True):
         """


### PR DESCRIPTION
The gradient array-based approach, while smoother, was unexpectedly slow upon further testing; memorizing may help, but in the meantime reverting to the pixel-vertex function approach to not unexpectedly slow down computation. 