### PR TITLE
Remove duplicate Laue spots from simulator

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -1367,7 +1367,7 @@ class Detector:
 
             # Filter out g-vectors going in the wrong direction. `gvec_to_xy()` used
             # to do this, but not anymore.
-            to_keep = gvec_c[2] * self.bvec[2] <= 0
+            to_keep = np.dot(gvec_c.T, self.bvec) <= 0
 
             hkls = hkls[:, to_keep]
             gvec_c = gvec_c[:, to_keep]

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -1364,6 +1364,13 @@ class Detector:
 
             # and the unit plane normals (G-vectors) in CRYSTAL FRAME
             gvec_c = np.dot(plane_data.latVecOps['B'], hkls)
+
+            # Filter out g-vectors going in the wrong direction. `gvec_to_xy()` used
+            # to do this, but not anymore.
+            to_keep = gvec_c[2] * self.bvec[2] <= 0
+
+            hkls = hkls[:, to_keep]
+            gvec_c = gvec_c[:, to_keep]
         elif len(crystal_data) == 2:
             # !!! should clean this up
             hkls = np.array(crystal_data[0])


### PR DESCRIPTION
This issue arose from #509, due to somewhat complex details.

In short, the old `gvecToDetectorXY()` would filter out g-vectors going the wrong way (they would result in `nan`), but `gvecToDetectorXYArray()` would not.

The new `gvec_to_xy()` has behavior matching `gvecToDetectorXYArray()`. But that means that places where `gvecToDetectorXY()` used to be used, we need to verify that the function does not receive g-vectors going the wrong way.

Looking through the code, however, I only found one place where `gvecToDetectorXY()` used to receive g-vectors going the wrong way. It was the Laue overlay simulator, which would compute g-vectors from symmetrical HKLs (which is why it would have duplicate g-vectors going the wrong way).

All other cases where `gvecToDetectorXY()` was called would be after the g-vectors were computed from `anglesToGvec()`, which I believe should always produce g-vectors going in the correct direction.

As such, we only need to filter out wrong-direction g-vectors in the Laue simulator.

Fixes: hexrd/hexrdgui#1412