### PR TITLE
Fix memoization size updates for detectors

### DIFF
--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -215,11 +215,12 @@ class CylindricalDetector(Detector):
     def update_memoization_sizes(all_panels):
         Detector.update_memoization_sizes(all_panels)
 
-        num_matches = sum(x is CylindricalDetector for x in all_panels)
+        num_matches = sum(isinstance(x, CylindricalDetector) for x in all_panels)
         funcs = [
             _pixel_angles,
             _pixel_tth_gradient,
             _pixel_eta_gradient,
+            _pixel_solid_angles,
         ]
         Detector.increase_memoization_sizes(funcs, num_matches)
 

--- a/hexrd/instrument/planar_detector.py
+++ b/hexrd/instrument/planar_detector.py
@@ -130,11 +130,12 @@ class PlanarDetector(Detector):
     def update_memoization_sizes(all_panels):
         Detector.update_memoization_sizes(all_panels)
 
-        num_matches = sum(x is PlanarDetector for x in all_panels)
+        num_matches = sum(isinstance(x, PlanarDetector) for x in all_panels)
         funcs = [
             _pixel_angles,
             _pixel_tth_gradient,
             _pixel_eta_gradient,
+            _pixel_solid_angles,
         ]
         Detector.increase_memoization_sizes(funcs, num_matches)
 


### PR DESCRIPTION
This logic was not working before, and we needed to add the `_pixel_solid_angles` functions to the memoization size updates.

It appears to be working correctly now.