### PR TITLE
Catch for flat patch data

### DIFF
--- a/hexrd/fitting/calibration.py
+++ b/hexrd/fitting/calibration.py
@@ -265,6 +265,8 @@ class PowderCalibrator(object):
                         #     np.array(intensities).squeeze(),
                         #     axis=0
                         # )
+                        if len(intensities) == 0:
+                            continue
                         spec_data = np.vstack(
                             [np.degrees(angs[0]),
                              intensities[0]]

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1117,6 +1117,14 @@ class HEDMInstrument(object):
                         else:
                             tmp = image[ijs[0], ijs[1]]*area_fac
 
+                        # catch flat spectrum data, which will cause
+                        # fitting to fail.
+                        # ???: best here, or make fitting handle it?
+                        mxval = np.max(tmp)
+                        mnval = np.min(tmp)
+                        if mxval == 0 or (1. - mnval/mxval) < 0.01:
+                            continue
+
                         # catch collapsing options
                         if collapse_tth:
                             patch_data[i_p, j_p] = np.average(tmp)


### PR DESCRIPTION
The fitting will fail as currently implemented if the patch/spectrum data is all zeros or otherwise has no discernible peak.  Can you test this for your failing cases @psavery?  Satisfies one of the tasks in #404.