### PR TITLE
Material load

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -195,6 +195,11 @@ class Material(object):
             elif isinstance(material_file, h5py.Group) or form in h5_suffixes:
                 self._readHDFxtal(fhdf=material_file, xtal=name)
 
+            if not dmin is None:
+                self._dmin = dmin
+
+            if not kev is None:
+                self._beamEnergy = kev
         else:
             # default name
             self._name = Material.DFLT_XTAL

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -167,6 +167,16 @@ class Material(object):
 
         self.sgsetting = sgsetting
 
+        if not dmin is None:
+            self._dmin = dmin
+        else:
+            self._dmin = Material.DFLT_DMIN
+
+        if not kev is None:
+            self._beamEnergy = kev
+        else:
+            self._beamEnergy = Material.DFLT_KEV
+
         if material_file:
             # Get values from configuration
             # self._readCfg(material_file)
@@ -185,10 +195,6 @@ class Material(object):
             elif isinstance(material_file, h5py.Group) or form in h5_suffixes:
                 self._readHDFxtal(fhdf=material_file, xtal=name)
 
-            if not dmin is None:
-                self._dmin = dmin
-            if not kev is None:
-                self._beamEnergy = kev
         else:
             # default name
             self._name = Material.DFLT_XTAL

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -71,6 +71,7 @@ def _degrees(x):
 def _kev(x):
     return valWUnit('xrayenergy', 'energy',  x, 'keV')
 
+
 def _key(x):
     return x.name
 
@@ -100,8 +101,9 @@ class Material(object):
     DFLT_TTH = numpy.radians(0.25)
     DFLT_TTHMAX = None
     """
-    ATOMINFO    Fractional Atom Position of an atom in the unit cell followed by the
-    site occupany and debye waller (U) factor in A^(-2)
+    ATOMINFO    Fractional Atom Position of an atom in the
+    unit cell followed by the site occupany and debye waller
+    (U) factor in A^(-2)
     B is related to U by B = 8 pi^2 U
 
     ATOMTYPE    atomic number of all the different species in the unitcell
@@ -167,22 +169,19 @@ class Material(object):
 
         self.sgsetting = sgsetting
 
-        if not dmin is None:
+        if dmin is not None:
             self._dmin = dmin
         else:
             self._dmin = Material.DFLT_DMIN
 
-        if not kev is None:
+        if kev is not None:
             self._beamEnergy = kev
         else:
             self._beamEnergy = Material.DFLT_KEV
 
         if material_file:
-            # Get values from configuration
-            # self._readCfg(material_file)
+
             # >> @ date 08/20/2020 SS removing dependence on hklmax
-            #self._hklMax = Material.DFLT_SSMAX
-            # self._beamEnergy = Material.DFLT_KEV
             if isinstance(material_file, (Path, str)):
                 form = Path(material_file).suffix[1:]
             else:
@@ -195,10 +194,10 @@ class Material(object):
             elif isinstance(material_file, h5py.Group) or form in h5_suffixes:
                 self._readHDFxtal(fhdf=material_file, xtal=name)
 
-            if not dmin is None:
+            if dmin is not None:
                 self._dmin = dmin
 
-            if not kev is None:
+            if kev is not None:
                 self._beamEnergy = kev
         else:
             # default name
@@ -406,10 +405,10 @@ class Material(object):
 
         requested feature from Amy Jenei
         """
-        tth = numpy.degrees(self.planeData.getTTh()) # convert to degrees
-        Ip  = self.planeData.powder_intensity
+        tth = numpy.degrees(self.planeData.getTTh())  # convert to degrees
+        Ip = self.planeData.powder_intensity
         self.powder_overlay = numpy.zeros_like(ttharray)
-        for t,I in zip(tth, Ip):
+        for t, I in zip(tth, Ip):
             p = [t, fwhm]
             self.powder_overlay += scale*I*_unit_gaussian(p, ttharray)
 
@@ -423,13 +422,16 @@ class Material(object):
         self._hkls_changed()
 
     def _readCif(self, fcif=DFLT_NAME+'.cif'):
+
         """
-        >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab, saransh1@llnl.gov
+        >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab,
+                        saransh1@llnl.gov
         >> @DATE:       10/16/2019 SS 1.0 original
-        >> @DETAILS:    hexrd3 will have real structure factors and will require the overhaul
-                        of the crystallography. In this effort, we will have a cif reader and
-                        also the HDF5 format reader in the material class. We will be using
-                        pycifrw for i/o
+        >> @DETAILS:    hexrd3 will have real structure factors and will
+                        require the overhaul of the crystallography.
+                        In this effort, we will have a cif reader and
+                        also the HDF5 format reader in the material
+                        class. We will be using pycifrw for i/o
         """
 
         try:
@@ -468,7 +470,7 @@ class Material(object):
         elif (skey is sgkey[1]):
             HM = cifdata[sgkey[1]]
             HM = HM.replace(" ", "")
-            HM = HM.replace("_","")
+            HM = HM.replace("_", "")
             sgnum = HM_to_sgnum[HM]
         elif (skey is sgkey[2]):
             hall = cifdata[sgkey[2]]
@@ -537,8 +539,8 @@ class Material(object):
             atompos.append(pos)
 
         """note that the vibration amplitude, U is just the amplitude (in A)
-            to convert to the typical B which occurs in the debye-waller factor,
-            we will use the following formula
+            to convert to the typical B which occurs in the debye-waller
+            factor, we will use the following formula
             B = 8 * pi ^2 * < U_av^2 >
             this will be done here so we dont have to worry about it later
         """
@@ -561,7 +563,7 @@ class Material(object):
                 else:
                     occ.append(p)
 
-            chkstr = numpy.asarray([isinstance(x,str) for x in occ])
+            chkstr = numpy.asarray([isinstance(x, str) for x in occ])
             occstr = numpy.array(occ)
             occstr[chkstr] = 1.0
 
@@ -589,9 +591,9 @@ class Material(object):
                 else:
                     U.append(p)
 
-            chkstr = numpy.asarray([isinstance(x,str) for x in U])
+            chkstr = numpy.asarray([isinstance(x, str) for x in U])
 
-            for ii,x in enumerate(chkstr):
+            for ii, x in enumerate(chkstr):
                 if x:
                     U[ii] = 1.0/numpy.pi/2./numpy.sqrt(2.)
 
@@ -640,14 +642,17 @@ class Material(object):
 
     def _readHDFxtal(self, fhdf=DFLT_NAME, xtal=DFLT_NAME):
         """
-        >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab, saransh1@llnl.gov
+        >> @AUTHOR:     Saransh Singh, Lawrence Livermore National Lab,
+                        saransh1@llnl.gov
         >> @DATE:       10/17/2019 SS 1.0 original
-                        01/07/2021 SS 1.1 check for optional stiffness in material file.
+                        01/07/2021 SS 1.1 check for optional
+                        stiffness in material file.
                         read and initialize unitcell stiffness field if present
-        >> @DETAILS:    hexrd3 will have real structure factors and will require the overhaul
-                        of the crystallography. In this effort, we will have a HDF file reader.
-                        the file will be the same as the EMsoft xtal file. h5py will be used for
-                        i/o
+        >> @DETAILS:    hexrd3 will have real structure factors and will
+                        require the overhaul of the crystallography.
+                        In this effort, we will have a HDF file reader
+                        the file will be the same as the EMsoft xtal
+                        file. h5py will be used for i/o
         """
 
         if isinstance(fhdf, (Path, str)):
@@ -684,7 +689,7 @@ class Material(object):
                 lparms[i] = _degrees(lparms[i])
 
         self._lparms = lparms
-        #self._lparms    = self._toSixLP(sgnum, lparms)
+
         # fill space group and lattice parameters
         self.sgnum = sgnum
 
@@ -727,14 +732,14 @@ class Material(object):
         # if kev is present in file
         if('kev' in gid):
             kev = numpy.array(gid.get('kev'),
-                               dtype=numpy.float64).item()
+                              dtype=numpy.float64).item()
             self._beamEnergy = _kev(kev)
         else:
             self._beamEnergy = Material.DFLT_KEV
 
         if 'tThWidth' in gid:
             tThWidth = numpy.array(gid.get('tThWidth'),
-                   dtype=numpy.float64).item()
+                                   dtype=numpy.float64).item()
             tThWidth = numpy.radians(tThWidth)
         else:
             tThWidth = Material.DFLT_TTH
@@ -978,12 +983,12 @@ class Material(object):
         """
         if len(vals) != len(self.atomtype):
             msg = (f"incorrect size of charge. "
-                f"must be same size as number of aom types.")
+                   f"must be same size as number of aom types.")
             raise ValueError(msg)
         """
         now check if charge states are actually allowed
         """
-        for ii,z in enumerate(self.atomtype):
+        for ii, z in enumerate(self.atomtype):
             elem = ptableinverse[z]
             cs = chargestate[elem]
             if not vals[ii] in cs:
@@ -1019,19 +1024,6 @@ class Material(object):
 
         self._atominfo = v
 
-        # if self._atominfo.shape == v.shape:
-        #     if not numpy.allclose(self._atominfo, v):
-        #         self._atominfo = v
-        #         #self.unitcell.atom_pos = v
-        #         #self.update_structure_factor()
-
-        #     else:
-        #         return
-        # else:
-        #     self._atominfo = v
-            #self.unitcell.atom_pos = v
-            #self.update_structure_factor()
-
     atominfo = property(
         _get_atominfo, _set_atominfo, None,
         "Information about atomic positions and electron number")
@@ -1066,8 +1058,8 @@ class Material(object):
         #         return
         # else:
         #     self._atomtype = numpy.array(v)
-            #self._newUnitcell()
-            #self.update_structure_factor()
+        # self._newUnitcell()
+        # self.update_structure_factor()
         self._atomtype = v
 
     atomtype = property(
@@ -1100,25 +1092,25 @@ class Material(object):
         if atomtype.shape[0] != atominfo.shape[0]:
             msg = (f"inconsistent shapes: number of atoms "
                    f"types passed = {atomtype.shape[0]} \n"
-                   f" number of atom positions passed = {atominfo.shape[0]}" )
+                   f" number of atom positions passed = {atominfo.shape[0]}")
             raise ValueError(msg)
 
         if atomtype.shape[0] != U.shape[0]:
             msg = (f"inconsistent shapes: number of atoms "
                    f"types passed = {atomtype.shape[0]} \n"
-                   f" U passed for {U.shape[0]} atoms." )
+                   f" U passed for {U.shape[0]} atoms.")
             raise ValueError(msg)
 
         if atominfo.shape[0] != U.shape[0]:
             msg = (f"inconsistent shapes: number of atom "
                    f"positions passed = {atominfo.shape[0]} \n"
-                   f"U passed for {U.shape[0]} atoms." )
+                   f"U passed for {U.shape[0]} atoms.")
             raise ValueError(msg)
 
         if len(charge) != atomtype.shape[0]:
             msg = (f"inconsistent shapes: number of atoms "
                    f"types passed = {atomtype.shape[0]} \n"
-                   f"charge value passed for {len(charge)} atoms." )
+                   f"charge value passed for {len(charge)} atoms.")
             raise ValueError(msg)
 
         self.atomtype = atomtype
@@ -1196,6 +1188,7 @@ def save_materials_hdf5(f, materials, path=None):
     """Save a dict of materials into an HDF5 file"""
     for material in materials.values():
         material.dump_material(f, path)
+
 
 def hkls_match(a, b):
     # Check if hkls match. Expects inputs to have shape (x, 3).

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -154,30 +154,7 @@ class Material(object):
 
         self.description = ''
 
-        """
-        set dmin to default value if its None
-        if h5 file has a value, it will be substituted
-        if not none, then set it to the value
-        supplied and ignore the value in the h5 file
-        """
-        # self.read_dmin_file = True
-        # if dmin is None:
-        #     self._dmin = Material.DFLT_DMIN
-        # else:
-        #     self._dmin = dmin
-        #     self.read_dmin_file = False
-
         self.sgsetting = sgsetting
-
-        if dmin is not None:
-            self._dmin = dmin
-        else:
-            self._dmin = Material.DFLT_DMIN
-
-        if kev is not None:
-            self._beamEnergy = kev
-        else:
-            self._beamEnergy = Material.DFLT_KEV
 
         if material_file:
 
@@ -193,12 +170,6 @@ class Material(object):
                 self._readCif(material_file)
             elif isinstance(material_file, h5py.Group) or form in h5_suffixes:
                 self._readHDFxtal(fhdf=material_file, xtal=name)
-
-            if dmin is not None:
-                self._dmin = dmin
-
-            if kev is not None:
-                self._beamEnergy = kev
         else:
             # default name
             self._name = Material.DFLT_XTAL
@@ -219,6 +190,16 @@ class Material(object):
             self._charge = Material.DFLT_CHARGE
             self._tThWidth = Material.DFLT_TTH
             #
+            self._dmin = Material.DFLT_DMIN
+            self._beamEnergy = Material.DFLT_KEV
+
+        # If these were specified, they override any other method of
+        # obtaining them (including loading them from files).
+        if dmin is not None:
+            self._dmin = dmin
+
+        if kev is not None:
+            self._beamEnergy = kev
 
         self._newUnitcell()
         self._newPdata()

--- a/hexrd/mksupport.py
+++ b/hexrd/mksupport.py
@@ -531,6 +531,10 @@ def WriteH5Data(fid, AtomInfo, lat_param, path=None):
         did = gid.create_dataset("dmin", (1,), dtype=np.float64)
         did.write_direct(np.array(AtomInfo['dmin'], dtype=np.float64))
 
+    if 'kev' in AtomInfo:
+        did = gid.create_dataset("kev", (1,), dtype=np.float64)
+        did.write_direct(np.array(AtomInfo['kev'], dtype=np.float64))
+
     did = gid.create_dataset(
         "AtomData", (4, len(AtomInfo['Z'])), dtype=np.float64)
     # this is done for contiguous c-allocation


### PR DESCRIPTION
Changing behavior of material load. the beam energy is written to the h5 file now. changes summarized below:

1. If values for `dmin` and `kev` are passed, then they supersede values in the file or the default values.
2. If values are not passed, then file is checked for values of `dmin` and `kev`. If found, then these values are used.
3. If nothing is passed and values not present in file, then the default values are used.

Tested with GUI, with both old material files and new ones (with kev)