### PR TITLE
fixing HKL reset problem in fitgrains

### DIFF
--- a/hexrd/cli/fit_grains.py
+++ b/hexrd/cli/fit_grains.py
@@ -188,6 +188,20 @@ def execute(args, parser):
                 )
             sys.exit()
 
+        # Set HKLs to use.
+        if cfg.fit_grains.tth_max is False:
+            cfg.material.plane_data.exclude(
+                sfacmin=cfg.material.fminr
+            )
+        else:
+            if cfg.fit_grains.tth_max is True:
+                max_tth = instrument.max_tth(cfg.instrument.hedm)
+            else:
+                max_tth = cfg.fit_grains.tth_max
+            cfg.material.plane_data.exclude(
+                sfacmin=cfg.material.fminr, tthmax=max_tth
+            )
+
         # make output directories
         instr = cfg.instrument.hedm
         if not os.path.exists(cfg.analysis_dir):

--- a/hexrd/cli/fit_grains.py
+++ b/hexrd/cli/fit_grains.py
@@ -197,7 +197,7 @@ def execute(args, parser):
             if cfg.fit_grains.tth_max is True:
                 max_tth = instrument.max_tth(cfg.instrument.hedm)
             else:
-                max_tth = cfg.fit_grains.tth_max
+                max_tth = np.radians(cfg.fit_grains.tth_max)
             cfg.material.plane_data.exclude(
                 sfacmin=cfg.material.fminr, tthmax=max_tth
             )

--- a/hexrd/config/__init__.py
+++ b/hexrd/config/__init__.py
@@ -3,7 +3,6 @@ import yaml
 from . import root
 from . import utils
 
-
 """
 Note that we need to use the open() builtin in what was formerly the "open()"
 function. So we define the _open(), and then redefine open() to the new
@@ -28,17 +27,18 @@ def open(file_name=None):
             try:
                 # take the previous config section and update with values
                 # from the current one
-                res.append(utils.merge_dicts(res[0], cfg))
+                res.append(utils.merge_dicts(res[-1], cfg))
             except IndexError:
                 # this is the first config section
                 res.append(cfg)
+
         return [root.RootConfig(i) for i in res]
 
 
 def save(config_list, file_name):
     res = [cfg._cfg for cfg in config_list]
 
-    with file(file_name, 'w') as f:
+    with open_file(file_name, 'w') as f:
         if len(res) > 1:
             yaml.dump_all(res, f)
         else:

--- a/hexrd/config/material.py
+++ b/hexrd/config/material.py
@@ -64,6 +64,15 @@ class MaterialConfig(Config):
 
     @property
     def plane_data(self):
+        """crystallographic information"""
+        #
+        # Only generate this once, not on each call.
+        #
+        if not hasattr(self, "_plane_data"):
+            self._plane_data = self._make_plane_data()
+        return self._plane_data
+
+    def _make_plane_data(self):
         """Return the active material PlaneData class."""
         pd = self.materials[self.active].planeData
         pd.tThWidth = np.radians(self.tthw)

--- a/hexrd/crystallography.py
+++ b/hexrd/crystallography.py
@@ -816,6 +816,73 @@ class PlaneData(object):
         return
     exclusions = property(get_exclusions, set_exclusions, None)
 
+    def exclude(
+            self, dmin=None, dmax=None, tthmin=None, tthmax=None,
+            sfacmin=None, sfacmax=None, pintmin=None, pintmax=None
+    ):
+        """Set exclusions according to various parameters
+
+        Any hkl with a value below any min or above any max will be excluded. So
+        to be included, an hkl needs to have values between the min and max
+        for all of the conditions given.
+
+        Note that method resets the tThMax attribute to None.
+
+        PARAMETERS
+        ----------
+        dmin: float > 0
+            minimum lattice spacing (angstroms)
+        dmax: float > 0
+            maximum lattice spacing (angstroms)
+        tthmin: float > 0
+            minimum two theta (radians)
+        tthmax: float > 0
+            maximum two theta (radians)
+        sfacmin: float > 0
+            minimum structure factor as a proportion of maximum
+        sfacmax: float > 0
+            maximum structure factor as a proportion of maximum
+        pintmin: float > 0
+            minimum powder intensity as a proportion of maximum
+        pintmax: float > 0
+            maximum powder intensity as a proportion of maximum
+        """
+        excl = np.zeros(self.getNhklRef(), dtype=bool)
+        self.exclusions = None
+        self.tThMax = None
+
+        if (dmin is not None) or (dmax is not None):
+            d = np.array(self.getPlaneSpacings())
+            if (dmin is not None):
+                excl[d < dmin] = True
+            if (dmax is not None):
+                excl[d > dmax] = True
+
+        if (tthmin is not None) or (tthmax is not None):
+            tth = self.getTTh()
+            if (tthmin is not None):
+                excl[tth < tthmin] = True
+            if (tthmax is not None):
+                excl[tth > tthmax] = True
+
+        if (sfacmin is not None) or (sfacmax is not None):
+            sfac = self.structFact
+            sfac = sfac/sfac.max()
+            if (sfacmin is not None):
+                excl[sfac < sfacmin] = True
+            if (sfacmax is not None):
+                excl[sfac > sfacmax] = True
+
+        if (pintmin is not None) or (pintmax is not None):
+            pint = self.powder_intensity
+            pint = pint/pint.max()
+            if (pintmin is not None):
+                excl[pint < pintmin] = True
+            if (pintmax is not None):
+                excl[pint > pintmax] = True
+
+        self.exclusions = excl
+
     def get_lparms(self):
         return self.__lparms
 

--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -313,26 +313,6 @@ def fit_grains(cfg,
     # grab instrument
     instr = cfg.instrument.hedm
 
-    # process plane data
-    plane_data = cfg.material.plane_data
-    tth_max = cfg.fit_grains.tth_max
-    if isinstance(tth_max, bool):
-        if tth_max:
-            max_tth = instrument.max_tth(instr)
-            plane_data.exclusions = None
-            plane_data.tThMax = max_tth
-            logger.info("\tsetting the maximum 2theta to instrument"
-                        + " maximum: %.2f degrees",
-                        np.degrees(max_tth))
-        else:
-            logger.info("\tnot adjusting exclusions in planeData")
-    else:
-        # a value for tth max has been specified
-        plane_data.exclusions = None
-        plane_data.tThMax = np.radians(tth_max)
-        logger.info("\tsetting the maximum 2theta to %.2f degrees",
-                    tth_max)
-
     # grab eta ranges and ome_period
     eta_ranges = np.radians(cfg.find_orientations.eta.range)
 
@@ -352,7 +332,7 @@ def fit_grains(cfg,
     spots_filename = "spots_%05d.out" if write_spots_files else None
     params = dict(
             grains_table=grains_table,
-            plane_data=plane_data,
+            plane_data=cfg.material.plane_data,
             instrument=instr,
             imgser_dict=imsd,
             tth_tol=cfg.fit_grains.tolerance.tth,


### PR DESCRIPTION
This fixes #512 . 

Changes include:

- A new `exclude()` method in PlaneData for selection of HKLs using min/max cutoff values for d-spacing, two theta, structure factor and powder intensity. See  [test_exclude.py](https://github.com/HEXRD/hexrd/files/11314214/test_exclude.py.txt) for a script for testing the exclude() method. I used the ruby material in the single_GE example.

- A simple fix for a problem in handling multiple configuration files (each subsequent config was merged with the first instead of being merged with the previous, as described; and the `save() `function was out of date.)
- Setting plane data exclusions in `cli.fit_grains` before the main fitting method is called instead of in `hexrd.fitgrains` inside the main fitting method. This was the main problem because it reset the HKLs inside the main call; this applies to the GUI as well as the CLI.
- Had the material config file process the plane data only once, instead of on each call.

To verify this, I ran a completeness study on the single_GE example, which I will post shortly.
