### PR TITLE
Hide invalid pixel conversion warning

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -760,7 +760,11 @@ class Detector:
 
         ij_det = np.vstack([i_pix, j_pix]).T
         if pixels:
-            ij_det = np.array(np.round(ij_det), dtype=int)
+            # Hide any runtime warnings in this conversion. Their output values
+            # will certainly be off the detector, which is fine.
+            with np.errstate(invalid='ignore'):
+                ij_det = np.array(np.round(ij_det), dtype=int)
+
         return ij_det
 
     def pixelToCart(self, ij_det):


### PR DESCRIPTION
These will come out as invalid values anyways, which will be caught in
other parts of the code, so we don't need to see the warning.