### PR TITLE
Guard against unicode when saving HDF5 imageseries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,15 +43,17 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Checkout HEXRD
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: hexrd
 
     - name: Checkout examples
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: HEXRD/examples
         path: examples
+        # Note: to be removed once hexrd/hexrd#454 is merged
+        ref: be1efb5664058731368ab425ccab375fcb7bcd13
 
     - name: Set environment variable to work around setuptools/numpy issue
       run: echo 'SETUPTOOLS_USE_DISTUTILS=stdlib' >> $GITHUB_ENV

--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -128,6 +128,10 @@ class WriteH5(Writer):
 
         # add metadata
         for k, v in list(self._meta.items()):
+            if np.issubdtype(v.dtype, 'U'):
+                # HDF5 can't handle unicode strings. Turn it into a regular string.
+                v = v.astype('S')
+
             g.attrs[k] = v
 
     @property

--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -129,7 +129,8 @@ class WriteH5(Writer):
         # add metadata
         for k, v in list(self._meta.items()):
             if np.issubdtype(v.dtype, 'U'):
-                # HDF5 can't handle unicode strings. Turn it into a regular string.
+                # HDF5 can't handle unicode strings.
+                # Turn it into a regular string.
                 v = v.astype('S')
 
             g.attrs[k] = v


### PR DESCRIPTION
When writing out the [multiruby dexelas](https://github.com/HEXRD/examples/tree/master/NIST_ruby/multiruby_dexelas) example imageseries in hexrdgui after
performing aggregation, I would encounter the following error:

```
TypeError: No conversion path for dtype: dtype('<U3')
```

It appears that some of the metadata being saved as HDF5 attributes
was a unicode string. Specifically, for this case, it appears that the
`panel_id` key had a unicode `ff1` value.

Converting to a regular string fixes the issue.

I don't know why the panel ID came out to have a unicode value, but
we can guard against it and convert it into a regular string.