### PR TITLE
Bump pinned numpy version to 1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<1.22", "setuptools_scm[toml]"]
+requires = ["setuptools", "wheel", "numpy<1.23", "setuptools_scm[toml]"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_reqs = [
     'h5py',
     'lmfit',
     'numba',
-    'numpy<1.22',
+    'numpy<1.23',
     'psutil',
     'pycifrw',
     'pyyaml',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_reqs = [
     'h5py',
     'lmfit',
     'numba',
-    'numpy<1.23',
+    'numpy<1.23',  # NOTE: bump this to support the latest version numba supports
     'psutil',
     'pycifrw',
     'pyyaml',


### PR DESCRIPTION
The latest numba supports numpy 1.22, so allow that version.

When numba releases 0.56.1, numpy 1.23 will be supported as well.