### PR TITLE
Unitcell fixes

### DIFF
--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -743,7 +743,7 @@ class unitcell:
                 elem = constants.ptableinverse[Z]
                 gid = fid.get('/'+elem)
                 data = np.array(gid.get('data'))
-                self.pe_cs[elem] = interp1d(data[:,7], data[:,3])
+                self.pe_cs[elem] = interp1d(data[:, 7], data[:, 3])
                 data = data[:, [7, 1, 2]]
                 f_anomalous_data.append(data)
 

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -666,7 +666,7 @@ class unitcell:
         initialize interpolation from table for anomalous scattering
         '''
         self.InitializeInterpTable()
-        self.CalcAnomalous()
+        # self.CalcAnomalous()
         self.CalcPositions()
         self.CalcDensity()
         self.calc_absorption_length()

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -734,6 +734,7 @@ class unitcell:
     def InitializeInterpTable(self):
 
         f_anomalous_data = []
+        self.pe_cs = {}
         data = importlib.resources.open_binary(hexrd.resources, 'Anomalous.h5')
         with h5py.File(data, 'r') as fid:
             for i in range(0, self.atom_ntype):
@@ -742,6 +743,7 @@ class unitcell:
                 elem = constants.ptableinverse[Z]
                 gid = fid.get('/'+elem)
                 data = np.array(gid.get('data'))
+                self.pe_cs[elem] = interp1d(data[:,7], data[:,3])
                 data = data[:, [7, 1, 2]]
                 f_anomalous_data.append(data)
 
@@ -1631,7 +1633,7 @@ class unitcell:
                                                   self._supergroup,
                                                   self._supergroup_laue)
         self.CalcDensity()
-        # self.calc_absorption_length()
+        self.calc_absorption_length()
 
     @property
     def atom_pos(self):

--- a/hexrd/wppf/phase.py
+++ b/hexrd/wppf/phase.py
@@ -735,9 +735,9 @@ class Material_Rietveld:
         self.multiplicity = multiplicity
 
         # interpolation tables and anomalous form factors
-        self.f1 = material_obj.unitcell.f1
-        self.f2 = material_obj.unitcell.f2
-        self.f_anam = material_obj.unitcell.f_anam
+        # self.f1 = material_obj.unitcell.f1
+        # self.f2 = material_obj.unitcell.f2
+        # self.f_anam = material_obj.unitcell.f_anam
 
         # final step is to calculate the asymmetric positions in
         # the unit cell


### PR DESCRIPTION
The defunct `unitcell.CalcAnomalous()` function was being called inside `unitcell.remove_duplicate_atoms()`. This PR removes that call. Additionally, `wppf/phase.py` was referencing `unitcell.f1` and `unitcell.f2` variables, which got defunct with `unitcell.CalcAnomalous()`. Those references are removed too. 

The broken `unitcell.calc_absorption_length()` function was fixed as well.

Tested with GUI and command line.