### PR TITLE
add tqdm package dependency

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - scikit-image
     - scikit-learn
     - scipy
+    - tqdm
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_reqs = [
     'pyyaml',
     'scikit-learn',
     'scipy',
+    'tqdm',
     'xxhash',
 ]
 


### PR DESCRIPTION
The updated calibration package uses this for a status bar, and we should probably use `tqdm` across the code base to report status in loops.  @psavery -- would be great to figure out how to use it to talk to status bars in the GUI.