### PR TITLE
added npz file and namedtuple for grains output

### DIFF
--- a/hexrd/cli/find_orientations.py
+++ b/hexrd/cli/find_orientations.py
@@ -40,8 +40,8 @@ def configure_parser(sub_parsers):
     p.add_argument(
         '--hkls', metavar='HKLs', type=str, default=None,
         help="""\
-list hkl entries in the materials file to use for fitting
-if None, defaults to list specified in the yml file"""
+          list hkl entries in the materials file to use for fitting;
+          if None, defaults to list specified in the yml file"""
         )
     p.add_argument(
         '-p', '--profile', action='store_true',


### PR DESCRIPTION
This is just for convenience of the form of output of grains data. In addition to the `grains.out` file, this writes a `grains.npz` containing arrays for each field in the grains.out file. There is a namedtuple that carries the data that can be easily written to an npz file or read from an npz file. You can load a file like this:

```
from hexrd.fitgrains import GrainData
gd = GrainData.load("grains.npz")
```
The convenience is that all the data can be accessed by name, e.g. `gd.completeness` or `gd.centroids`.