### PR TITLE
Ignore anomalous scattering factors for Z > 92

### DIFF
--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -578,7 +578,7 @@ class Material(object):
                 if x:
                     try:
                         U[ii] = float(U[ii])
-                    except:
+                    except ValueError:
                         U[ii] = self.DFLT_U[0]
 
             self._U = numpy.asarray(U)

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -554,7 +554,7 @@ class Material(object):
             msg = (f"'Debye-Waller factors not present. "
                    f"setting to same values for all atoms.'")
             warn(msg)
-            U = 1.0/numpy.pi/2./numpy.sqrt(2.) * numpy.ones(atompos[0].shape)
+            U = self.DFLT_U[0] * numpy.ones(atompos[0].shape)
             self._U = U
         else:
             if(occ_U[1] in cifdata.keys()):
@@ -576,7 +576,10 @@ class Material(object):
 
             for ii, x in enumerate(chkstr):
                 if x:
-                    U[ii] = 1.0/numpy.pi/2./numpy.sqrt(2.)
+                    try:
+                        U[ii] = float(U[ii])
+                    except:
+                        U[ii] = self.DFLT_U[0]
 
             self._U = numpy.asarray(U)
         '''

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -747,11 +747,20 @@ class unitcell:
 
                 Z = self.atom_type[i]
                 elem = constants.ptableinverse[Z]
-                gid = fid.get('/'+elem)
-                data = np.array(gid.get('data'))
-                self.pe_cs[elem] = interp1d(data[:, 7], data[:, 3])
-                data = data[:, [7, 1, 2]]
-                f_anomalous_data.append(data)
+
+                wav = np.linspace(1.16E2, 2.86399992e-03, 189)
+                zs = np.ones_like(wav)*Z
+                zrs = np.zeros_like(wav)
+                data_zs = np.vstack((wav, zs, zrs)).T
+                if Z <= 92:
+                    gid = fid.get('/'+elem)
+                    data = np.array(gid.get('data'))
+                    self.pe_cs[elem] = interp1d(data[:, 7], data[:, 3])
+                    data = data[:, [7, 1, 2]]
+                    f_anomalous_data.append(data)
+                else:
+                    self.pe_cs[elem] = interp1d(wav, zrs)
+                    f_anomalous_data.append(data_zs)
 
         n = max([x.shape[0] for x in f_anomalous_data])
         self.f_anomalous_data = np.zeros([self.atom_ntype, n, 3])
@@ -774,7 +783,7 @@ class unitcell:
             f2 = self.f2[elem](self.wavelength)
             frel = constants.frel[elem]
             Z = constants.ptable[elem]
-            self.f_anam[elem] = np.complex(f1+frel-Z, f2)
+            self.f_anam[elem] = complex(f1+frel-Z, f2)
 
     def CalcXRFormFactor(self, Z, charge, s):
         '''
@@ -846,8 +855,9 @@ class unitcell:
             Z = self.atom_type[i]
             elem = constants.ptableinverse[Z]
             scatfac[i, :] = constants.scatfac[elem]
-            frel[i] = constants.frel[elem]
-            fNT[i] = constants.fNT[elem]
+            if Z <= 92:
+                frel[i] = constants.frel[elem]
+                fNT[i] = constants.fNT[elem]
 
         sf, sf_raw = _calcxrsf(hkl2d,
                                nref,


### PR DESCRIPTION
As the title says. Ignores `f'`, `f"`, `fNT` and `frel` for atoms with Z > 92. Came up during analysis of alpha-Pu.