### PR TITLE
tolerancing for detecting binary rotation was failing

### DIFF
--- a/hexrd/rotations.py
+++ b/hexrd/rotations.py
@@ -782,7 +782,7 @@ def angleAxisOfRotMat(R):
     #  *   near pi   -- binary rotation; need to find axis
     #  *   neither   -- general case; can use skew part
     #
-    tol = cnst.ten_epsf
+    tol = cnst.sqrt_epsf
 
     anear0 = angle < tol
 
@@ -795,7 +795,8 @@ def angleAxisOfRotMat(R):
     )
     raxis[:, anear0] = 1.
 
-    special = angle > pi - tol  # !!! see above
+    special = abs(angle - pi) < 1e-6  # !!! see above
+
     nspec = special.sum()
     if nspec > 0:
 

--- a/hexrd/rotations.py
+++ b/hexrd/rotations.py
@@ -782,9 +782,9 @@ def angleAxisOfRotMat(R):
     #  *   near pi   -- binary rotation; need to find axis
     #  *   neither   -- general case; can use skew part
     #
-    tol = cnst.sqrt_epsf
+    tol = 1e-6  # !!! ~1e-12 in cosine(angle); cnst.sqrt_epsf too tight
 
-    anear0 = angle < tol
+    anear0 = abs(angle) < tol
 
     angle[anear0] = 0.
 
@@ -795,7 +795,7 @@ def angleAxisOfRotMat(R):
     )
     raxis[:, anear0] = 1.
 
-    special = abs(angle - pi) < 1e-6  # !!! see above
+    special = abs(angle - pi) < tol  # !!! see above
 
     nspec = special.sum()
     if nspec > 0:


### PR DESCRIPTION
I ran into a case really close (angle was within ~2e-8 of pi) to a binary rotation that was not triggering the special axis calculation in `rotations.angleAxisOfRotMat`.  I adjusted the tolerance, but it could use a closer look @donald-e-boyce.

Two questions:

1. is the case of small angle sufficiently handled so as not to clobber rotations for which the axis is still calculable?
2. is the tolerance of 1e-6 the best choice for detecting the binary rotation?  Using 1e-8 wasn't quite working...

We really need unit tests for the rotations module...