### PR TITLE
Fix default material tThWidth for HDF5

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -700,10 +700,11 @@ class Material(object):
         if 'tThWidth' in gid:
             tThWidth = numpy.array(gid.get('tThWidth'),
                    dtype=numpy.float64).item()
+            tThWidth = numpy.radians(tThWidth)
         else:
             tThWidth = Material.DFLT_TTH
 
-        self._tThWidth = numpy.radians(tThWidth)
+        self._tThWidth = tThWidth
 
         if('hkls' in gid):
             self.hkl_from_file = numpy.array(gid.get('hkls'),

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -385,8 +385,8 @@ class Material(object):
                                scale=1.0):
         """
         this function computes a simulated spectra
-        for using in place of lines for the powder 
-        overlay. inputs are simplified as compared 
+        for using in place of lines for the powder
+        overlay. inputs are simplified as compared
         to the typical LeBail/Rietveld computation.
         only a fwhm (in degrees) and scale are passed
 


### PR DESCRIPTION
If the `tThWidth` wasn't in the HDF5 file, then the default was being
set to `np.radians(Material.DFLT_TTH)`. However, `Material.DFLT_TTH`
was already in radians.

This would result in the default two theta widths in HexrdGui being
0.004° instead of 0.25°.

Fix this so that the conversion to radians only occurs if the two theta
width is loaded from the HDF5 file.
