### PR TITLE
Fix remaining deprecated numpy aliases

### DIFF
--- a/hexrd/transforms/xf.py
+++ b/hexrd/transforms/xf.py
@@ -799,7 +799,7 @@ def mapAngle(ang, *args, **kwargs):
         angRange = np.asarray(args[0], dtype=float)
 
         # divide of multiples of period
-        ang = ang - np.int(ang / period) * period
+        ang = ang - int(ang / period) * period
 
         lb = angRange.min()
         ub = angRange.max()

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -994,7 +994,7 @@ class unitcell:
         for g in hkllist:
             glen.append(np.round(self.CalcLength(g, 'r'), 8))
 
-        # glen = np.atleast_2d(np.array(glen,dtype=np.float)).T
+        # glen = np.atleast_2d(np.array(glen,dtype=float)).T
         dtype = [('glen', float), ('max', int), ('sum', int),
                  ('h', int), ('k', int), ('l', int)]
 

--- a/hexrd/wppf/LeBailCalibration.py
+++ b/hexrd/wppf/LeBailCalibration.py
@@ -790,8 +790,8 @@ class LeBailCalibrator:
                     """
                     for k in param_info:
                         v = param_info[k]
-                        params.add(k, value=np.float(v[0]),
-                                   min=np.float(v[1]), max=np.float(v[2]),
+                        params.add(k, value=float(v[0]),
+                                   min=float(v[1]), max=float(v[2]),
                                    vary=bool(v[3]))
 
                 elif(isinstance(param_info, str)):

--- a/hexrd/wppf/RietveldHEDM.py
+++ b/hexrd/wppf/RietveldHEDM.py
@@ -424,8 +424,8 @@ class RietveldHEDM:
                     """
                     for k in param_info:
                         v = param_info[k]
-                        params.add(k, value=np.float(v[0]),
-                                   min=np.float(v[1]), max=np.float(v[2]),
+                        params.add(k, value=float(v[0]),
+                                   min=float(v[1]), max=float(v[2]),
                                    vary=bool(v[3]))
 
                 elif(isinstance(param_info, str)):

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1228,9 +1228,9 @@ class LeBail:
                     for k, v in param_info.items():
                         params.add(
                             k,
-                            value=np.float(v[0]),
-                            lb=np.float(v[1]),
-                            ub=np.float(v[2]),
+                            value=float(v[0]),
+                            lb=float(v[1]),
+                            ub=float(v[2]),
                             vary=bool(v[3]),
                         )
 
@@ -2224,9 +2224,9 @@ class Rietveld:
                     for k, v in param_info.items():
                         params.add(
                             k,
-                            value=np.float(v[0]),
-                            lb=np.float(v[1]),
-                            ub=np.float(v[2]),
+                            value=float(v[0]),
+                            lb=float(v[1]),
+                            ub=float(v[2]),
                             vary=bool(v[3]),
                         )
 

--- a/hexrd/wppf/parameters.py
+++ b/hexrd/wppf/parameters.py
@@ -78,8 +78,8 @@ class Parameters:
 
         for k in dic.keys():
             v = dic[k]
-            self.add(k, value=np.float(v[0]), lb=np.float(v[1]),
-                     ub=np.float(v[2]), vary=bool(v[3]))
+            self.add(k, value=float(v[0]), lb=float(v[1]),
+                     ub=float(v[2]), vary=bool(v[3]))
 
     def dump(self, fname):
         """

--- a/hexrd/wppf/phase.py
+++ b/hexrd/wppf/phase.py
@@ -330,7 +330,7 @@ class Material_LeBail:
         glen = []
         for g in hkllist:
             glen.append(np.round(self.CalcLength(g, 'r'), 8))
-        # glen = np.atleast_2d(np.array(glen,dtype=np.float)).T
+        # glen = np.atleast_2d(np.array(glen,dtype=float)).T
         dtype = [('glen', float), ('max', int), ('sum', int),
                  ('h', int), ('k', int), ('l', int)]
         a = []
@@ -1039,7 +1039,7 @@ class Material_Rietveld:
         glen = []
         for g in hkllist:
             glen.append(np.round(self.CalcLength(g, 'r'), 8))
-        # glen = np.atleast_2d(np.array(glen,dtype=np.float)).T
+        # glen = np.atleast_2d(np.array(glen,dtype=float)).T
         dtype = [('glen', float), ('max', int), ('sum', int),
                  ('h', int), ('k', int), ('l', int)]
         a = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<1.24", "setuptools_scm[toml]"]
+requires = ["setuptools", "wheel", "numpy<1.25", "setuptools_scm[toml]"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_reqs = [
     'h5py',
     'lmfit',
     'numba',
-    'numpy<1.24',  # NOTE: bump this to support the latest version numba supports
+    'numpy<1.25',  # NOTE: bump this to support the latest version numba supports
     'psutil',
     'pycifrw',
     'pyyaml',

--- a/tests/test_find_orientations.py
+++ b/tests/test_find_orientations.py
@@ -80,7 +80,7 @@ def reference_orientations(reference_orientations_path):
 
 
 def plane_data(plane_data):
-    args = np.array(plane_data.getParams())[:4]
+    args = plane_data.getParams()[:4]
     hkls = plane_data.hkls
 
     return PlaneData(hkls, *args)


### PR DESCRIPTION
See [here](https://numpy.org/doc/stable/release/1.24.0-notes.html).

The list of deprecated aliases is:

```
np.object, np.bool, np.float, np.complex, np.str, and np.int
```

Fixes: #533