### PR TITLE
update test to use new data location in examples repo

### DIFF
--- a/tests/test_fit-grains.py
+++ b/tests/test_fit-grains.py
@@ -62,7 +62,7 @@ def grains_file_path(analysis_path):
 
 @pytest.fixture
 def grains_reference_file_path(single_ge_results_path):
-    return single_ge_results_path / 'RUBY_SWEEP_0' / 'grains.out'
+    return single_ge_results_path / 'ruby-b035e' / 'scan-0' / 'grains.out'
 
 
 @pytest.fixture


### PR DESCRIPTION
This updates tests following the HEXRD/examples#7, which changed the location of one of the data files.