### PR TITLE
angle units change

### DIFF
--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -1738,7 +1738,7 @@ def getFriedelPair(tth0, eta0, *ome0, **kwargs):
     eta_min = np.nan * np.ones_like(ome_min)
 
     # mark feasible reflections
-    goodOnes = -np.isnan(ome_min)
+    goodOnes = ~np.isnan(ome_min)
 
     numGood = np.sum(goodOnes)
     tmp_eta = np.empty(numGood)

--- a/hexrd/xrdutil/utils.py
+++ b/hexrd/xrdutil/utils.py
@@ -440,6 +440,12 @@ class SphericalView(object):
         paxf = PiecewiseAffineTransform()
 
         img = np.array(pimg['intensities'])
+
+        # remove SNIP bg if there
+        if 'snip_background' in pimg:
+            # !!! these are float64 so we should be good
+            img -= np.array(pimg['snip_background'])
+
         nrows_in, ncols_in = img.shape
 
         tth_cen = np.array(pimg['tth_coordinates'])[0, :]
@@ -451,11 +457,11 @@ class SphericalView(object):
                              np.arange(nrows_in)[::skip])
         op = np.zeros_like(tp.flatten())
 
-        angs = np.vstack(
-            [tp.flatten(),
-             ep.flatten(),
-             op.flatten()]
-        ).T
+        angs = np.radians(
+            np.vstack([tp.flatten(),
+                       ep.flatten(),
+                       op.flatten()]).T
+        )
 
         ppts = zproject_sph_angles(
             angs, method='stereographic', source='d', invert_z=self.invert_z,


### PR DESCRIPTION
The polar view output format from `hexrdgui` has angles for the 2θ and η coordinates; had to update `SphericalView.warp_polar_image` to be compatible.