### PR TITLE
Use skimage for center of mass instead of scipy

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -45,6 +45,7 @@ from io import IOBase
 
 from scipy import ndimage
 from scipy.linalg.matfuncs import logm
+from skimage.measure import regionprops
 
 from hexrd import constants
 from hexrd.gridutil import cellConnectivity, cellIndices, make_tolerance_grid
@@ -1724,13 +1725,9 @@ class HEDMInstrument(object):
 
                             if num_peaks > 0:
                                 peak_id = iRefl
-                                coms = np.array(
-                                    ndimage.center_of_mass(
-                                        patch_data,
-                                        labels=labels,
-                                        index=slabels
-                                    )
-                                )
+                                props = regionprops(labels, patch_data)
+                                coms = np.vstack(
+                                    [x.weighted_centroid for x in props])
                                 if num_peaks > 1:
                                     center = np.r_[patch_data.shape]*0.5
                                     center_t = np.tile(center, (num_peaks, 1))


### PR DESCRIPTION
It appear's that skimage's `regionprops` followed by `weighted_centroid`
is much faster than scipy's `center_of_mass` for `pull_spots()`.

In one example I had, using `skimage` brought the total time for
`pull_spots()` down from 55.2 seconds to 31.6 seconds (where
skimage took 1.4 seconds compared to scipy's 23.8 seconds).

We should make sure that our results are identical before merging, and
that skimage can handle all cases the same way that scipy did.