### PR TITLE
force cast imput to ndarray

### DIFF
--- a/hexrd/distortion/ge_41rt.py
+++ b/hexrd/distortion/ge_41rt.py
@@ -210,6 +210,7 @@ class GE_41RT(DistortionABC, metaclass=_RegisterDistortionClass):
         if self.is_trivial:
             return xy_in
         else:
+            xy_in = np.asarray(xy_in, dtype=float)
             xy_out = np.empty_like(xy_in)
             _ge_41rt_distortion(
                 xy_out, xy_in, float(RHO_MAX), np.asarray(self.params)
@@ -220,6 +221,7 @@ class GE_41RT(DistortionABC, metaclass=_RegisterDistortionClass):
         if self.is_trivial:
             return xy_in
         else:
+            xy_in = np.asarray(xy_in, dtype=float)
             xy_out = np.empty_like(xy_in)
             _ge_41rt_inverse_distortion(
                 xy_out, xy_in, float(RHO_MAX), np.asarray(self.params)


### PR DESCRIPTION
Got a weird error in the GUI when running repeated "Fast Powder" calibrations with the GE distortion function enabled.
![image](https://user-images.githubusercontent.com/1154130/183331526-8345d704-1995-471c-8a38-a19ce33a6594.png)

When I turned off the Numba implementation to debug, I got an error indicating that the input coordinates were coming in as a `list` rather than a `numpy.ndarray`.  Force-casting the input seems to have solved the problem.

@psavery -- strange I was only getting this in the GUI, specifically when running the cal more than once in the same session.  I suppose the overlay plotting uses the distortion when active too?