### PR TITLE
Remove duplicate atom fix

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -399,6 +399,15 @@ class Material(object):
             p = [t, fwhm]
             self.powder_overlay += scale*I*_unit_gaussian(p, ttharray)
 
+    def remove_duplicate_atoms(self):
+        """
+        this function calls the same function in the
+        unitcell class and updates planedata structure
+        factors etc.
+        """
+        self.unitcell.remove_duplicate_atoms()
+        self._hkls_changed()
+
     def _readCif(self, fcif=DFLT_NAME+'.cif'):
         """
         >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab, saransh1@llnl.gov

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -646,7 +646,7 @@ class unitcell:
         initialize interpolation from table for anomalous scattering
         '''
         self.InitializeInterpTable()
-
+        self.CalcAnomalous()
         self.CalcPositions()
         self.CalcDensity()
         self.calc_absorption_length()
@@ -716,7 +716,6 @@ class unitcell:
 
         self.f1 = {}
         self.f2 = {}
-        self.f_anam = {}
         self.pe_cs = {}
 
         data = importlib.resources.open_binary(hexrd.resources, 'Anomalous.h5')
@@ -727,13 +726,13 @@ class unitcell:
                 elem = constants.ptableinverse[Z]
                 gid = fid.get('/'+elem)
                 data = gid.get('data')
-
                 self.f1[elem] = interp1d(data[:, 7], data[:, 1])
                 self.f2[elem] = interp1d(data[:, 7], data[:, 2])
                 self.pe_cs[elem] = interp1d(data[:,7], data[:,3]+data[:,4])
 
     def CalcAnomalous(self):
 
+        self.f_anam = {}
         for i in range(self.atom_ntype):
 
             Z = self.atom_type[i]

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -593,36 +593,39 @@ class unitcell:
         for i in range(atom_pos.shape[0]):
             pos = atom_pos[i, 0:3]
             occ = atom_pos[i, 3]
-
-            v1, n1 = self.CalcOrbit(pos)
-
-            for j in range(i+1, atom_pos.shape[0]):
-                isclose = False
+            if i == 0:
                 atom_pos_fixed.append(np.hstack([pos, occ]))
-                pos = atom_pos[j, 0:3]
-                occ = atom_pos[j, 3]
-                v2, n2 = self.CalcOrbit(pos)
 
-                for v in v2:
-                    vv = np.tile(v, [v1.shape[0], 1])
-                    vv = vv - v1
+            else:
+                v1, n1 = self.CalcOrbit(pos)
 
-                    for vvv in vv:
+                for j in range(i+1, atom_pos.shape[0]):
+                    isclose = False
+                    atom_pos_fixed.append(np.hstack([pos, occ]))
+                    pos = atom_pos[j, 0:3]
+                    occ = atom_pos[j, 3]
+                    v2, n2 = self.CalcOrbit(pos)
 
-                        # check if distance less than tol
-                        # the factor of 10 is for A --> nm
-                        if self.CalcLength(vvv, 'd') < tol/10.:
-                            # if true then its a repeated atom
-                            isclose = True
+                    for v in v2:
+                        vv = np.tile(v, [v1.shape[0], 1])
+                        vv = vv - v1
+
+                        for vvv in vv:
+
+                            # check if distance less than tol
+                            # the factor of 10 is for A --> nm
+                            if self.CalcLength(vvv, 'd') < tol/10.:
+                                # if true then its a repeated atom
+                                isclose = True
+                                break
+
+                        if isclose:
                             break
 
                     if isclose:
                         break
-
-                if isclose:
-                    break
-                else:
-                    atom_pos_fixed.append(np.hstack([pos, occ]))
+                    else:
+                        atom_pos_fixed.append(np.hstack([pos, occ]))
 
         return np.array(atom_pos_fixed)
 


### PR DESCRIPTION
The main function to call is `Material.remove_duplicate_atoms`. This function will call the `unitcell.remove_duplicate_atoms` function and update `Material.planeData` after the `unitcell` class is updated. 
Some logic fixes to the `unitcell.remove_duplicate_atoms` function. Instead of returning the sites, the function now updates the `unitcell` class.