### PR TITLE
Use np.nanmax() for getting max powderI

### DIFF
--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -796,7 +796,7 @@ class PlaneData(object):
         lp = (1 + np.cos(tth)**2)/np.cos(0.5*tth)/np.sin(0.5*tth)**2/2.0
 
         powderI = structFact*multiplicity*lp
-        powderI = 100.0*powderI/powderI.max()
+        powderI = 100.0*powderI/np.nanmax(powderI)
 
         self._powder_intensity = powderI
 


### PR DESCRIPTION
Previously, `powderI.max()` was being used, which would return `nan` if
any of the `powderI` values were `nan`. This would result in the rescaled
`powderI` values all being `nan`.

Use `np.nanmax()` instead, which ignores `nan` values when computing the
max. This results in a real value max.

Fixes: hexrd/hexrdgui#1068