### PR TITLE
fix weights and definition of chi^2

### DIFF
--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -665,12 +665,9 @@ class LeBail:
         self.gofFlist = np.append(self.gofFlist, self.gofF)
 
         if print_to_screen:
-            print(
-                "Finished iteration. Rwp: \
-                {:.3f} % goodness of fit: {:.3f}".format(
-                    self.Rwp * 100.0, self.gofF
-                )
-            )
+            msg = (f"Finished iteration. Rwp: "
+                f"{self.Rwp*100.0:.2f} % and chi^2: {self.gofF:.2f}")
+            print(msg)
 
     def Refine(self):
         """
@@ -2020,12 +2017,9 @@ class Rietveld:
             self.Rwplist = np.append(self.Rwplist, self.Rwp)
             self.gofFlist = np.append(self.gofFlist, self.gofF)
 
-            print(
-                "Finished iteration. Rwp: {:.3f} % goodness of \
-                  fit: {:.3f}".format(
-                    self.Rwp * 100.0, self.gofF
-                )
-            )
+            msg = (f"Finished iteration. Rwp: "
+                f"{self.Rwp*100.0:.2f} % and chi^2: {self.gofF:.2f}")
+            print(msg)
         else:
             print("Nothing to refine...")
 
@@ -2462,7 +2456,7 @@ class Rietveld:
                 ww = np.zeros(s.y.shape)
                 """also initialize statistical weights
                 for the error calculation"""
-                ww[~mask] = 1.0 / np.sqrt(s.y[~mask])
+                ww[~mask] = 1.0 / s.y[~mask]
                 self._weights.append(ww)
 
             self.initialize_bkg()

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -287,7 +287,7 @@ class LeBail:
                 self._background.append(Spectrum(x=tth, y=np.zeros(tth.shape)))
             else:
                 p = np.polynomial.Chebyshev.fit(
-                    tth, s.y, degree, w=self._weights[i] ** 4
+                    tth, s.y, degree, w=self._weights[i] ** 2
                 )
                 self._background.append(Spectrum(x=tth, y=p(tth)))
 

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1154,7 +1154,7 @@ class LeBail:
                 ww = np.zeros(s.y.shape)
                 """also initialize statistical weights
                 for the error calculation"""
-                ww[~mask] = 1.0 / np.sqrt(s.y[~mask])
+                ww[~mask] = 1.0 / s.y[~mask]
                 self._weights.append(ww)
 
             self.initialize_bkg()

--- a/hexrd/wppf/peakfunctions.py
+++ b/hexrd/wppf/peakfunctions.py
@@ -839,9 +839,7 @@ def calc_rwp(spectrum_sim,
     moved outside of the class to allow numba implementation
     P : number of independent parameters in fitting
     """
-    err = weights[:,1]* \
-    (spectrum_sim[:,1] - \
-    spectrum_expt[:,1])**2
+    err = weights[:,1]*(spectrum_sim[:,1] - spectrum_expt[:,1])**2
 
     weighted_expt = weights[:,1] * spectrum_expt[:,1] **2
 

--- a/hexrd/wppf/peakfunctions.py
+++ b/hexrd/wppf/peakfunctions.py
@@ -848,8 +848,8 @@ def calc_rwp(spectrum_sim,
     errvec = np.sqrt(err)
 
     """ weighted sum of square """
-    wss = np.trapz(err, spectrum_expt[:,0])
-    den = np.trapz(weighted_expt, spectrum_expt[:,0])
+    wss = np.sum(err)
+    den = np.sum(weighted_expt)
 
     """ standard Rwp i.e. weighted residual """
     if(den > 0.):
@@ -873,7 +873,7 @@ def calc_rwp(spectrum_sim,
 
     # Rwp and goodness of fit parameters
     if Rexp > 0.:
-        gofF = (Rwp / Rexp)**2
+        gofF = wss/(N-P)
     else:
         gofF = np.inf
 


### PR DESCRIPTION
Recently discovered a bug in the statistical weights and definition of goodness of fit (chi^2). This was causing chi^2 to be less than 1 which should not be the case. Fixing those bugs. 

Reference:
Brian H. Toby, R factors in Rietveld analysis: How good is good enough? Powder Diffraction 21(1), March 2006.