### PR TITLE
Fix multiprocessing context for ProcessPoolExecutor

### DIFF
--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -26,9 +26,18 @@
 # Boston, MA 02111-1307 USA or visit <http://www.gnu.org/licenses/>.
 # =============================================================================
 import os
+import platform
+import multiprocessing as mp
 
 import numpy as np
+
 from scipy import constants as sc
+
+# !!! for stetting mp start method
+if 'Windows' in platform.system():
+    mp_context = mp.get_context("spawn")
+else:
+    mp_context = mp.get_context("fork")
 
 # pi related
 pi = np.pi

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -3852,7 +3852,8 @@ def _pixel_solid_angles(rows, cols, pixel_size_row, pixel_size_col,
         'tvec': tvec,
     }
     func = partial(_generate_pixel_solid_angles, **kwargs)
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+    with ProcessPoolExecutor(mp_context=constants.mp_context,
+                             max_workers=max_workers) as executor:
         results = executor.map(func, tasks)
 
     # Concatenate all the results together


### PR DESCRIPTION
We need to force the multiprocessing context to 'fork' on platforms (not Windows) where it is available.