### PR TITLE
Bump numpy version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,9 @@ build:
 
 requirements:
   build:
-    - numpy=1.20
+    # Numba is only here to ensure the numpy version is compatible
+    - numba
+    - numpy
     - python {{ python }}
     - setuptools
     - setuptools_scm
@@ -25,7 +27,7 @@ requirements:
     - h5py
     - lmfit
     - numba
-    - numpy=1.20
+    - numpy
     - psutil
     - pycifrw
     - python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<1.21", "setuptools_scm[toml]"]
+requires = ["setuptools", "wheel", "numpy<1.22", "setuptools_scm[toml]"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_reqs = [
     'h5py',
     'lmfit',
     'numba',
-    'numpy<1.21',
+    'numpy<1.22',
     'psutil',
     'pycifrw',
     'pyyaml',


### PR DESCRIPTION
1. Bump maximum numpy version on PyPI to 1.21
    
The latest numba, 0.55, which was released a few weeks ago, is
compatible with numpy 1.21, but not numpy 1.22.
    
Bump the maximum numpy version to 1.21 to reflect this.

2. Add numba to conda build reqs, unfix numpy version

This is to ensure that the numpy version used to build hexrd is
compatible with numba.

We should test this to be sure it works...