### PR TITLE
add ability to set box constraints

### DIFF
--- a/hexrd/fitting/utils.py
+++ b/hexrd/fitting/utils.py
@@ -45,11 +45,16 @@ def _set_equality_constraints(params, pname_spec):
 
 
 def _set_bound_constraints(params, pname_spec,
-                           min_val=-np.inf, max_val=np.inf):
+                           min_val=-np.inf, max_val=np.inf, box=None):
     target_pnames = _extract_parameters_by_name(params, pname_spec)
     for pname in target_pnames:
-        params[pname].min = min_val
-        params[pname].max = max_val
+        if box is None:
+            params[pname].min = min_val
+            params[pname].max = max_val
+        else:
+            params[pname].min = params[pname].value - 0.5*box
+            params[pname].max = params[pname].value + 0.5*box
+
 
 
 def _set_width_mixing_bounds(params, min_w=0.01, max_w=np.inf):


### PR DESCRIPTION
Now bounds can be specified as `±0.5*box` in lieu of explicit min/max.