### PR TITLE
WPPF -- Rietveld fixes

### DIFF
--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -335,7 +335,7 @@ class LeBail:
             self.hkls[p] = {}
             self.dsp[p] = {}
             for k, l in self.phases.wavelength.items():
-                t = self.phases[p].getTTh(l[0].value)
+                t = self.phases[p].getTTh(l[0].getVal('nm'))
                 allowed = self.phases[p].wavelength_allowed_hkls
                 t = t[allowed]
                 hkl = self.phases[p].hkls[allowed, :]
@@ -1768,7 +1768,7 @@ class Rietveld:
             self.limit[p] = {}
 
             for k, l in self.phases.wavelength.items():
-                t = self.phases[p][k].getTTh(l[0].value)
+                t = self.phases[p][k].getTTh(l[0].getVal('nm'))
                 allowed = self.phases[p][k].wavelength_allowed_hkls
                 t = t[allowed]
                 hkl = self.phases[p][k].hkls[allowed, :]
@@ -1824,7 +1824,7 @@ class Rietveld:
                     (1 + Ph * np.cos(t) ** 2)
                     / np.cos(0.5 * t)
                     / np.sin(0.5 * t) ** 2
-                    / (2.0 * (1 + Ph))
+                    #/ (2.0 * (1 + Ph))
                 )
 
     def computespectrum(self):
@@ -2542,7 +2542,7 @@ class Rietveld:
                             * constants.cPlanck
                             * constants.cLight
                             / constants.cCharge
-                            / v[0].value
+                            / v[0].getVal('nm')
                         )
                         phase_info.beamEnergy = valWUnit(
                             "kev", "ENERGY", E, "keV"
@@ -2563,7 +2563,7 @@ class Rietveld:
                                 * constants.cPlanck
                                 * constants.cLight
                                 / constants.cCharge
-                                / v[0].value
+                                / v[0].getVal('nm')
                             )
                             mat.beamEnergy = valWUnit(
                                 "kev", "ENERGY", E, "keV"

--- a/hexrd/wppf/phase.py
+++ b/hexrd/wppf/phase.py
@@ -665,6 +665,9 @@ class Material_Rietveld:
         # name
         self.name = material_obj.name
 
+        # inverse of absorption length
+        self.abs_fact = 1e-4 * (1./material_obj.absorption_length)
+
         # min d-spacing for sampling hkl
         self.dmin = material_obj.dmin
 
@@ -1371,7 +1374,7 @@ class Phases_Rietveld:
         self[material_key] = {}
         self.num_phases += 1
         for l in self.wavelength:
-            lam = self.wavelength[l][0].value * 1e-9
+            lam = self.wavelength[l][0].getVal('nm') * 1e-9
             E = constants.cPlanck * constants.cLight / constants.cCharge / lam
             E *= 1e-3
             kev = valWUnit('beamenergy', 'energy', E, 'keV')
@@ -1388,7 +1391,7 @@ class Phases_Rietveld:
             self[k] = {}
             self.num_phases += 1
             for l in self.wavelength:
-                lam = self.wavelength[l][0].value * 1e-9
+                lam = self.wavelength[l][0].getVal('nm') * 1e-9
                 E = constants.cPlanck * constants.cLight / \
                     constants.cCharge / lam
                 E *= 1e-3

--- a/hexrd/wppf/xtal.py
+++ b/hexrd/wppf/xtal.py
@@ -155,8 +155,8 @@ def _calcxrsf(hkls,
         struct_factors_raw[ii] = np.abs(sf)**2
         struct_factors[ii] = w_int*mm*struct_factors_raw[ii]
 
-    ma = struct_factors.max()
-    struct_factors = 100.0*struct_factors/ma
+    # ma = struct_factors.max()
+    # struct_factors = 100.0*struct_factors/ma
     # ma = struct_factors_raw.max()
     # struct_factors_raw = 100.0*struct_factors_raw/ma
     return struct_factors, struct_factors_raw
@@ -181,8 +181,8 @@ def _calc_laue_factor(x,tth):
     if x <= 1.:
       El = (1.-0.5*x+0.25*x**2-(5./48.)*x**3+(7./192.)*x**4)
     elif x > 1.:
-      El = (2./np.pi/x)**2 * (1.-0.125*x**2-(3./128.)*x**2-\
-            (15./1024.)*x**3)
+      El = (2./np.pi/x)**2 * (1.-(1/8./x)-(3./128.)*(1./x)**2-\
+            (15./1024.)*(1/x)**3)
     return El*ctth
 
 @numba_njit_if_available(cache=True, nogil=True, parallel=True)


### PR DESCRIPTION
Fixing issue https://github.com/HEXRD/hexrdgui/issues/1296

1. Always convert wavelength to nm.
2. Modify the polarization factor for transmission geometry
3. Remove normalization of structure factor for best Rietveld results.