### PR TITLE
when none of the charge state is present in the element description.

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -578,6 +578,7 @@ class Material(object):
                 if c[0] == '-':
                     c = c[::-1]
             else:
+                ss = s
                 c = "0"
 
             atomtype.append(ptable[ss])


### PR DESCRIPTION
Catching a case when the element is **_not_** specified as `El+ / +El` or `El- / -El` 