### PR TITLE
added logic to handle omega gaps

### DIFF
--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -551,7 +551,7 @@ def _filter_eta_ome_maps(eta_ome, filter_stdev=False):
     gl_filter = ndimage.filters.gaussian_laplace
     for i, pf in enumerate(eta_ome.dataStore):
         # first compoute row-wise median over omega channel
-        ome_median = np.tile(np.median(pf, axis=0), (len(pf), 1))
+        ome_median = np.tile(np.nanmedian(pf, axis=0), (len(pf), 1))
 
         # subtract
         # !!! this changes the reference obj, but fitlering does not

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -3706,8 +3706,12 @@ class GenerateEtaOmeMaps(object):
             # compute total nsteps
             # FIXME: need check for roundoff badness
             nsteps = int((ostop - ostart)/delta_omes)
-            ome_edges_full = np.linspace(ostart, ostop, num=nsteps, endpoint=True)
-            omegas_array = np.vstack([ome_edges_full[:-1], ome_edges_full[1:]]).T
+            ome_edges_full = np.linspace(
+                ostart, ostop, num=nsteps, endpoint=True
+            )
+            omegas_array = np.vstack(
+                [ome_edges_full[:-1], ome_edges_full[1:]]
+            ).T
             ome_centers = np.average(omegas_array, axis=1)
 
             # use OmegaImageSeries method to determine which bins have data

--- a/hexrd/rotations.py
+++ b/hexrd/rotations.py
@@ -744,22 +744,27 @@ def rotMatOfQuat(quat):
 
 def angleAxisOfRotMat(R):
     """
-    Extract angle and axis invariants from a rotation matrix.
+    Extracts angle and axis invariants from rotation matrices.
 
     Parameters
     ----------
-    R : TYPE
-        DESCRIPTION.
+    R : numpy.ndarray
+        The (3, 3) or (n, 3, 3) array of rotation matrices.
+        Note that these are assumed to be proper orthogonal.
 
     Raises
     ------
     RuntimeError
-        DESCRIPTION.
+        If `R` is not an shape is not (3, 3) or (n, 3, 3).
 
     Returns
     -------
-    TYPE
-        DESCRIPTION.
+    phi : numpy.ndarray
+        The (n, ) array of rotation angles for the n input
+        rotation matrices.
+    n : numpy.ndarray
+        The (3, n) array of unit rotation axes for the n
+        input rotation matrices.
 
     """
     if not isinstance(R, ndarray):
@@ -781,7 +786,7 @@ def angleAxisOfRotMat(R):
     #
     ca = 0.5*(R[:, 0, 0] + R[:, 1, 1] + R[:, 2, 2] - 1)
 
-    angle = arccosSafe(ca)
+    angle = arccosSafe(ca)  # !!! result in (0, pi)
 
     #
     #  Three cases for the angle:
@@ -790,7 +795,7 @@ def angleAxisOfRotMat(R):
     #  *   near pi   -- binary rotation; need to find axis
     #  *   neither   -- general case; can use skew part
     #
-    tol = cnst.sqrt_epsf
+    tol = cnst.epsf
 
     anear0 = angle < tol
 
@@ -801,11 +806,12 @@ def angleAxisOfRotMat(R):
          R[:, 0, 2] - R[:, 2, 0],
          R[:, 1, 0] - R[:, 0, 1]]
     )
-    raxis[:, anear0] = 1
+    raxis[:, anear0] = 1.
 
-    special = angle > pi - tol
+    special = angle > pi - tol  # !!! see above
     nspec = special.sum()
     if nspec > 0:
+
         tmp = R[special, :, :] + tile(I3, (nspec, 1, 1))
         tmpr = tmp.transpose(0, 2, 1).reshape(nspec*3, 3).T
 


### PR DESCRIPTION
Currently, the η-ω map generation could not handle multi-wedge imageseries.  This PR addresses that shortcoming.  There are a few tacit assumptions about the imageseries, however:
1. the wedges must be non-overlapping
2. the wedges must not exceed 360º
3. the wedges, and thus frame order, must be monotonically increasing in ω
I will attach a test case form a DAC experiment. 