### PR TITLE
Build time performance optimization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+import distutils.ccompiler
 import os
-import sys
-from setuptools import setup, find_packages, Extension
 from pathlib import Path
+from setuptools import setup, find_packages, Extension
+import sys
+
 import numpy
 np_include_dir = numpy.get_include()
-import distutils.ccompiler
 
 install_reqs = [
     'fabio>=0.11',
@@ -28,7 +29,7 @@ compiler_type = distutils.ccompiler.get_default_compiler()
 if compiler_type in ("unix", "mingw32"):
     compiler_optimize_flags = ['-O3', '-ftree-vectorize']
 elif compiler_type == "msvc":
-    compiler_optimize_flags = ['/Ox', '/Ob2', '/Oi', '/Ot', '/Oy', '/GL']
+    compiler_optimize_flags = ['/Ox', '/GL']
 else:
     compiler_optimize_flags = []
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ def get_old_xfcapi_extension_modules():
         'hexrd.extensions._transforms_CAPI',
         sources=srclist,
         include_dirs=[np_include_dir],
+        extra_compile_args=['-O3', '-ftree-vectorize'],
     )
 
     return [transforms_mod]

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ def get_new_xfcapi_extension_modules():
         'hexrd.extensions._new_transforms_capi',
         sources=['hexrd/transforms/new_capi/module.c'],
         include_dirs=[np_include_dir],
+        extra_compile_args=['-O3', '-ftree-vectorize'],
     )
 
     return [transforms_mod]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages, Extension
 from pathlib import Path
 import numpy
 np_include_dir = numpy.get_include()
+import distutils.ccompiler
 
 install_reqs = [
     'fabio>=0.11',
@@ -21,6 +22,15 @@ install_reqs = [
     'tqdm',
     'xxhash',
 ]
+
+# This will determine which compiler is being used to build the C modules
+compiler_type = distutils.ccompiler.get_default_compiler()
+if compiler_type in ("unix", "mingw32"):
+    compiler_optimize_flags = ['-O3', '-ftree-vectorize']
+elif compiler_type == "msvc":
+    compiler_optimize_flags = ['/O2', '/Ob2', '/Oi', '/Ot', '/Oy', '/GL']
+else:
+    compiler_optimize_flags = []
 
 # This a hack to get around the fact that scikit-image on conda-forge doesn't install
 # dist info so setuptools can't find it, even though its there, which results in
@@ -41,6 +51,7 @@ def get_convolution_extensions():
     extra_compile_args=['-UNDEBUG']
     if not sys.platform.startswith('win'):
         extra_compile_args.append('-fPIC')
+    extra_compile_args += compiler_optimize_flags
     # Add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
     # to report missed optimizations
     _convolve_ext = Extension(name='hexrd.convolution._convolve', sources=src_files,
@@ -59,7 +70,7 @@ def get_old_xfcapi_extension_modules():
         'hexrd.extensions._transforms_CAPI',
         sources=srclist,
         include_dirs=[np_include_dir],
-        extra_compile_args=['-O3', '-ftree-vectorize'],
+        extra_compile_args=compiler_optimize_flags,
     )
 
     return [transforms_mod]
@@ -70,7 +81,7 @@ def get_new_xfcapi_extension_modules():
         'hexrd.extensions._new_transforms_capi',
         sources=['hexrd/transforms/new_capi/module.c'],
         include_dirs=[np_include_dir],
-        extra_compile_args=['-O3', '-ftree-vectorize'],
+        extra_compile_args=compiler_optimize_flags,
     )
 
     return [transforms_mod]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ compiler_type = distutils.ccompiler.get_default_compiler()
 if compiler_type in ("unix", "mingw32"):
     compiler_optimize_flags = ['-O3', '-ftree-vectorize']
 elif compiler_type == "msvc":
-    compiler_optimize_flags = ['/O2', '/Ob2', '/Oi', '/Ot', '/Oy', '/GL']
+    compiler_optimize_flags = ['/Ox', '/Ob2', '/Oi', '/Ot', '/Oy', '/GL']
 else:
     compiler_optimize_flags = []
 


### PR DESCRIPTION
This change adds gcc compiler flags to optimize the runtime for the C API calls.

**Estimated performance increase: 10%**

Changes include:
- Add `-O3` to compiler flags for `transforms_CAPI.c`, `transforms_CFUNC.c`, `hexrd/transforms/new_capi/module.c`
- Add `-ftree-vectorize` to compiler flags for `transforms_CAPI.c`, `transforms_CFUNC.c`, `hexrd/transforms/new_capi/module.c`

Future proposed changes may include:
- Add the `-march=native` flag
- Add the `-mtune=native` flag
