### PR TITLE
Try fuzzy constraint for numpy version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   build:
-    - numpy==1.20
+    - numpy=1.20
     - python {{ python }}
     - setuptools
     - setuptools_scm
@@ -25,7 +25,7 @@ requirements:
     - h5py
     - lmfit
     - numba
-    - numpy==1.20
+    - numpy=1.20
     - psutil
     - pycifrw
     - python


### PR DESCRIPTION
I believe that the strict constraint is causing some issues with installing
the latest hexrd pre-release.