### PR TITLE
handle the IP separations better.

### DIFF
--- a/hexrd/fitting/calibration.py
+++ b/hexrd/fitting/calibration.py
@@ -754,10 +754,30 @@ class StructureLessCalibrator:
             # their absolute values to get the difference.
             dist_plates = (np.abs(self.params['IMAGE_PLATE_2_tvec_y'])+
                            np.abs(self.params['IMAGE_PLATE_4_tvec_y']))
+            # if distance between plates exceeds a certain value, then cap it
+            # at the max/min value and adjust the value of tvec_ys
+            if dist_plates > 24.13:
+                delta = np.abs(dist_plates - 24.13)
+                dist_plates = 24.13
+                self.params['IMAGE_PLATE_2_tvec_y'].value = (
+                    self.params['IMAGE_PLATE_2_tvec_y'].value +
+                    0.5*delta)
+                self.params['IMAGE_PLATE_4_tvec_y'].value = (
+                    self.params['IMAGE_PLATE_4_tvec_y'].value -
+                    0.5*delta)
+            elif dist_plates < 22.13:
+                delta = np.abs(dist_plates - 22.13)
+                dist_plates = 22.13
+                self.params['IMAGE_PLATE_2_tvec_y'].value = (
+                    self.params['IMAGE_PLATE_2_tvec_y'].value -
+                    0.5*delta)
+                self.params['IMAGE_PLATE_4_tvec_y'].value = (
+                    self.params['IMAGE_PLATE_4_tvec_y'].value +
+                    0.5*delta)
             self.params.add('tardis_distance_between_plates',
                              value=dist_plates,
-                             min=dist_plates-0.5,
-                             max=dist_plates+0.5,
+                             min=22.13,
+                             max=24.13,
                              vary=True)
             expr = 'tardis_distance_between_plates - abs(IMAGE_PLATE_2_tvec_y)'
             self.params['IMAGE_PLATE_4_tvec_y'].expr = expr


### PR DESCRIPTION
Set the min and max to the absolute maximum allowed values. Handle the locations better if the separation falls outside this range.