### PR TITLE
Use latest lxml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,6 +23,9 @@ requirements:
   run:
     - appdirs
     - fabio >=0.11
+    # fabio uses lxml, and lxml 4.9.1 has some crashing issue on Windows
+    # so, make sure lxml >= 4.9.2 is being used
+    - lxml >=4.9.2
     - fast-histogram
     - h5py
     - lmfit


### PR DESCRIPTION
Fabio uses lxml (it is optional, but installing fabio installs it by default).

On Windows, lxml 4.9.1 is causing the application to crash silently. There are no errors - the application just crashes when fabio is imported.

We need to force it to use lxml 4.9.2 or greater to avoid this crash. We could alternatively just stop it from being installed as well if we run into more issues in the future.