### PR TITLE
Remove _memo_hkls dict and its memoization

### DIFF
--- a/hexrd/xrdutil/__init__.py
+++ b/hexrd/xrdutil/__init__.py
@@ -4,4 +4,3 @@ from .utils import *
 from .utils import _project_on_detector_plane
 from .utils import _fetch_hkls_from_planedata
 from .utils import _filter_hkls_eta_ome
-from .utils import _memo_hkls

--- a/hexrd/xrdutil/utils.py
+++ b/hexrd/xrdutil/utils.py
@@ -66,8 +66,6 @@ eHat_l_DFLT = constants.eta_vec.flatten()
 
 nans_1x2 = np.nan*np.ones((1, 2))
 
-_memo_hkls = {}
-
 
 # =============================================================================
 # CLASSES
@@ -1046,11 +1044,7 @@ def simulateOmeEtaMaps(omeEdges, etaEdges, planeData, expMaps,
 
 
 def _fetch_hkls_from_planedata(pd):
-    if pd not in _memo_hkls:
-        _memo_hkls[pd] = np.ascontiguousarray(
-            np.hstack(pd.getSymHKLs(withID=True)).T,
-            dtype=float)
-    return _memo_hkls[pd]
+    return np.hstack(pd.getSymHKLs(withID=True)).T
 
 
 def _filter_hkls_eta_ome(hkls, angles, eta_range, ome_range):


### PR DESCRIPTION
This has caused many hard-to-track bugs in hexrdgui, because it only
memoizes based upon the `PlaneData` object, and does not check to see
if the exclusions or any other properties of the `PlaneData` object has
changed before returning its memoized result. This results in incorrect
hkls being returned when some of the `PlaneData` properties have been
changed.

It does not appear to make much of a difference in timings. For the
`NIST_ruby` example, I get these timings:

```
Without memo hkls:
find-orientations: 17.4 s
fit-grains: 112.5 s

With memo hkls:
find-orientations: 18.3 s
fit-grains: 110.5 s
```

So we can just remove it rather than improving the memoization.

It also does not need to return a contiguous array of floats, so we can
remove those parts.

This fixes an issue mentioned in hexrd/hexrdgui#450