### PR TITLE
density fix for ruby

### DIFF
--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -1123,7 +1123,6 @@ SYM_GENERATORS['g'][1, 0] = 1.
 SYM_GENERATORS['g'][2, 2] = 1.
 
 # inversion
-SYM_GENERATORS['h'] = np.zeros([3, 3])
 SYM_GENERATORS['h'] = -np.eye(3)
 
 # c-mirror

--- a/hexrd/symmetry.py
+++ b/hexrd/symmetry.py
@@ -456,7 +456,7 @@ def GenerateSGSym(sgnum, setting=0):
             frac = np.modf(gnew[0:3,3])[0]
             frac[frac < 0.] += 1.
             frac[np.abs(frac) < 1E-5] = 0.0
-
+            frac[np.abs(frac-1.0) < 1E-5] = 0.0
             gnew[0:3,3] = frac
 
             if(isnew(gnew, SYM_SG)):


### PR DESCRIPTION
fractional coordinates of 0 and 1 are the same; `numpy.modf` was not handling it properly. Added additional handling. Fixes density of ruby. All other densities are also consistent.

Tested with GUI