### PR TITLE
Use xxhash to hash numpy arrays for memoizing

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - psutil
     - pycifrw
     - python=3.8
+    - python-xxhash
     - pyyaml
     - scikit-image
     - scikit-learn

--- a/hexrd/utils/decorators.py
+++ b/hexrd/utils/decorators.py
@@ -8,9 +8,9 @@ go into another topical module in :mod:`hexrd.utils`.
 
 from collections import OrderedDict
 from functools import wraps
-import hashlib
 
 import numpy as np
+import xxhash
 
 from hexrd.constants import USE_NUMBA
 
@@ -97,7 +97,7 @@ def _make_hashable(items):
             # Create an sha1 of the data, and throw in a string
             # and the shape.
             return ('__type_np.ndarray', x.shape,
-                    hashlib.sha1(x).hexdigest())
+                    xxhash.xxh3_128_hexdigest(x))
         elif isinstance(x, (list, tuple)):
             return _make_hashable(x)
         elif isinstance(x, dict):

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_reqs = [
     'pyyaml',
     'scikit-learn',
     'scipy',
+    'xxhash',
 ]
 
 # This a hack to get around the fact that scikit-image on conda-forge doesn't install


### PR DESCRIPTION
[xxhash](https://github.com/Cyan4973/xxHash) is non-cryptographic, so some collisions are expected, especially intentional collisions. However, the collisions are hopefully rare enough for numpy arrays that it won't affect our results. The benefit is that xxhash is nearly 15x faster in some of our examples compared to `sha1`, so it provides a significant speed-up to memoization-checking.

It has a 2-clause BSD license, and no python dependencies. There are python bindings [on pypi](https://pypi.org/project/xxhash/) and [on conda-forge](https://anaconda.org/conda-forge/python-xxhash/) that are implemented [here](https://github.com/ifduyue/python-xxhash).