### PR TITLE
Add Rygg pinhole to phutil

### DIFF
--- a/hexrd/utils/decorators.py
+++ b/hexrd/utils/decorators.py
@@ -132,3 +132,10 @@ def numba_njit_if_available(func=None, *args, **kwargs):
         return decorator
     else:
         return decorator(func)
+
+
+# Also expose prange depending on whether we have numba or not
+if USE_NUMBA:
+    from numba import prange
+else:
+    prange = range

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -748,6 +748,10 @@ def tth_corr_rygg_pinhole(panel, material, xy_pts,
         panel, material, nom_tth, nom_eta, pinhole_thickness,
         pinhole_radius, num_phi_elements, clip_to_panel=False)
 
+    # Make the distortion shift to the left instead of the right
+    # FIXME: why is qq_p shifting the data to the right instead of the left?
+    qq_p = nom_tth - (qq_p - nom_tth)
+
     angs = np.vstack([qq_p, nom_eta]).T
     new_xy_pts = panel.angles_to_cart(angs)
     # Clip these to the panel now
@@ -770,7 +774,7 @@ def tth_corr_map_rygg_pinhole(instrument, material, pinhole_thickness,
         qq_p = calc_tth_rygg_pinhole(
             panel, material, nom_ptth, nom_peta, pinhole_thickness,
             pinhole_radius, num_phi_elements)
-        tth_corr[det_key] = qq_p - nom_ptth
+        tth_corr[det_key] = nom_ptth - qq_p
     return tth_corr
 
 
@@ -778,5 +782,5 @@ def polar_tth_corr_map_rygg_pinhole(tth, eta, instrument, material, pinhole_thic
                                     pinhole_radius, num_phi_elements=60):
     """Generate a polar tth corr map directly for all panels"""
     panels = list(instrument.detectors.values())
-    return tth - calc_tth_rygg_pinhole(panels, material, tth, eta, pinhole_thickness,
-                                       pinhole_radius, num_phi_elements)
+    return calc_tth_rygg_pinhole(panels, material, tth, eta, pinhole_thickness,
+                                 pinhole_radius, num_phi_elements) - tth

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -10,13 +10,13 @@ import copy
 import numpy as np
 
 from hexrd import constants as ct
-from hexrd.instrument import PlanarDetector
+from hexrd.instrument import calc_angles_from_beam_vec, PlanarDetector
 from hexrd.transforms import xfcapi
 
 detector_classes = (PlanarDetector, )
 
 
-class SampleLayerDistortion(object):
+class SampleLayerDistortion:
     def __init__(self, detector,
                  layer_standoff, layer_thickness,
                  pinhole_thickness, source_distance):
@@ -77,7 +77,7 @@ class SampleLayerDistortion(object):
                                      return_nominal=return_nominal)
 
 
-class PinholeDistortion(object):
+class PinholeDistortion:
     def __init__(self, detector,
                  pinhole_thickness, pinhole_radius):
         self._detector = detector
@@ -116,6 +116,21 @@ class PinholeDistortion(object):
         return tth_corr_pinhole(self.detector, xy_pts,
                                 self.ph_thickness, self.ph_radius,
                                 return_nominal=return_nominal)
+
+
+class RyggPinholeDistortion:
+    def __init__(self, detector, material,
+                 pinhole_thickness, pinhole_radius, num_phi_elements=240):
+
+        self.detector = detector
+        self.material = material
+        self.ph_thickness = pinhole_thickness
+        self.ph_radius = pinhole_radius
+
+    def apply(self, xy_pts, return_nominal=True):
+        return tth_corr_rygg_pinhole(self.detector, self.material, xy_pts,
+                                     self.ph_thickness, self.ph_radius,
+                                     return_nominal=return_nominal)
 
 
 def tth_corr_sample_layer(detector, xy_pts,
@@ -348,4 +363,201 @@ def tth_corr_map_pinhole(instrument, pinhole_thickness, pinhole_radius):
                 etaVec=instrument.eta_vector)
             new_ptth[i] = angs[0]
         tth_corr[det_key] = new_ptth.reshape(det.shape) - nom_ptth
+    return tth_corr
+
+
+def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
+                          pinhole_radius, num_phi_elements=240):
+    """Return pinhole twotheta [rad] and effective scattering volume [mm3].
+
+    num_phi_elements: number of pinhole phi elements for integration
+    """
+    # Make sure these are at least 2D
+    original_shape = tth.shape
+    tth = np.atleast_2d(tth)
+    eta = np.atleast_2d(eta)
+
+    # ------ Determine geometric parameters ------
+
+    # distance of xray source from origin (i. e., center of pinhole) [mm]
+    r_x = panel.xrs_dist
+
+    # Get our version of these beam angles
+    # !!! these are in degrees. Theirs are in radians.
+    azim, pola = calc_angles_from_beam_vec(panel.bvec)
+
+    # zenith angle of the x-ray source from (negative) pinhole axis
+    alpha = np.arccos(np.dot(panel.bvec, [0, 0, -1]))
+
+    # azimuthal angle of the x-ray source around the pinhole axis
+    # FIXME: hardcoded to 0 for now
+    phi_x = 0
+    # phi_x = np.radians(azim)
+
+    # pinhole substrate thickness [mm]
+    h_p = pinhole_thickness
+
+    # pinhole aperture diameter [mm]
+    d_p = pinhole_radius * 2
+
+    # mu_p is the attenuation coefficent [um^-1]
+    # This is the inverse of the absorption length, which is in [um]
+    mu_p = 1 / material.absorption_length
+    mu_p = 1000 * mu_p  # convert to [mm^-1]
+
+    # Convert tth and eta to phi_d, beta, and r_d
+    dvec_arg = np.vstack((tth.flatten(), eta.flatten(),
+                          np.zeros(np.prod(eta.shape))))
+    dvectors = xfcapi.anglesToDVec(dvec_arg.T, panel.bvec)
+
+    phi_d = np.mod(np.arctan2(dvectors[:, 1], dvectors[:, 0]) + 1.5 * np.pi,
+                   2 * np.pi).reshape(tth.shape)
+    beta = np.arccos(np.dot(dvectors, [0, 0, -1])).reshape(tth.shape)
+
+    # Compute r_d
+    # We will first convert to Cartesian, then clip to the panel, add the
+    # extra Z dimension, apply the rotation matrix, add the tvec, and then
+    # compute the distance.
+    angles_full = np.stack((tth, eta)).reshape((2, np.prod(tth.shape))).T
+    cart = panel.angles_to_cart(angles_full)
+    _, on_panel = panel.clip_to_panel(cart)
+    cart[~on_panel] = np.nan
+    cart = cart.T.reshape((2, *tth.shape))
+    full_cart = np.stack((cart[0], cart[1], np.zeros(tth.shape)))
+    flat_coords = full_cart.reshape((3, np.prod(tth.shape)))
+    rotated = panel.rmat.dot(flat_coords).reshape(full_cart.shape).T
+    full_vector = panel.tvec + rotated
+    r_d = np.sqrt(np.sum((full_vector)**2, axis=2)).T
+
+    # Store the nan values so we can use them again later
+    is_nan = np.isnan(r_d)
+
+    # reshape so D grids are on axes indices 2 and 3 [1 x 1 x Nu x Nv]
+    r_d = np.atleast_2d(r_d)[None, None, :, :]
+    beta = np.atleast_2d(beta)[None, None, :, :]
+    phi_d = np.atleast_2d(phi_d)[None, None, :, :]
+
+    Np = num_phi_elements
+
+    # ------ define pinhole grid ------
+    # approximately square pinhole surface elements
+    Nz = max(3, int(Np * h_p / (np.pi * d_p)))
+    dphi = 2 * np.pi / Np  # [rad] phi interval
+    dl = d_p * dphi  # [mm] azimuthal distance increment
+    dz = h_p / Nz  # [mm] axial distance increment
+    dA = dz * dl  # [mm^2] area element
+    dV_s = dA * mu_p**-1  # [mm^3] volume of surface element
+    dV_e = dl * mu_p**-2  # [mm^3] volume of edge element
+
+    phi_vec = np.arange(dphi / 2, 2 * np.pi, dphi)
+    # includes elements for X and D edges
+    z_vec = np.arange(-h_p/2 - dz/2, h_p/2 + dz/1.999, dz)
+    z_vec[0] = -h_p/2  # X-side edge (negative z)
+    z_vec[-1] = h_p/2  # D-side edge (positive z)
+    phi_i, z_i = np.meshgrid(phi_vec, z_vec)  # [Nz x Np]
+    phi_i = phi_i[:, :, None, None]    # [Nz x Np x 1 x 1]
+    z_i = z_i[:, :, None, None]      # axes 0,1 => P; axes 2,3 => D
+
+    # ------ calculate twotheta_i [a.k.a. qq_i], for each grid element ------
+    bx, bd = (d_p / (2 * r_x),  d_p / (2 * r_d))
+    sin_a, cos_a, tan_a = np.sin(alpha), np.cos(alpha), np.tan(alpha)
+    sin_b, cos_b, tan_b = np.sin(beta),  np.cos(beta),  np.tan(beta)
+    sin_phii, cos_phii = np.sin(phi_i), np.cos(phi_i)
+    cos_dphi_x = np.cos(phi_i - phi_x + np.pi)  # [Nz x Np x Nu x Nv]
+    cos_dphi_d = np.cos(phi_i - phi_d + np.pi)
+
+    alpha_i = np.arctan2(np.sqrt(sin_a**2 + 2*bx*sin_a*cos_dphi_x + bx**2),
+                         cos_a + z_i/r_x)
+    beta_i = np.arctan2(np.sqrt(sin_b**2 + 2*bd*sin_b*cos_dphi_d + bd**2),
+                        cos_b - z_i/r_d)
+    phi_xi = np.arctan2(sin_a * np.sin(phi_x) - bx*sin_phii,
+                        sin_a * np.cos(phi_x) - bx * cos_phii)
+    phi_di = np.arctan2(sin_b * np.sin(phi_d) - bd*sin_phii,
+                        sin_b * np.cos(phi_d) - bd * cos_phii)
+
+    arg = (np.cos(alpha_i) * np.cos(beta_i) - np.sin(alpha_i) *
+           np.sin(beta_i) * np.cos(phi_di - phi_xi))
+    # scattering angle for each P to each D
+    qq_i = np.arccos(np.clip(arg, -1, 1))
+
+    # ------ calculate effective volumes: 1 (surface), 2 (Xedge), 3 (Dedge) ---
+    sec_psi_x = 1 / (sin_a * cos_dphi_x)
+    sec_psi_d = 1 / (sin_b * cos_dphi_d)
+    sec_alpha = 1 / cos_a
+    sec_beta = 1 / cos_b
+    tan_eta_x = np.where(cos_dphi_x[0] <= 0, 0, cos_a * cos_dphi_x[0])
+    tan_eta_d = np.where(cos_dphi_d[-1] <= 0, 0, cos_b * cos_dphi_d[-1])
+
+    V_i = dV_s / (sec_psi_x + sec_psi_d)  # [mm^3]
+    # X-side edge (z = -h_p / 2)
+    V_i[0] = dV_e / (sec_psi_d[0] * (sec_alpha + sec_psi_d[0] * tan_eta_x))
+    # D-side edge (z = +h_p / 2)
+    V_i[-1] = dV_e / (sec_psi_x[-1] * (sec_beta + sec_psi_x[-1] * tan_eta_d))
+
+    # ------ visibility of each grid element ------
+    # pinhole surface
+    is_seen = np.logical_and(z_i > h_p/2 - d_p/tan_b * cos_dphi_d,
+                             z_i < -h_p/2 + d_p/tan_a * cos_dphi_x)
+    # X-side edge
+    is_seen[0] = np.where(h_p/d_p * tan_b < cos_dphi_d[0], 1, 0)
+    # D-side edge
+    is_seen[-1] = np.where(h_p/d_p * tan_a < cos_dphi_x[-1], 1, 0)
+
+    # ------ weighted sum over elements to obtain average ------
+    V_i *= is_seen  # zero weight to elements with no view of both X and D
+    V_p = np.nansum(V_i, axis=(0, 1))  # [Nu x Nv] <= detector
+    qq_p = np.nansum(V_i * qq_i, axis=(0, 1)) / V_p  # [Nu x Nv] <= detector
+
+    # Set the nan values back to nan so it is clear they were not computed
+    qq_p[is_nan] = np.nan
+
+    return qq_p.reshape(original_shape)
+
+
+def tth_corr_rygg_pinhole(panel, material, xy_pts,
+                          pinhole_thickness, pinhole_radius,
+                          return_nominal=True, num_phi_elements=240):
+    # FIXME: Joel did this for the other function. Do we need to?
+    # cp_det = copy.deepcopy(panel)
+    # cp_det.bvec = ct.beam_vec  # !!! [0, 0, -1]
+    # ref_angs, _ = cp_det.cart_to_angles(
+    #     xy_pts,
+    #     rmat_s=None, tvec_s=None,
+    #     tvec_c=None, apply_distortion=True
+    # )
+    # ref_eta = ref_angs[:, 1]
+
+    # These are the nominal tth values
+    nom_angs, _ = panel.cart_to_angles(
+        xy_pts,
+        rmat_s=None, tvec_s=None,
+        tvec_c=None, apply_distortion=True
+    )
+    nom_tth, nom_eta = nom_angs[:, :2].T
+
+    qq_p = calc_tth_rygg_pinhole(
+        panel, material, nom_tth, nom_eta, pinhole_thickness,
+        pinhole_radius, num_phi_elements)
+
+    tth_corr = qq_p - nom_tth
+    if return_nominal:
+        return np.vstack([nom_tth - tth_corr, nom_angs[:, 1]]).T
+    else:
+        # !!! NEED TO CHECK THIS
+        return np.vstack([-tth_corr, nom_angs[:, 1]]).T
+
+
+def tth_corr_map_rygg_pinhole(instrument, material, pinhole_thickness,
+                              pinhole_radius, num_phi_elements=240):
+    # FIXME: Joel did this for the other function. Do we need to?
+    # cp_instr = copy.deepcopy(instrument)
+    # cp_instr.beam_vector = ct.beam_vec  # !!! [0, 0, -1]
+
+    tth_corr = {}
+    for det_key, panel in instrument.detectors.items():
+        nom_ptth, nom_peta = panel.pixel_angles()
+        qq_p = calc_tth_rygg_pinhole(
+            panel, material, nom_ptth, nom_peta, pinhole_thickness,
+            pinhole_radius, num_phi_elements)
+        tth_corr[det_key] = qq_p - nom_ptth
     return tth_corr

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -125,7 +125,7 @@ class PinholeDistortion:
 
 class RyggPinholeDistortion:
     def __init__(self, detector, material,
-                 pinhole_thickness, pinhole_radius, num_phi_elements=120):
+                 pinhole_thickness, pinhole_radius, num_phi_elements=60):
 
         self.detector = detector
         self.material = material
@@ -453,7 +453,7 @@ def _infer_eta_shift(panel):
 
 
 def calc_tth_rygg_pinhole(panels, material, tth, eta, pinhole_thickness,
-                          pinhole_radius, num_phi_elements=120,
+                          pinhole_radius, num_phi_elements=60,
                           clip_to_panel=True):
     """Return pinhole twotheta [rad] and effective scattering volume [mm3].
 
@@ -734,7 +734,7 @@ _compute_vi_qq_i_numba = numba_njit_if_available(nogil=True, cache=True)(_comput
 
 def tth_corr_rygg_pinhole(panel, material, xy_pts,
                           pinhole_thickness, pinhole_radius,
-                          return_nominal=True, num_phi_elements=120):
+                          return_nominal=True, num_phi_elements=60):
     # Clip these to the panel now
     _, on_panel = panel.clip_to_panel(xy_pts)
     xy_pts[~on_panel] = np.nan
@@ -760,7 +760,7 @@ def tth_corr_rygg_pinhole(panel, material, xy_pts,
 
 
 def tth_corr_map_rygg_pinhole(instrument, material, pinhole_thickness,
-                              pinhole_radius, num_phi_elements=120):
+                              pinhole_radius, num_phi_elements=60):
     tth_corr = {}
     for det_key, panel in instrument.detectors.items():
         nom_ptth, nom_peta = panel.pixel_angles()
@@ -772,7 +772,7 @@ def tth_corr_map_rygg_pinhole(instrument, material, pinhole_thickness,
 
 
 def polar_tth_corr_map_rygg_pinhole(tth, eta, instrument, material, pinhole_thickness,
-                                    pinhole_radius, num_phi_elements=120):
+                                    pinhole_radius, num_phi_elements=60):
     """Generate a polar tth corr map directly for all panels"""
     panels = list(instrument.detectors.values())
     return tth - calc_tth_rygg_pinhole(panels, material, tth, eta, pinhole_thickness,

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -761,8 +761,7 @@ def tth_corr_rygg_pinhole(panel, material, xy_pts,
     if return_nominal:
         return angs
     else:
-        # !!! NEED TO CHECK THIS
-        angs[:, 0] = nom_tth - angs[:, 0]
+        angs[:, 0] -= nom_tth
         return angs
 
 

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -478,7 +478,16 @@ def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
     # extra Z dimension, apply the rotation matrix, add the tvec, and then
     # compute the distance.
     angles_full = np.stack((tth, eta)).reshape((2, np.prod(tth.shape))).T
-    cart = panel.angles_to_cart(angles_full)
+
+    try:
+        # Set the evec to eHat_l while converting to cartesian
+        # This is important so that the r_d values end up in the right spots
+        old_evec = panel.evec
+        panel.evec = eHat_l
+        cart = panel.angles_to_cart(angles_full)
+    finally:
+        panel.evec = old_evec
+
     _, on_panel = panel.clip_to_panel(cart)
     cart[~on_panel] = np.nan
     cart = cart.T.reshape((2, *tth.shape))

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -399,7 +399,6 @@ def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
     alpha = np.arccos(np.dot(panel.bvec, [0, 0, -1]))
 
     # azimuthal angle of the x-ray source around the pinhole axis
-    # FIXME: hardcoded to 0 for now
     phi_x = calc_phi_x(panel)
 
     # pinhole substrate thickness [mm]

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -120,17 +120,19 @@ class PinholeDistortion:
 
 class RyggPinholeDistortion:
     def __init__(self, detector, material,
-                 pinhole_thickness, pinhole_radius, num_phi_elements=240):
+                 pinhole_thickness, pinhole_radius, num_phi_elements=120):
 
         self.detector = detector
         self.material = material
         self.ph_thickness = pinhole_thickness
         self.ph_radius = pinhole_radius
+        self.num_phi_elements = num_phi_elements
 
     def apply(self, xy_pts, return_nominal=True):
         return tth_corr_rygg_pinhole(self.detector, self.material, xy_pts,
                                      self.ph_thickness, self.ph_radius,
-                                     return_nominal=return_nominal)
+                                     return_nominal=return_nominal,
+                                     num_phi_elements=self.num_phi_elements)
 
 
 def tth_corr_sample_layer(detector, xy_pts,
@@ -365,6 +367,7 @@ def tth_corr_map_pinhole(instrument, pinhole_thickness, pinhole_radius):
         tth_corr[det_key] = new_ptth.reshape(det.shape) - nom_ptth
     return tth_corr
 
+
 def calc_phi_x(panel):
     """
     returns phi_x in RADIANS
@@ -376,7 +379,7 @@ def calc_phi_x(panel):
 
 
 def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
-                          pinhole_radius, num_phi_elements=240):
+                          pinhole_radius, num_phi_elements=120):
     """Return pinhole twotheta [rad] and effective scattering volume [mm3].
 
     num_phi_elements: number of pinhole phi elements for integration
@@ -523,7 +526,7 @@ def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
 
 def tth_corr_rygg_pinhole(panel, material, xy_pts,
                           pinhole_thickness, pinhole_radius,
-                          return_nominal=True, num_phi_elements=240):
+                          return_nominal=True, num_phi_elements=120):
     # FIXME: Joel did this for the other function. Do we need to?
     # cp_det = copy.deepcopy(panel)
     # cp_det.bvec = ct.beam_vec  # !!! [0, 0, -1]
@@ -546,16 +549,15 @@ def tth_corr_rygg_pinhole(panel, material, xy_pts,
         panel, material, nom_tth, nom_eta, pinhole_thickness,
         pinhole_radius, num_phi_elements)
 
-    tth_corr = qq_p - nom_tth
     if return_nominal:
-        return np.vstack([nom_tth - tth_corr, nom_angs[:, 1]]).T
+        return np.vstack([qq_p, nom_angs[:, 1]]).T
     else:
         # !!! NEED TO CHECK THIS
-        return np.vstack([-tth_corr, nom_angs[:, 1]]).T
+        return np.vstack([nom_tth - qq_p, nom_angs[:, 1]]).T
 
 
 def tth_corr_map_rygg_pinhole(instrument, material, pinhole_thickness,
-                              pinhole_radius, num_phi_elements=240):
+                              pinhole_radius, num_phi_elements=120):
     # FIXME: Joel did this for the other function. Do we need to?
     # cp_instr = copy.deepcopy(instrument)
     # cp_instr.beam_vector = ct.beam_vec  # !!! [0, 0, -1]

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -365,6 +365,15 @@ def tth_corr_map_pinhole(instrument, pinhole_thickness, pinhole_radius):
         tth_corr[det_key] = new_ptth.reshape(det.shape) - nom_ptth
     return tth_corr
 
+def calc_phi_x(panel):
+    """
+    returns phi_x in RADIANS
+    """
+    bv = panel.bvec.copy()
+    bv[2] = 0.
+    bv = bv/np.linalg.norm(bv)
+    return np.arccos(np.dot(bv, [0, -1, 0]))
+
 
 def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
                           pinhole_radius, num_phi_elements=240):
@@ -391,8 +400,7 @@ def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
 
     # azimuthal angle of the x-ray source around the pinhole axis
     # FIXME: hardcoded to 0 for now
-    phi_x = 0
-    # phi_x = np.radians(azim)
+    phi_x = calc_phi_x(panel)
 
     # pinhole substrate thickness [mm]
     h_p = pinhole_thickness

--- a/hexrd/xrdutil/phutil.py
+++ b/hexrd/xrdutil/phutil.py
@@ -527,16 +527,6 @@ def calc_tth_rygg_pinhole(panel, material, tth, eta, pinhole_thickness,
 def tth_corr_rygg_pinhole(panel, material, xy_pts,
                           pinhole_thickness, pinhole_radius,
                           return_nominal=True, num_phi_elements=120):
-    # FIXME: Joel did this for the other function. Do we need to?
-    # cp_det = copy.deepcopy(panel)
-    # cp_det.bvec = ct.beam_vec  # !!! [0, 0, -1]
-    # ref_angs, _ = cp_det.cart_to_angles(
-    #     xy_pts,
-    #     rmat_s=None, tvec_s=None,
-    #     tvec_c=None, apply_distortion=True
-    # )
-    # ref_eta = ref_angs[:, 1]
-
     # These are the nominal tth values
     nom_angs, _ = panel.cart_to_angles(
         xy_pts,
@@ -558,10 +548,6 @@ def tth_corr_rygg_pinhole(panel, material, xy_pts,
 
 def tth_corr_map_rygg_pinhole(instrument, material, pinhole_thickness,
                               pinhole_radius, num_phi_elements=120):
-    # FIXME: Joel did this for the other function. Do we need to?
-    # cp_instr = copy.deepcopy(instrument)
-    # cp_instr.beam_vector = ct.beam_vec  # !!! [0, 0, -1]
-
     tth_corr = {}
     for det_key, panel in instrument.detectors.items():
         nom_ptth, nom_peta = panel.pixel_angles()


### PR DESCRIPTION
This follows [`calc_twotheta_pinhole()`](https://github.com/HEXRD/hexrd/blob/cb7bbaa341d07596754f3b55435f17654f89e288/scripts/pinhole_2theta.py#L176), but assembles the inputs from the hexrd classes.

~~Once we have two versions of this function: one that takes arbitrary xys and calculates the tth distortion for them, and one that outputs a tth distortion correlation map for all detector pixels, it will be easy to integrate into hexrdgui.~~

~~The function is not complete - we do not yet have the pixel positions in spherical coordinates.~~

~~This function is now working, but the results are not correct. We need to review the inputs to ensure they are being converted properly.~~

This now appears to be working exactly as it should!

The only thing left is to look into improving performance, which may be done on a separate PR.

To fix:
- [x] Shift for both overlays and polar field appear to be going in the wrong directions