### PR TITLE
addresses case where cluster has 2 orientations

### DIFF
--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -343,7 +343,7 @@ def run_cluster(compl, qfib, qsym, cfg,
         for i in range(nblobs):
             npts = sum(cl == i + 1)
             qbar[:, i] = rot.quatAverageCluster(
-                qfib_r[:, cl == i + 1].reshape(4, npts), qsym
+                qfib_r[:, cl == i + 1], qsym
             ).flatten()
             pass
         pass

--- a/hexrd/fitting/calibration.py
+++ b/hexrd/fitting/calibration.py
@@ -401,6 +401,17 @@ class PowderCalibrator(object):
                     apply_distortion=True
                 )
 
+                # !!! apply tth distortion
+                if panel.tth_distortion is not None:
+                    eval_pts = panel.cartToPixel(
+                        meas_xy,
+                        pixels=True,
+                        apply_distortion=True
+                    )
+                    updated_angles[:, 0] = \
+                        updated_angles[:, 0] \
+                        + panel.tth_distortion[eval_pts[:, 0], eval_pts[:, 1]]
+
                 # derive ideal tth positions from additional ring point info
                 hkls = pdata[:, 3:6]
                 gvecs = np.dot(hkls, bmat.T)

--- a/hexrd/rotations.py
+++ b/hexrd/rotations.py
@@ -429,9 +429,10 @@ def quatAverageCluster(q_in, qsym):
         else:
             ma, mq = misorientation(q_in[:, 0].reshape(4, 1),
                                     q_in[:, 1].reshape(4, 1), (qsym,))
+
             q_bar = quatProduct(
                 q_in[:, 0].reshape(4, 1),
-                quatOfExpMap(0.5*ma*unitVector(mq[1:].reshape(3, 1)))
+                quatOfExpMap(0.5*ma*unitVector(mq[1:])).reshape(4, 1)
             )
     else:
         # first drag to origin using first quat (arb!)


### PR DESCRIPTION
In the event a cluster has exactly 2 points, there was an error in computing the average quaternion.  This has been fixed.