### PR TITLE
add roi handling

### DIFF
--- a/hexrd/config/imageseries.py
+++ b/hexrd/config/imageseries.py
@@ -6,6 +6,7 @@ class ImageSeries(Config):
     """
     """
     BASEKEY = 'image_series'
+    share_ims_key = 'mulitple'
 
     def __init__(self, cfg):
         super(ImageSeries, self).__init__(cfg)
@@ -17,7 +18,7 @@ class ImageSeries(Config):
 
     @property
     def imageseries(self):
-        """Return the imageseries dictionar.y"""
+        """Return the imageseries dictionary"""
         if self._image_dict is None:
             self._image_dict = dict()
             fmt = self.format
@@ -26,7 +27,12 @@ class ImageSeries(Config):
                 args = ispec['args']
                 ims = imageseries.open(fname, fmt, **args)
                 oms = imageseries.omega.OmegaImageSeries(ims)
-                panel = oms.metadata['panel']
+                # handle special case for single IMS
+                # for use with ROI
+                try:
+                    panel = oms.metadata['panel']
+                except(KeyError):
+                    panel = 'share_ims_key'
                 self._image_dict[panel] = oms
 
         return self._image_dict

--- a/hexrd/config/imageseries.py
+++ b/hexrd/config/imageseries.py
@@ -1,12 +1,11 @@
 from .config import Config
 from hexrd import imageseries
 
+from hexrd.constants import shared_ims_key
+
 
 class ImageSeries(Config):
-    """
-    """
     BASEKEY = 'image_series'
-    share_ims_key = 'mulitple'
 
     def __init__(self, cfg):
         super(ImageSeries, self).__init__(cfg)
@@ -31,8 +30,12 @@ class ImageSeries(Config):
                 # for use with ROI
                 try:
                     panel = oms.metadata['panel']
+                    if isinstance(panel, (tuple, list)):
+                        panel = '_'.join(panel)
+                    elif panel is None:
+                        panel = shared_ims_key
                 except(KeyError):
-                    panel = 'share_ims_key'
+                    panel = shared_ims_key
                 self._image_dict[panel] = oms
 
         return self._image_dict

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -2,7 +2,7 @@ import os
 import logging
 import multiprocessing as mp
 
-# from hexrd.utils.decorators import memoized
+from hexrd.constants import shared_ims_key
 from hexrd import imageseries
 
 from .config import Config
@@ -160,8 +160,15 @@ class RootConfig(Config):
                 oms = imageseries.omega.OmegaImageSeries(ims)
                 try:
                     panel = ispec['panel']
+                    if isinstance(panel, (tuple, list)):
+                        panel = '_'.join(panel)
+                    elif panel is None:
+                        panel = shared_ims_key
                 except(KeyError):
-                    panel = oms.metadata['panel']
+                    try:
+                        panel = oms.metadata['panel']
+                    except(KeyError):
+                        panel = shared_ims_key
                 self._image_dict[panel] = oms
 
         return self._image_dict

--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -105,6 +105,8 @@ fable_to_hexrd_cob_qpm = np.array(
      [ 0.5, -0.5, -0.5,  0.5]]
 )
 
+# shared key for imageseries shared by multiple detectors (ROI's)
+shared_ims_key = 'SHARED-IMAGES'
 
 """
 >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab,

--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -238,7 +238,7 @@ def fit_grain_FF_reduced(grain_id):
                 culled_results_r[det_key] = []
                 continue
 
-            ims = imgser_dict[det_key]
+            ims = next(iter(imgser_dict.values()))  # grab first for the omes
             ome_step = sum(np.r_[-1, 1]*ims.metadata['omega'][0, :])
 
             xyo_det = np.atleast_2d(

--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -77,7 +77,7 @@ class ProcessedImageSeries(ImageSeries):
 
     def _rectangle(self, img, r):
         # restrict to rectangle
-        return img[r[0, 0]:r[0, 1], r[1, 0]:r[1, 1]]
+        return img[r[0][0]:r[0][1], r[1][0]:r[1][1]]
 
     def _flip(self, img, flip):
         if flip in ('y', 'v'):  # about y-axis (vertical)

--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -330,8 +330,10 @@ def _parse_imgser_dict(imgser_dict, det_key, roi=None):
                 raise RuntimeError(
                     f"multiple entries found for '{det_key}'"
                 )
-            img_keys = list(imgser_dict.keys())  # same order
-            matched_det_key = img_keys[matched_det_keys]
+            # use boolean array to index the proper key
+            # !!! these should be in the same order
+            img_keys = img_keys = np.asarray(list(imgser_dict.keys()))
+            matched_det_key = img_keys[matched_det_keys][0]  # !!! only one
             images_in = imgser_dict[matched_det_key]
         else:
             raise RuntimeError(
@@ -2558,10 +2560,13 @@ class PlanarDetector(object):
         # assign local vars; listify if necessary
         tilt = self.tilt
         translation = self.tvec
+        roi = None if self.roi is None \
+            else np.array([self.roi[0][0], self.roi[1][0]]).flatten()
         if style.lower() == 'yaml':
             tilt = tilt.tolist()
             translation = translation.tolist()
             tvec = tvec.tolist()
+            roi = None if roi is None else roi.tolist()
 
         det_dict = dict(
             transform=dict(
@@ -2569,11 +2574,11 @@ class PlanarDetector(object):
                 translation=translation,
             ),
             pixels=dict(
-                rows=self.rows,
-                columns=self.cols,
+                rows=int(self.rows),
+                columns=int(self.cols),
                 size=[float(self.pixel_size_row),
                       float(self.pixel_size_col)],
-                roi=None if self.roi is None else [self.roi[0][0], self.roi[1][0]]
+                roi=roi
             )
         )
 


### PR DESCRIPTION
Finally adding the ability to specify ROI in a detector.  The usage is that any imageseries with an unspecified detector panel will be treated as "shared", and the detectors not represented in an image dictionary input will use the ROI to grab its pixel data.  The obvious application is for multi element detectors.  Closes #419. 
- [x] handle case where there is at most 1 shared imageseries
- [ ] generalize to multiple shared imageseries
  - requires explicitly passing a list of detectors over which to share