### PR TITLE
Change numpy==1.20 to numpy<1.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy==1.20", "setuptools_scm[toml]"]
+requires = ["setuptools", "wheel", "numpy<1.21", "setuptools_scm[toml]"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_reqs = [
     'h5py',
     'lmfit',
     'numba',
-    'numpy==1.20',
+    'numpy<1.21',
     'psutil',
     'pycifrw',
     'pyyaml',


### PR DESCRIPTION
We need numpy<1.21 for the latest numba to work.

Loosening up the restriction from numpy==1.20 to numpy<1.21 fixes an
issue with conda dev environments where numpy being 1.20.3 would not
match perfectly, and produce an error.