### PR TITLE
DCS singlepeakfit

### DIFF
--- a/hexrd/fitting/fitpeak.py
+++ b/hexrd/fitting/fitpeak.py
@@ -207,6 +207,7 @@ def fit_pk_parms_1d(p0, x, f, pktype='pvoigt'):
             fit_pk_obj_1d, p0,
             jac='2-point',
             bounds=(lb, ub),
+            method='trf',
             args=fitArgs,
             ftol=ftol, 
             xtol=xtol)

--- a/hexrd/fitting/peakfunctions.py
+++ b/hexrd/fitting/peakfunctions.py
@@ -417,7 +417,7 @@ def _gaussian_pink_beam(p, x):
     Von Dreele et. al., J. Appl. Cryst. (2021). 54, 3–6
 
     p has the following parameters
-    p = [A,x0,alpha0,alpha1,beta0,beta1,fwhm_g]
+    p = [A,x0,alpha0,alpha1,beta0,beta1,fwhm_g,bkg_c0,bkg_c1,bkg_c2]
     """
     
     A,x0,a0,a1,b0,b1,fwhm_g = p


### PR DESCRIPTION
Single peak fit for DCS data. The API is the same as other peaks. 
Can be called as `hexrd.fitting.fitpeak.fit_pk_parms_1d(p0, x, f, pktype='dcs_pinkbeam')`
`p0` has the following parameters: 
```
A : scale factor
x0 : Bragg angle
alpha0 : pink beam shape parameter
alpha1 : pink beam shape parameter
beta0 : pink beam shape parameter
beta1 : pink beam shape parameter
fwhm_g : full-width at half max of gaussian component
fwhm_l : full-width at half max of lorentzian component
bkg_c0 : c0 for chebyshev polynomial background
bkg_c1 : c1 for chebyshev polynomial background
bkg_c2 : c2 for chebyshev polynomial background
```
Tested with simulated data shown below. Fixes issue https://github.com/HEXRD/hexrdgui/issues/1069

![Screen Shot 2021-10-18 at 2 55 59 PM](https://user-images.githubusercontent.com/15834451/137812774-ee7b1615-64a4-45d6-b81d-0f0c53774815.png)


