### PR TITLE
Don't check scikit-learn version

### DIFF
--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -24,12 +24,9 @@ from hexrd.xrdutil import EtaOmeMaps
 # just require scikit-learn?
 have_sklearn = False
 try:
-    import sklearn
-    vstring = sklearn.__version__.split('.')
-    if vstring[0] == '0' and int(vstring[1]) >= 14:
-        from sklearn.cluster import dbscan
-        from sklearn.metrics.pairwise import pairwise_distances
-        have_sklearn = True
+    from sklearn.cluster import dbscan
+    from sklearn.metrics.pairwise import pairwise_distances
+    have_sklearn = True
 except ImportError:
     pass
 


### PR DESCRIPTION
If we are using too old of a version of scikit-learn, we will get an
`ImportError` anyways, so don't worry about the version, just check
for the `ImportError`.

This fixes an issue where the logic thought scikit learn version "1.0"
was not new enough...