### PR TITLE
Downgrade windows CI to windows-2019

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
           }
         - {
             name: "Windows",
-            os: windows-latest
+            os: windows-2019
           }
     defaults:
       run:


### PR DESCRIPTION
Within the past few weeks, `windows-latest` was changed to point to
`windows-2022` instead of `windows-2019`. Our Windows packaging has
had errors since that transition.

It would be preferable to fix the issues with `windows-2022` so that
we can use it. However, the error messages are cryptic (pasted below).
We can downgrade to `windows-2019` until we find a fix.

```python
error: command 'cl.exe' failed: None
Traceback (most recent call last):
  File "C:\Miniconda\envs\hexrd\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\cli\main_build.py", line 488, in main
    execute(sys.argv[1:])
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\cli\main_build.py", line 477, in execute
    outputs = api.build(args.recipe, post=args.post, test_run_post=args.test_run_post,
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\api.py", line 186, in build
    return build_tree(
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\build.py", line 3088, in build_tree
    packages_from_this = build(metadata, stats,
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\build.py", line 2179, in build
    windows.build(m, build_file, stats=build_stats, provision_only=provision_only)
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\windows.py", line 297, in build
    check_call_env(cmd, cwd=m.config.work_dir, stats=stats, rewrite_stdout_env=rewrite_env)
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\utils.py", line 410, in check_call_env
    return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
  File "C:\Miniconda\envs\hexrd\lib\site-packages\conda_build\utils.py", line 390, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['cmd.exe', '/d', '/c', 'conda_build.bat']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```

The error appears to occur while building `transforms_CAPI.c`.