### PR TITLE
Set default dmin to None in load_materials_hdf5()

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -1133,7 +1133,7 @@ def loadMaterialList(cfgFile):
     return matList
 
 
-def load_materials_hdf5(f, dmin=Material.DFLT_DMIN, kev=Material.DFLT_KEV,
+def load_materials_hdf5(f, dmin=None, kev=Material.DFLT_KEV,
                         sgsetting=Material.DFLT_SGSETTING):
     """Load materials from an HDF5 file
 


### PR DESCRIPTION
For the dmin argument, `Material.__init__()` treats `None` and
`Material.DFLT_DMIN` differently. If it is `None`, then the dmin is read
from the HDF5 file if available. However, if it is not `None`, as was
the case before, then the dmin will not be read from the HDF5 file.

Default it to `None` in `load_materials_hdf5()` so that it will be read
from the HDF5 file.

Fixes: hexrd/hexrdgui#1186