### PR TITLE
routines to get absorption length of a material

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -924,6 +924,10 @@ class Material(object):
         # self.update_structure_factor()
 
     @property
+    def absorption_length(self):
+        return self.unitcell.absorption_length
+
+    @property
     def natoms(self):
         return self.atominfo.shape[0]
 


### PR DESCRIPTION
The absorption length is calculated based on the theoretical density, X-ray energy and atom info of the unit cell.  The property is `Material.absorption_length` and the value returned is in microns.

Tested for a few test cases and matched with the data available from https://henke.lbl.gov/optical_constants/atten2.html