### PR TITLE
Fixing write error in material

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -732,7 +732,7 @@ class Material(object):
         AtomInfo['hkls'] = self.planeData.getHKLs()
         AtomInfo['dmin'] = self.unitcell.dmin
         if self.planeData.tThWidth is None:
-            AtomInfo['tThWidth'] = Material.DFLT_TTH
+            AtomInfo['tThWidth'] = numpy.degrees(Material.DFLT_TTH)
         else:
             AtomInfo['tThWidth'] = numpy.degrees(self.planeData.tThWidth)
         '''

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -385,8 +385,8 @@ class Material(object):
                                scale=1.0):
         """
         this function computes a simulated spectra
-        for using in place of lines for the powder 
-        overlay. inputs are simplified as compared 
+        for using in place of lines for the powder
+        overlay. inputs are simplified as compared
         to the typical LeBail/Rietveld computation.
         only a fwhm (in degrees) and scale are passed
 

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -731,7 +731,10 @@ class Material(object):
         AtomInfo['stiffness'] = self.unitcell.stiffness
         AtomInfo['hkls'] = self.planeData.getHKLs()
         AtomInfo['dmin'] = self.unitcell.dmin
-        AtomInfo['tThWidth'] = numpy.degrees(self.planeData.tThWidth)
+        if self.planeData.tThWidth is None:
+            AtomInfo['tThWidth'] = Material.DFLT_TTH
+        else:
+            AtomInfo['tThWidth'] = numpy.degrees(self.planeData.tThWidth)
         '''
         lattice parameters
         '''


### PR DESCRIPTION
check if tThWidth is present in planeData before trying to convert to degrees. This was leading to an error during state write.