### PR TITLE
Pin numpy to version 1.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "setuptools_scm[toml]"]
+requires = ["setuptools", "wheel", "numpy==1.20", "setuptools_scm[toml]"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_reqs = [
     'h5py',
     'lmfit',
     'numba',
-    'numpy',
+    'numpy==1.20',
     'psutil',
     'pycifrw',
     'pyyaml',


### PR DESCRIPTION
The latest version of numba (0.54.1) requires numpy to be < 1.21. The
latest version of numpy is 1.22, however.

Thus, for both the build environment and the run environment, we need
to downgrade numpy to 1.20, so that it is compatible with numba. Fixing
the version is needed for pip dev environments, because pip is not smart
enough to downgrade numpy for us. Conda, however, does downgrade the numpy
version automatically, which is why we aren't running into the issue with
conda environments.

This should fix the errors occurring on hexrdgui master.

Note: it looks like numba 0.55 is supposed to come out soon, which will
require numpy < 1.22.