### PR TITLE
catch None in hdf5 write as TypeError

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -3581,8 +3581,11 @@ def unwrap_dict_to_h5(grp, d, asattr=False):
                 try:
                     grp.create_dataset(key, data=np.atleast_1d(item))
                 except(TypeError):
-                    # probably a string badness
-                    grp.create_dataset(key, data=item)
+                    if item is None:
+                        continue
+                    else:
+                        # probably a string badness
+                        grp.create_dataset(key, data=item)
 
 
 def unwrap_h5_to_dict(f, d):

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -3585,6 +3585,8 @@ def unwrap_dict_to_h5(grp, d, asattr=False):
                 except(TypeError):
                     if item is None:
                         continue
+                    else:
+                        raise
             else:
                 try:
                     grp.create_dataset(key, data=np.atleast_1d(item))

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -2366,7 +2366,7 @@ class PlanarDetector(object):
 
         # panel buffer
         if panel_buffer is None:
-            # could be non, a 2-element list, or a 2-d array (rows, cols)
+            # could be none, a 2-element list, or a 2-d array (rows, cols)
             panel_buffer = copy.deepcopy(self.panel_buffer)
         # !!! now we have to do some style-dependent munging of panel_buffer
         if isinstance(panel_buffer, np.ndarray):
@@ -2389,9 +2389,13 @@ class PlanarDetector(object):
                 )
         elif panel_buffer is None:
             # still None on self
+            # !!! this gets handled by unwrap_dict_to_h5 now
+            '''
             if style.lower() == 'hdf5':
                 # !!! can't write None to hdf5; substitute with zeros
                 panel_buffer = np.r_[0., 0.]
+            '''
+            pass
         det_dict['buffer'] = panel_buffer
 
         # =====================================================================
@@ -3576,7 +3580,11 @@ def unwrap_dict_to_h5(grp, d, asattr=False):
             unwrap_dict_to_h5(subgrp, item, asattr=asattr)
         else:
             if asattr:
-                grp.attrs.create(key, item)
+                try:
+                    grp.attrs.create(key, item)
+                except(TypeError):
+                    if item is None:
+                        continue
             else:
                 try:
                     grp.create_dataset(key, data=np.atleast_1d(item))


### PR DESCRIPTION
This address https://github.com/HEXRD/hexrdgui/issues/1161; now if a `panel_buffer` attribute is `None`, no exception is encoutnered.  However the HDF5 format (.hexrd) config gets written with `panel_buffer = [0., 0.]` instead of omitting it.  I think we should alter that behavior to just omit, which gets caught in the `HEDMInstrument.__init__`.