### PR TITLE
Change default polar angle for pxrdip to 67.5

### DIFF
--- a/hexrd/resources/pxrdip_reference_config.yml
+++ b/hexrd/resources/pxrdip_reference_config.yml
@@ -2,7 +2,7 @@ beam:
   energy: 10.2505
   vector:
     azimuth: 90.
-    polar_angle: 70.
+    polar_angle: 67.5
 detectors:
   IMAGE-PLATE-L:
     buffer:


### PR DESCRIPTION
This is the most common polar angle that is used.