### PR TITLE
changed hkl specification for indexing to master hklID

### DIFF
--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -218,12 +218,6 @@ class OrientationMapsConfig(Config):
         return temp
 
     @property
-    def explicit_hkls(self):
-        return self._cfg.get(
-            'find_orientations:orientation_maps:explicit_hkls', default=1
-            )
-
-    @property
     def bin_frames(self):
         return self._cfg.get(
             'find_orientations:orientation_maps:bin_frames', default=1

--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -218,6 +218,12 @@ class OrientationMapsConfig(Config):
         return temp
 
     @property
+    def explicit_hkls(self):
+        return self._cfg.get(
+            'find_orientations:orientation_maps:explicit_hkls', default=1
+            )
+
+    @property
     def bin_frames(self):
         return self._cfg.get(
             'find_orientations:orientation_maps:bin_frames', default=1
@@ -240,5 +246,3 @@ class OrientationMapsConfig(Config):
     def filter_maps(self):
         return self._cfg.get('find_orientations:orientation_maps:filter_maps',
                              default=False)
-
-

--- a/hexrd/indexer.py
+++ b/hexrd/indexer.py
@@ -154,8 +154,13 @@ def paintGrid(quats, etaOmeMaps,
 
     planeData = etaOmeMaps.planeData
 
-    hklIDs = np.r_[etaOmeMaps.iHKLList]
-    hklList = np.atleast_2d(planeData.hkls[:, hklIDs].T).tolist()
+    # !!! these are master hklIDs
+    hklIDs = np.asarray(etaOmeMaps.iHKLList)
+    hklList = planeData.getHKLs(*hklIDs).tolist()
+    hkl_idx = planeData.getHKLID(
+        planeData.getHKLs(*hklIDs).T,
+        master=False
+    )
     nHKLS = len(hklIDs)
 
     numEtas = len(etaOmeMaps.etaEdges) - 1
@@ -165,11 +170,9 @@ def paintGrid(quats, etaOmeMaps,
         threshold = np.zeros(nHKLS)
         for i in range(nHKLS):
             threshold[i] = np.mean(
-                np.r_[
-                    np.mean(etaOmeMaps.dataStore[i]),
-                    np.median(etaOmeMaps.dataStore[i])
-                    ]
-                )
+                np.r_[np.mean(etaOmeMaps.dataStore[i]),
+                      np.median(etaOmeMaps.dataStore[i])]
+            )
     elif threshold is not None and not hasattr(threshold, '__len__'):
         threshold = threshold * np.ones(nHKLS)
     elif hasattr(threshold, '__len__'):
@@ -229,7 +232,7 @@ def paintGrid(quats, etaOmeMaps,
 
     # Get the symHKLs for the selected hklIDs
     symHKLs = planeData.getSymHKLs()
-    symHKLs = [symHKLs[id] for id in hklIDs]
+    symHKLs = [symHKLs[id] for id in hkl_idx]
     # Restructure symHKLs into a flat NumPy HKL array with
     # each HKL stored contiguously (C-order instead of F-order)
     # symHKLs_ix provides the start/end index for each subarray

--- a/hexrd/xrdutil/utils.py
+++ b/hexrd/xrdutil/utils.py
@@ -519,7 +519,7 @@ class EtaOmeMaps(object):
         """
         args = np.array(eta_ome.planeData.getParams(), dtype=object)[:4]
         args[2] = valWUnit('wavelength', 'length', args[2], 'angstrom')
-        hkls = eta_ome.planeData.hkls
+        hkls = np.vstack([i['hkl'] for i in eta_ome.planeData.hklDataList]).T
         save_dict = {'dataStore': eta_ome.dataStore,
                      'etas': eta_ome.etas,
                      'etaEdges': eta_ome.etaEdges,

--- a/hexrd/xrdutil/utils.py
+++ b/hexrd/xrdutil/utils.py
@@ -496,6 +496,7 @@ class EtaOmeMaps(object):
         planeData_args = ome_eta['planeData_args']
         planeData_hkls = ome_eta['planeData_hkls']
         self.planeData = PlaneData(planeData_hkls, *planeData_args)
+        self.planeData.exclusions = ome_eta['planeData_excl']
         self.dataStore = ome_eta['dataStore']
         self.iHKLList = ome_eta['iHKLList']
         self.etaEdges = ome_eta['etaEdges']
@@ -527,7 +528,8 @@ class EtaOmeMaps(object):
                      'omegas': eta_ome.omegas,
                      'omeEdges': eta_ome.omeEdges,
                      'planeData_args': args,
-                     'planeData_hkls': hkls}
+                     'planeData_hkls': hkls,
+                     'planeData_excl': eta_ome.planeData.exclusions}
         np.savez_compressed(filename, **save_dict)
     pass  # end of class: EtaOmeMaps
 


### PR DESCRIPTION
This closes #452 and cleans up the yaml config for far-field HEDM.

- [x] Change `PlaneData.getHKL` to take an optional `hklID` args
- [x] Change `PlaneData.getHKLID` to optionally return reduced or master indices
- [x] Change `EtaOmeMaps.iHKLList` to reflect master `hklID`
- [x] Track down all uses of `EtaOmeMaps.iHKLList` and reconcile the update to master indices.

We will probably have to make accompanying changes in `hexrdgui` as well @psavery...

Fixes: #188