### PR TITLE
Fix spot export error for multiple grains

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1761,8 +1761,7 @@ class HEDMInstrument(object):
                 output_dir = os.path.join(
                     dirname, detector_id
                     )
-                if not os.path.exists(output_dir):
-                    os.makedirs(output_dir)
+                os.makedirs(output_dir, exist_ok=True)
                 this_filename = os.path.join(
                     output_dir, filename
                 )


### PR DESCRIPTION
When multiple grains were being exported simultaneously due to
multiprocessing the `pull_spots()` function, a race condition would
cause an error with this body of code:

```python
if not os.path.exists(output_dir):
    os.makedirs(output_dir)
```

Basically, two processes would both see at the same time that the
output directory does not exist, and then they would both try to
make it at the same time. One process would make the directory,
however, and then the second process would get a `FileExistsError`
because the directory was already created.

To avoid the race condition, just modify the code to this:

```python
os.makedirs(output_dir, exist_ok=True)
```

This appears to fix the issue in my testing.

Fixes: hexrd/hexrdgui#1192