### PR TITLE
Fix conda numpy version to 1.20

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   build:
-    - numpy>=1.20
+    - numpy==1.20
     - python {{ python }}
     - setuptools
     - setuptools_scm
@@ -25,7 +25,7 @@ requirements:
     - h5py
     - lmfit
     - numba
-    - numpy>=1.20
+    - numpy==1.20
     - psutil
     - pycifrw
     - python


### PR DESCRIPTION
The build step of hexrd was using numpy 1.22, because it is the latest.
However, at runtime, numpy 1.20 would be installed because it is the
latest version that numba supports.

The mismatch in version caused an error containing the following:
```python
RuntimeError: module compiled against API version 0xf but this version of numpy is 0xe
```

Fix the versions of numpy to 1.20 so they will both match. We can bump
the numpy version when numba supports newer versions.