### PR TITLE
Performance tuning

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -2,7 +2,12 @@
 cd /github/workspace/
 
 # Install dependencies
-yum install -y wget git centos-release-scl
+yum install -y wget git centos-release-scl eigen3-devel
+
+# Install xsimd headers
+git clone https://github.com/xtensor-stack/xsimd.git
+mkdir -p /usr/include/xsimd
+cp -r xsimd/include/xsimd/* /usr/include/xsimd/
 
 # Need to install packages that depend on centos-release-scl on a different line.
 # This will use gcc==10, which is the same as what manylinux2014 uses.
@@ -23,6 +28,7 @@ ${HOME}/miniconda3/bin/conda activate hexrd
 
 # Install conda build and create output directory
 ${HOME}/miniconda3/bin/conda install --override-channels -c conda-forge conda-build -y
+${HOME}/miniconda3/bin/conda install -c conda-forge pybind11 -y
 mkdir output
 
 # Build the package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,12 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, refactor ]
   pull_request:
     branches: [ master ]
+
+env:
+  EIGEN3_INCLUDE_DIR: /eigen3/eigen-3.4.0
 
 jobs:
   pytest:
@@ -59,6 +62,75 @@ jobs:
       run: |
           pip install fabio==0.12
       if: ${{ matrix.config.os == 'macos-latest'}}
+
+    - name: Install Eigen on Linux
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y libeigen3-dev
+      if: runner.os == 'Linux'
+
+    - name: Install Eigen on MacOS
+      run: |
+          brew update
+          brew install eigen
+      if: runner.os == 'macOS'
+
+    - name: Install Eigen on Windows
+      run: |
+          Invoke-WebRequest -Uri https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip -o eigen.zip
+          Expand-Archive -Path eigen.zip -DestinationPath C:\eigen3
+          cp -r C:\eigen3\eigen-3.4.0 D:/a/hexrd/hexrd/eigen
+      if: runner.os == 'Windows'
+      shell: pwsh
+
+    - name: Install xsimd on Linux
+      run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ wget unzip
+          wget -O xsimd.tar.gz https://github.com/xtensor-stack/xsimd/archive/refs/tags/7.4.10.tar.gz
+          tar -xf xsimd.tar.gz
+          cd xsimd-7.4.10
+          mkdir build
+          cd build
+          cmake ..
+          make -j$(nproc)
+          sudo make install
+      if: runner.os == 'Linux'
+      
+    - name: Install xsimd on macOS
+      run: |
+          brew install cmake wget
+          wget -O xsimd.tar.gz https://github.com/xtensor-stack/xsimd/archive/refs/tags/7.4.10.tar.gz
+          tar -xf xsimd.tar.gz
+          cd xsimd-7.4.10
+          mkdir build
+          cd build
+          cmake ..
+          make -j$(sysctl -n hw.physicalcpu)
+          sudo make install
+      if: runner.os == 'macOS'
+    
+    - name: Install xsimd on Windows
+      run: |
+          # Download and build xsimd from source
+          Invoke-WebRequest -Uri https://github.com/xtensor-stack/xsimd/archive/refs/tags/7.4.10.tar.gz  -o xsimd.tar.gz
+          tar -xf xsimd.tar.gz
+          mv xsimd-7.4.10 xsimd
+          cd xsimd
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=/xsimd ..
+          cmake --build .
+          cmake --install .
+          echo "XSIMD_INCLUDE_DIR=/xsimd/include" >> $GITHUB_ENV
+      if: runner.os == 'Windows'
+      shell: pwsh
+
+    - name: Set up environment variables for Eigen3 and xsimd
+      run: |
+          echo "EIGEN3_INCLUDE_DIR=$(pwd)/eigen" >> $GITHUB_ENV
+          echo "XSIMD_INCLUDE_DIR=$(pwd)/xsimd/include" >> $GITHUB_ENV
+      if: runner.os == 'Windows'
 
     - name: Install HEXRD
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, performance-tuning ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [ master, refactor ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - python {{ python }}
     - setuptools
     - setuptools_scm
+    - eigen
+    - xsimd
 
   run:
     - appdirs

--- a/hexrd/distortion/ge_41rt.py
+++ b/hexrd/distortion/ge_41rt.py
@@ -9,52 +9,22 @@ if USE_NUMBA:
 from .distortionabc import DistortionABC
 from .registry import _RegisterDistortionClass
 from .utils import newton
+from hexrd.extensions import inverse_distortion
 
 RHO_MAX = 204.8  # max radius in mm for ge detector
 
 if USE_NUMBA:
-    @numba.njit(nogil=True, cache=True)
-    def _ge_41rt_inverse_distortion(out, in_, rhoMax, params):
-        maxiter = 100
-        prec = cnst.epsf
+    @numba.njit(nogil=True, cache=True, fastmath=True)
+    def _ge_41rt_inverse_distortion(inputs, rhoMax, params):
+        radii = np.hypot(inputs[:, 0], inputs[:, 1])
+        inverted_radii = np.reciprocal(radii)
+        cosines = inputs[:, 0]*inverted_radii
+        cosine_double_angles = 2*np.square(cosines)-1
+        cosine_quadruple_angles = 2*np.square(cosine_double_angles)-1
+        sqrt_p_is = rhoMax / np.sqrt(-(params[0]*cosine_double_angles+params[1]*cosine_quadruple_angles+params[2]))
+        solutions = (2/np.sqrt(3))*sqrt_p_is*np.cos(np.arccos(((-3*np.sqrt(3)/2)*radii/sqrt_p_is))/3+4*np.pi/3)
 
-        p0, p1, p2, p3, p4, p5 = params[0:6]
-        rxi = 1.0/rhoMax
-        for el in range(len(in_)):
-            xi, yi = in_[el, 0:2]
-            ri = np.sqrt(xi*xi + yi*yi)
-            if ri < cnst.sqrt_epsf:
-                ri_inv = 0.0
-            else:
-                ri_inv = 1.0/ri
-            sinni = yi*ri_inv
-            cosni = xi*ri_inv
-            ro = ri
-            cos2ni = cosni*cosni - sinni*sinni
-            sin2ni = 2*sinni*cosni
-            cos4ni = cos2ni*cos2ni - sin2ni*sin2ni
-            # newton solver iteration
-            for i in range(maxiter):
-                ratio = ri*rxi
-                fx = (p0*ratio**p3*cos2ni +
-                      p1*ratio**p4*cos4ni +
-                      p2*ratio**p5 + 1)*ri - ro  # f(x)
-                fxp = (p0*ratio**p3*cos2ni*(p3+1) +
-                       p1*ratio**p4*cos4ni*(p4+1) +
-                       p2*ratio**p5*(p5+1) + 1)  # f'(x)
-
-                delta = fx/fxp
-                ri = ri - delta
-                # convergence check for newton
-                if np.abs(delta) <= prec*np.abs(ri):
-                    break
-
-            xi = ri*cosni
-            yi = ri*sinni
-            out[el, 0] = xi
-            out[el, 1] = yi
-
-        return out
+        return solutions[:, None] * inputs * inverted_radii[:, None]
 
     @numba.njit(nogil=True, cache=True)
     def _ge_41rt_distortion(out, in_, rhoMax, params):
@@ -87,53 +57,16 @@ if USE_NUMBA:
         return out
 else:
     # non-numba versions for the direct and inverse distortion
-    def _ge_41rt_inverse_distortion(out, in_, rhoMax, params):
-        maxiter = 100
-        prec = cnst.epsf
+    def _ge_41rt_inverse_distortion(out, inputs, rhoMax, params):
+        radii = np.hypot(inputs[:, 0], inputs[:, 1])
+        inverted_radii = np.reciprocal(radii)
+        cosines = inputs[:, 0]*inverted_radii
+        cosine_double_angles = 2*cosines*cosines-1
+        cosine_quadruple_angles = 2*cosine_double_angles*cosine_double_angles-1
+        sqrt_p_is = np.sqrt(-(rhoMax*rhoMax) / (params[0]*cosine_double_angles+params[1]*cosine_quadruple_angles+params[2]))
+        solutions = 2*(sqrt_p_is/np.sqrt(3))*np.cos(np.arccos((np.sqrt(3)/sqrt_p_is)*(-3*radii)/2)/3+4*np.pi/3)
 
-        p0, p1, p2, p3, p4, p5 = params[0:6]
-        rxi = 1.0/rhoMax
-
-        xi, yi = in_[:, 0], in_[:, 1]
-        ri = np.sqrt(xi*xi + yi*yi)
-        # !!! adding fix TypeError when processings list of coords
-        zfix = []
-        if np.any(ri) < cnst.sqrt_epsf:
-            zfix = ri < cnst.sqrt_epsf
-            ri[zfix] = 1.0
-        ri_inv = 1.0/ri
-        ri_inv[zfix] = 0.
-
-        sinni = yi*ri_inv
-        cosni = xi*ri_inv
-        ro = ri
-        cos2ni = cosni*cosni - sinni*sinni
-        sin2ni = 2*sinni*cosni
-        cos4ni = cos2ni*cos2ni - sin2ni*sin2ni
-
-        # newton solver iteration
-        #
-        # FIXME: looks like we hae a problem here,
-        #        should iterate over single coord pairs?
-        for i in range(maxiter):
-            ratio = ri*rxi
-            fx = (p0*ratio**p3*cos2ni +
-                  p1*ratio**p4*cos4ni +
-                  p2*ratio**p5 + 1)*ri - ro  # f(x)
-            fxp = (p0*ratio**p3*cos2ni*(p3+1) +
-                   p1*ratio**p4*cos4ni*(p4+1) +
-                   p2*ratio**p5*(p5+1) + 1)  # f'(x)
-
-            delta = fx/fxp
-            ri = ri - delta
-
-            # convergence check for newton
-            if np.max(np.abs(delta/ri)) <= prec:
-                break
-
-        out[:, 0] = ri*cosni
-        out[:, 1] = ri*sinni
-
+        out[:, 0], out[:, 1] = solutions*inputs[:, 0]*inverted_radii, solutions*inputs[:, 1]*inverted_radii
         return out
 
     def _ge_41rt_distortion(out, in_, rhoMax, params):
@@ -222,8 +155,7 @@ class GE_41RT(DistortionABC, metaclass=_RegisterDistortionClass):
             return xy_in
         else:
             xy_in = np.asarray(xy_in, dtype=float)
-            xy_out = np.empty_like(xy_in)
-            _ge_41rt_inverse_distortion(
-                xy_out, xy_in, float(RHO_MAX), np.asarray(self.params)
+            xy_out = inverse_distortion.ge_41rt_inverse_distortion(
+                xy_in, float(RHO_MAX), np.asarray(self.params[:3])
             )
             return xy_out

--- a/hexrd/gridutil.py
+++ b/hexrd/gridutil.py
@@ -75,11 +75,6 @@ def cellIndices(edges, points_1d):
     else:
         raise RuntimeError("edges array gives delta of 0")
 
-    try:
-        return np.array(idx, dtype=int)
-    except Exception as e:
-        print(e)
-        pass
     return np.array(idx, dtype=int)
 
 

--- a/hexrd/gridutil.py
+++ b/hexrd/gridutil.py
@@ -62,31 +62,24 @@ def cellIndices(edges, points_1d):
       must be mapped to the same branch cut, and
       abs(edges[0] - edges[-1]) = 2*pi
     """
-    ztol = sqrt_epsf
-
     assert len(edges) >= 2, "must have at least 2 edges"
 
-    points_1d = np.r_[points_1d].flatten()
-    delta = float(edges[1] - edges[0])
+    delta = edges[1] - edges[0]
 
     if delta > 0:
-        on_last_rhs = points_1d >= edges[-1] - ztol
-        points_1d[on_last_rhs] = points_1d[on_last_rhs] - ztol
+        points_1d[points_1d >= edges[-1] - sqrt_epsf] -= sqrt_epsf
         idx = np.floor((points_1d - edges[0]) / delta)
     elif delta < 0:
-        on_last_rhs = points_1d <= edges[-1] + ztol
-        points_1d[on_last_rhs] = points_1d[on_last_rhs] + ztol
+        points_1d[points_1d <= edges[-1] + sqrt_epsf] += sqrt_epsf
         idx = np.ceil((points_1d - edges[0]) / delta) - 1
     else:
         raise RuntimeError("edges array gives delta of 0")
 
-    # # mark points outside range with NaN
-    # off_lo = idx < 0
-    # off_hi = idx >= len(edges) - 1
-    # if np.any(off_lo):
-    #     idx[off_lo] = np.nan
-    # if np.any(off_hi):
-    #     idx[off_hi] = np.nan
+    try:
+        return np.array(idx, dtype=int)
+    except Exception as e:
+        print(e)
+        pass
     return np.array(idx, dtype=int)
 
 

--- a/hexrd/imageseries/load/framecache.py
+++ b/hexrd/imageseries/load/framecache.py
@@ -127,7 +127,7 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
         return self._shape
 
     def __getitem__(self, key):
-        return self._framelist[key].toarray()
+        return self._framelist[key]
 
     def __iter__(self):
         return ImageSeriesIterator(self)

--- a/hexrd/imageseries/omega.py
+++ b/hexrd/imageseries/omega.py
@@ -86,20 +86,13 @@ class OmegaImageSeries(ImageSeries):
         return d
 
     def omega_to_frame(self, om):
-        """Return frame and wedge which includes given omega, -1 if not found"""
-        f = -1
-        w = -1
-        for i in range(len(self._wedge_om)):
-            omin = self._wedge_om[i, 0]
-            omax = self._wedge_om[i, 1]
-            omcheck = omin + np.mod(om - omin, self.TAU)
-            if omcheck < omax:
-                odel = self._wedge_om[i, 2]
-                f = self._wedge_f[i,0] + int(np.floor((omcheck - omin)/odel))
-                w = i
-                break
+        for i, wedge_om in enumerate(self._wedge_om):
+            omin = wedge_om[0]
+            omcheck = omin + (om - omin) % self.TAU
+            if omcheck < wedge_om[1]:
+                return self._wedge_f[i, 0] + int((om - omin) / wedge_om[2]), i
 
-        return f, w
+        return -1, -1
 
     def omegarange_to_frames(self, omin, omax):
         """Return list of frames for range of omegas"""

--- a/hexrd/transforms/cpp_sublibrary/Makefile
+++ b/hexrd/transforms/cpp_sublibrary/Makefile
@@ -1,0 +1,26 @@
+CXX = c++
+CXXFLAGS = -O3 -Wall -shared -std=c++20 -fPIC -funroll-loops -Wno-maybe-uninitialized
+INCLUDES = -I/usr/include/eigen3/ -I/usr/include/xsimd -I/usr/include/pybind11 -I/usr/include/python3.10/
+SRCS_TRANSFORMS = src/transforms.cpp
+SRCS_INVERSE_DISTORTION = src/inverse_distortion.cpp
+TARGET_DIR = ../../extensions/
+TARGET_NAME_TRANSFORMS = transforms
+TARGET_NAME_INVERSE_DISTORTION = inverse_distortion
+EXTENSION_SUFFIX = $(shell python3-config --extension-suffix)
+
+all: transforms inverse_distortion
+
+transforms: $(TARGET_DIR)$(TARGET_NAME_TRANSFORMS)$(EXTENSION_SUFFIX)
+
+inverse_distortion: $(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX)
+
+$(TARGET_DIR)$(TARGET_NAME_TRANSFORMS)$(EXTENSION_SUFFIX): $(SRCS_TRANSFORMS)
+	$(CXX) $(CXXFLAGS) $(PYBIND_INCLUDES) $< -o $@ $(INCLUDES)
+
+$(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX): $(SRCS_INVERSE_DISTORTION)
+	$(CXX) $(CXXFLAGS) $(PYBIND_INCLUDES) $< -o $@ $(INCLUDES)
+
+.PHONY: clean transforms inverse_distortion
+clean:
+	rm -f $(TARGET_DIR)$(TARGET_NAME_TRANSFORMS)$(EXTENSION_SUFFIX) \
+				$(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX)

--- a/hexrd/transforms/cpp_sublibrary/Makefile
+++ b/hexrd/transforms/cpp_sublibrary/Makefile
@@ -1,5 +1,5 @@
 CXX = c++
-CXXFLAGS = -O3 -Wall -shared -std=c++20 -fPIC -funroll-loops -Wno-maybe-uninitialized
+CXXFLAGS = -O3 -Wall -shared -fPIC -funroll-loops -Wno-maybe-uninitialized
 INCLUDES = -I/usr/include/eigen3/ -I/usr/include/xsimd -I/usr/include/pybind11 -I/usr/include/python3.10/
 SRCS_TRANSFORMS = src/transforms.cpp
 SRCS_INVERSE_DISTORTION = src/inverse_distortion.cpp

--- a/hexrd/transforms/cpp_sublibrary/src/inverse_distortion.cpp
+++ b/hexrd/transforms/cpp_sublibrary/src/inverse_distortion.cpp
@@ -1,0 +1,29 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <Eigen/Core>
+#include <xsimd/xsimd.hpp>
+
+namespace py = pybind11;
+constexpr double FOUR_THIRDS_PI = 4.1887902;
+constexpr double N_THREE_HALVES_SQRT_3 = -2.59807621;
+constexpr double TWO_OVER_SQRT_THREE = 1.154700538;
+
+Eigen::ArrayXXd ge_41rt_inverse_distortion(const Eigen::ArrayXXd& inputs, const double rhoMax, const Eigen::ArrayXd& params) {
+  Eigen::ArrayXd radii = inputs.matrix().rowwise().norm();
+  Eigen::ArrayXd inverted_radii = radii.cwiseInverse();
+  Eigen::ArrayXd cosines = inputs.col(0) * inverted_radii;
+  Eigen::ArrayXd cosine_double_angles = 2*cosines.square() - 1;
+  Eigen::ArrayXd cosine_quadruple_angles = 2*cosine_double_angles.square() - 1;
+  Eigen::ArrayXd sqrt_p_is = rhoMax / (-params[0]*cosine_double_angles - params[1]*cosine_quadruple_angles - params[2]).sqrt();
+  Eigen::ArrayXd solutions = TWO_OVER_SQRT_THREE*sqrt_p_is*(acos(N_THREE_HALVES_SQRT_3*radii/sqrt_p_is)/3 + FOUR_THIRDS_PI).cos();
+  Eigen::ArrayXXd results = solutions.rowwise().replicate(inputs.cols()).array() * inputs * inverted_radii.rowwise().replicate(inputs.cols()).array();
+
+  return results;
+}
+
+PYBIND11_MODULE(inverse_distortion, m)
+{
+  m.doc() = "HEXRD inverse distribution plugin";
+
+  m.def("ge_41rt_inverse_distortion", &ge_41rt_inverse_distortion, "Inverse distortion for ge_41rt");
+}

--- a/hexrd/transforms/cpp_sublibrary/src/transforms.cpp
+++ b/hexrd/transforms/cpp_sublibrary/src/transforms.cpp
@@ -1,0 +1,334 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <Eigen/Geometry>
+#include <Eigen/Core>
+#include <cmath>
+#include <xsimd/xsimd.hpp>
+#include <iostream>
+
+namespace py = pybind11;
+
+const Eigen::Vector3f Zl = {0.0, 0.0, 1.0};
+const float eps = std::numeric_limits<float>::epsilon();
+const float sqrtEps = std::sqrt(std::numeric_limits<float>::epsilon());
+
+
+const static Eigen::MatrixXf makeBinaryRotMat(const Eigen::Vector3f& a) {
+  Eigen::Matrix3f r = 2.0 * a * a.transpose();
+  r.diagonal() -= Eigen::Vector3f::Ones();
+  return r;
+}
+
+Eigen::MatrixXf makeRotMatOfExpMap(const Eigen::Vector3f& e) {
+  Eigen::AngleAxisf rotation(e.norm(), e.normalized());
+  return rotation.toRotationMatrix();
+}
+
+static Eigen::MatrixX3f makeOscillRotMat(const float chi, const Eigen::VectorXf& ome) {
+  Eigen::MatrixX3f rots(3 * ome.size(), 3);
+  const float cchi = cos(chi), schi = sin(chi);
+  xsimd::batch<float, 4UL> come_v, some_v;
+
+  const size_t batch_size = xsimd::simd_traits<float>::size;
+  const size_t vec_size = ome.size();
+
+  for (size_t i = 0; i < vec_size; i += batch_size) {
+    auto ome_v = xsimd::load_unaligned<float>(&ome[i]);
+    come_v = xsimd::cos(ome_v);
+    some_v = xsimd::sin(ome_v);
+
+    for(size_t j = 0; j < batch_size && (i+j) < vec_size; ++j) {
+      rots.block<3, 3>(3*(i+j), 0) <<         come_v[j],    0,         some_v[j],
+                                       schi * some_v[j], cchi, -schi * come_v[j],
+                                      -cchi * some_v[j], schi,  cchi * come_v[j];
+    }
+  }
+  return rots;
+}
+
+const static Eigen::MatrixX3f anglesToGvec(const Eigen::MatrixXf &angs,
+                                    const Eigen::Vector3f &bHat_l,
+                                    const Eigen::Vector3f &eHat_l, float chi,
+                                    const Eigen::Matrix3f &rMat_c) noexcept {
+  constexpr size_t batch_size = xsimd::simd_traits<float>::size;
+  const size_t vec_size = angs.rows();
+  const size_t num_full_batches = vec_size / batch_size;
+
+  auto cchi = cos(chi);
+  auto schi = sin(chi);
+  Eigen::MatrixX3f gVec_c(angs.rows(), 3);
+
+  const Eigen::Vector3f yHat = eHat_l.cross(bHat_l).normalized();
+  const Eigen::Vector3f bHat = bHat_l.normalized();
+  const Eigen::Vector3f xHat = bHat.cross(yHat);
+  Eigen::Matrix3f rotMat;
+  rotMat << xHat, yHat, -bHat;
+
+  auto rotMat00 = rotMat(0, 0);
+  auto rotMat01 = rotMat(0, 1);
+  auto rotMat02 = rotMat(0, 2);
+  auto rotMat10 = rotMat(1, 0);
+  auto rotMat11 = rotMat(1, 1);
+  auto rotMat12 = rotMat(1, 2);
+  auto rotMat20 = rotMat(2, 0);
+  auto rotMat21 = rotMat(2, 1);
+  auto rotMat22 = rotMat(2, 2);
+
+  auto mat00 = rMat_c(0, 0);
+  auto mat01 = rMat_c(0, 1);
+  auto mat02 = rMat_c(0, 2);
+  auto mat10 = rMat_c(1, 0);
+  auto mat11 = rMat_c(1, 1);
+  auto mat12 = rMat_c(1, 2);
+  auto mat20 = rMat_c(2, 0);
+  auto mat21 = rMat_c(2, 1);
+  auto mat22 = rMat_c(2, 2);
+
+  // SIMD loop for full batches
+  for (size_t i = 0; i < num_full_batches * batch_size; i += batch_size) {
+    auto half_angs_v = xsimd::load_unaligned(angs.data() + i) * 0.5;
+    auto angs1_v = xsimd::load_unaligned(angs.data() + vec_size + i);
+    auto angs2_v = xsimd::load_unaligned(angs.data() + 2 * vec_size + i);
+
+    auto cosHalfAngs = xsimd::cos(half_angs_v);
+    auto cosAngs2 = xsimd::cos(angs2_v);
+    auto sinAngs2 = xsimd::sin(angs2_v);
+
+    auto preMult_gVec_row_0 = cosHalfAngs * xsimd::cos(angs1_v);
+    auto preMult_gVec_row_1 = cosHalfAngs * xsimd::sin(angs1_v);
+    auto preMult_gVec_row_2 = xsimd::sin(half_angs_v);
+
+    auto gVec_row_0 = preMult_gVec_row_0 * rotMat00 +
+                      preMult_gVec_row_1 * rotMat01 +
+                      preMult_gVec_row_2 * rotMat02;
+    auto gVec_row_1 = preMult_gVec_row_0 * rotMat10 +
+                      preMult_gVec_row_1 * rotMat11 +
+                      preMult_gVec_row_2 * rotMat12;
+    auto gVec_row_2 = preMult_gVec_row_0 * rotMat20 +
+                      preMult_gVec_row_1 * rotMat21 +
+                      preMult_gVec_row_2 * rotMat22;
+
+    auto dot0 =
+        (mat00 * cosAngs2 + mat20 * sinAngs2) * gVec_row_0 +
+        (mat00 * schi * sinAngs2 + mat10 * cchi - mat20 * schi * cosAngs2) *
+            gVec_row_1 +
+        (-mat00 * cchi * sinAngs2 + mat10 * schi + mat20 * cchi * cosAngs2) *
+            gVec_row_2;
+    auto dot1 =
+        (mat01 * cosAngs2 + mat21 * sinAngs2) * gVec_row_0 +
+        (mat01 * schi * sinAngs2 + mat11 * cchi - mat21 * schi * cosAngs2) *
+            gVec_row_1 +
+        (-mat01 * cchi * sinAngs2 + mat11 * schi + mat21 * cchi * cosAngs2) *
+            gVec_row_2;
+    auto dot2 =
+        (mat02 * cosAngs2 + mat22 * sinAngs2) * gVec_row_0 +
+        (mat02 * schi * sinAngs2 + mat12 * cchi - mat22 * schi * cosAngs2) *
+            gVec_row_1 +
+        (-mat02 * cchi * sinAngs2 + mat12 * schi + mat22 * cchi * cosAngs2) *
+            gVec_row_2;
+
+    xsimd::store_unaligned(gVec_c.data() + i, dot0);
+    xsimd::store_unaligned(gVec_c.data() + vec_size + i, dot1);
+    xsimd::store_unaligned(gVec_c.data() + 2 * vec_size + i, dot2);
+  }
+
+  // Loop for remaining elements, if any
+  for (size_t i = num_full_batches * batch_size; i < vec_size; ++i) {
+    auto half_angs_v = *(angs.data() + i) * 0.5;
+    auto angs1_v = *(angs.data() + vec_size + i);
+    auto angs2_v = *(angs.data() + 2 * vec_size + i);
+
+    auto cosHalfAngs = std::cos(half_angs_v);
+    auto cosAngs2 = std::cos(angs2_v);
+    auto sinAngs2 = std::sin(angs2_v);
+
+    auto preMult_gVec_row_0 = cosHalfAngs * xsimd::cos(angs1_v);
+    auto preMult_gVec_row_1 = cosHalfAngs * xsimd::sin(angs1_v);
+    auto preMult_gVec_row_2 = xsimd::sin(half_angs_v);
+
+    auto gVec_row_0 = preMult_gVec_row_0 * rotMat00 +
+                      preMult_gVec_row_1 * rotMat01 +
+                      preMult_gVec_row_2 * rotMat02;
+    auto gVec_row_1 = preMult_gVec_row_0 * rotMat10 +
+                      preMult_gVec_row_1 * rotMat11 +
+                      preMult_gVec_row_2 * rotMat12;
+    auto gVec_row_2 = preMult_gVec_row_0 * rotMat20 +
+                      preMult_gVec_row_1 * rotMat21 +
+                      preMult_gVec_row_2 * rotMat22;
+
+    auto dot0 =
+        (mat00 * cosAngs2 + mat20 * sinAngs2) * gVec_row_0 +
+        (mat00 * schi * sinAngs2 + mat10 * cchi - mat20 * schi * cosAngs2) *
+            gVec_row_1 +
+        (-mat00 * cchi * sinAngs2 + mat10 * schi + mat20 * cchi * cosAngs2) *
+            gVec_row_2;
+    auto dot1 =
+        (mat01 * cosAngs2 + mat21 * sinAngs2) * gVec_row_0 +
+        (mat01 * schi * sinAngs2 + mat11 * cchi - mat21 * schi * cosAngs2) *
+            gVec_row_1 +
+        (-mat01 * cchi * sinAngs2 + mat11 * schi + mat21 * cchi * cosAngs2) *
+            gVec_row_2;
+    auto dot2 =
+        (mat02 * cosAngs2 + mat22 * sinAngs2) * gVec_row_0 +
+        (mat02 * schi * sinAngs2 + mat12 * cchi - mat22 * schi * cosAngs2) *
+            gVec_row_1 +
+        (-mat02 * cchi * sinAngs2 + mat12 * schi + mat22 * cchi * cosAngs2) *
+            gVec_row_2;
+
+    *(gVec_c.data() + i) = dot0;
+    *(gVec_c.data() + vec_size + i) = dot1;
+    *(gVec_c.data() + 2 * vec_size + i) = dot2;
+  }
+
+  return gVec_c;
+}
+
+const static Eigen::Vector2f gvecToDetectorXYOne(const Eigen::Vector3f& gVec_c, const Eigen::Matrix3f& rMat_d,
+                                    const Eigen::Matrix3f& rMat_sc, const Eigen::Vector3f& tVec_d,
+                                    const Eigen::Vector3f& bHat_l, const Eigen::Vector3f& nVec_l,
+                                    float num, const Eigen::Vector3f& P0_l)
+{
+    Eigen::Vector3f gHat_c = gVec_c.normalized();
+    Eigen::Vector3f gVec_l = rMat_sc * gHat_c;
+    float bDot = -bHat_l.dot(gVec_l);
+
+    if (bDot >= eps && bDot <= 1.0 - eps) {
+        Eigen::Matrix3f brMat = makeBinaryRotMat(gVec_l); // Ensure this function is correctly implemented
+
+        Eigen::Vector3f dVec_l = -brMat * bHat_l;
+        float denom = nVec_l.dot(dVec_l);
+
+        if (denom < -eps) {
+            Eigen::Vector3f P2_l = P0_l + dVec_l * num / denom;
+            Eigen::Vector2f result;
+            result[0] = (rMat_d.col(0).dot(P2_l - tVec_d));
+            result[1] = (rMat_d.col(1).dot(P2_l - tVec_d));
+
+            return result;
+        }
+    }
+
+    return Eigen::Vector2f(NAN, NAN);
+}
+
+const static Eigen::MatrixXf gvecToDetectorXY(const Eigen::MatrixXf& gVec_c, const Eigen::Matrix3f& rMat_d,
+                                 const Eigen::MatrixXf& rMat_s, const Eigen::Matrix3f& rMat_c,
+                                 const Eigen::Vector3f& tVec_d, const Eigen::Vector3f& tVec_s,
+                                 const Eigen::Vector3f& tVec_c, const Eigen::Vector3f& beamVec)
+{
+    if (gVec_c.cols() != 3) {
+        std::cerr << "Error: gVec_c should have 3 columns!" << std::endl;
+        return Eigen::MatrixXf(); // Return an empty matrix
+    }
+
+    if (rMat_s.rows() % 3 != 0 || rMat_s.cols() != 3) {
+        std::cerr << "Error: rMat_s dimensions are not valid!" << std::endl;
+        return Eigen::MatrixXf(); // Return an empty matrix
+    }
+
+    Eigen::MatrixXf result(gVec_c.rows(), 2);
+    Eigen::Vector3f bHat_l = beamVec.normalized();
+
+    for (int i = 0; i < gVec_c.rows(); i++) {
+        if (i * 3 + 2 >= rMat_s.rows()) {
+            std::cerr << "Error: Index out of bounds when accessing rMat_s!" << std::endl;
+            continue; // Skip this iteration
+        }
+
+        Eigen::Vector3f nVec_l = rMat_d * Zl;
+        Eigen::Vector3f P0_l = tVec_s + rMat_s.block<3, 3>(i * 3, 0) * tVec_c;
+        Eigen::Matrix3f rMat_sc = rMat_s.block<3, 3>(i * 3, 0) * rMat_c;
+
+        result.row(i) = gvecToDetectorXYOne(gVec_c.row(i), rMat_d, rMat_sc, tVec_d,
+                                            bHat_l, nVec_l, nVec_l.dot(P0_l), P0_l).transpose();
+    }
+
+    return result;
+}
+
+const static Eigen::Vector2f gvecToDetectorXYOneSimple(const Eigen::Vector3f& gVec_l, const Eigen::Matrix3f& rMat_d,
+                                    const Eigen::Vector3f& tVec_d,
+                                    const Eigen::Vector3f& bHat_l, const Eigen::Vector3f& nVec_l,
+                                    float num, const Eigen::Vector3f& P0_l)
+{
+  float bDot = -bHat_l.dot(gVec_l);
+
+  if ( bDot >= eps && bDot <= 1.0 - eps ) {
+    Eigen::Vector3f dVec_l = -makeBinaryRotMat(gVec_l) * bHat_l;
+    float denom = nVec_l.dot(dVec_l);
+
+    if ( denom < -eps ) {
+      Eigen::Vector3f P2_l = P0_l + dVec_l * num / denom  - tVec_d;
+      return Eigen::Vector2f(rMat_d.col(0).dot(P2_l), rMat_d.col(1).dot(P2_l));
+    }
+  }
+
+  return Eigen::Vector2f(NAN, NAN);
+}
+
+const static Eigen::MatrixXf gvecToDetectorXYFromAngles(const float chi, const Eigen::VectorXf omes,
+                                 const Eigen::MatrixXf& gVec_c, const Eigen::Matrix3f& rMat_d,
+                                 const Eigen::Matrix3f& rMat_c,
+                                 const Eigen::Vector3f& tVec_d, const Eigen::Vector3f& tVec_s,
+                                 const Eigen::Vector3f& tVec_c, const Eigen::Vector3f& beamVec)
+{
+  const int npts = gVec_c.rows();
+  Eigen::MatrixXf result(npts, 2);
+  Eigen::MatrixX3f rMat_s = makeOscillRotMat(chi, omes);
+
+  Eigen::Vector3f bHat_l = beamVec.normalized();
+
+  for (int i=0; i<npts; i++) {
+    Eigen::Vector3f nVec_l = rMat_d * Zl;
+    Eigen::Vector3f P0_l = tVec_s + rMat_s.block<3,3>(i*3, 0) * tVec_c;
+    Eigen::Vector3f P3_l = tVec_d;
+
+    float num = nVec_l.dot(P3_l - P0_l);
+
+    Eigen::Matrix3f rMat_sc = rMat_s.block<3,3>(i*3, 0) * rMat_c;
+
+    result.row(i) = gvecToDetectorXYOne(gVec_c.row(i), rMat_d, rMat_sc, tVec_d,
+                                        bHat_l, nVec_l, num, P0_l).transpose();
+  }
+
+  return result;
+}
+
+const static Eigen::MatrixX2f anglesToGvecToDetectorXYFromAngles(const float chi, const Eigen::MatrixXf omes,
+                                 const Eigen::Matrix3f& rMat_d, const Eigen::Matrix3f& rMat_c,
+                                 const Eigen::Vector3f& tVec_d, const Eigen::Vector3f& tVec_s,
+                                 const Eigen::Vector3f& tVec_c, const Eigen::Vector3f& beamVec)
+{
+  Eigen::MatrixX2f result(omes.rows(), 2);
+  const Eigen::MatrixX3f rMat_s = makeOscillRotMat(chi, omes.col(2));
+  const Eigen::MatrixX3f gVec_c = anglesToGvec(omes, beamVec, {1, 0, 0}, chi, rMat_c).rowwise().normalized();
+  const Eigen::Vector3f bHat_l = beamVec.normalized();
+
+  for (int i=0; i<omes.rows(); i++) {
+    Eigen::Matrix3f current_rmat = rMat_s.block<3,3>(i*3, 0);
+    Eigen::Vector3f nVec_l = rMat_d * Zl;
+    Eigen::Vector3f P0_l = tVec_s + current_rmat * tVec_c;
+
+    Eigen::Vector3f norm = gVec_c.row(i);
+    Eigen::Vector3f gVec_l = current_rmat * rMat_c * norm;
+
+    result.row(i) = gvecToDetectorXYOneSimple(gVec_l, rMat_d, tVec_d,
+                                              bHat_l, nVec_l, nVec_l.dot(tVec_d - P0_l), P0_l).transpose();
+  }
+
+  return result;
+}
+
+PYBIND11_MODULE(transforms, m)
+{
+  m.doc() = "HEXRD transforms plugin";
+
+  m.def("make_binary_rot_mat", &makeBinaryRotMat, "Function that computes a rotation matrix from a binary vector");
+  m.def("make_rot_mat_of_exp_map", &makeRotMatOfExpMap, "Function that computes a rotation matrix from an exponential map");
+  m.def("makeOscillRotMat", &makeOscillRotMat, "Function that generates a collection of rotation matrices from two angles (chi, ome)");
+  m.def("anglesToGvecToDetectorXYFromAngles", &anglesToGvecToDetectorXYFromAngles, "I hate this.");
+  m.def("anglesToGVec", &anglesToGvec, "Function that converts angles to g-vectors");
+  m.def("gvecToDetectorXY", &gvecToDetectorXY, "A function that converts gVec to detector XY");
+  m.def("gvec_to_detector_xy_one", &gvecToDetectorXYOne, "Function that converts g-vectors to detector xy coordinates");
+  m.def("gvecToDetectorXYFromAngles", &gvecToDetectorXYFromAngles, "Function that converts g-vectors to detector xy coordinates, given rotation axes");
+}

--- a/hexrd/transforms/new_capi/transforms_definitions.py
+++ b/hexrd/transforms/new_capi/transforms_definitions.py
@@ -22,6 +22,8 @@ import functools
 # Note this can be kind of redundant with the definition classes, but it also
 # allows for some coherence checks.
 API = (
+    'gvec_to_xy_from_angles',
+    'angles_to_gvec_to_xy_from_angles',
     "angles_to_gvec",
     "angles_to_dvec",
     "gvec_to_xy",
@@ -195,6 +197,22 @@ class DEF_gvec_to_xy(DEF_Func):
                    beam_vec=None,
                    vmat_inv=None,
                    bmat=None):
+        pass
+
+class DEF_gvec_to_xy_from_angles(DEF_Func):
+    """ Adding this in begrudgingly because I have to - Zack Singer """
+    def _signature(chi, omes, gvec_c,
+                   rmat_d, rmat_c,
+                   tvec_d, tvec_s, tvec_c,
+                   beam_vec):
+        pass
+
+class DEF_angles_to_gvec_to_xy_from_angles(DEF_Func):
+    """ Adding this in begrudgingly because I have to - Zack Singer """
+    def _signature(chi, omes,
+               rmat_d, rmat_c,
+               tvec_d, tvec_s, tvec_c,
+               beam_vec):
         pass
 
 

--- a/hexrd/transforms/xfcapi.py
+++ b/hexrd/transforms/xfcapi.py
@@ -35,4 +35,6 @@ from .new_capi.xf_new_capi import(
     angles_to_gvec,
     gvec_to_xy,  # this is gvecToDetectorXY and gvecToDetectorXYArray
     make_sample_rmat,  # this is makeOscillRotMat and makeOscillRotMatArray
+    gvec_to_xy_from_angles,
+    angles_to_gvec_to_xy_from_angles,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<1.25", "setuptools_scm[toml]"]
+requires = ["setuptools", "wheel", "numpy<1.25", "setuptools_scm[toml]", "pybind11"]

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def get_cpp_extensions():
     cpp_transform_pkgdir = Path('hexrd') / 'transforms/cpp_sublibrary'
     src_files = [str(cpp_transform_pkgdir / 'src/transforms.cpp'), str(cpp_transform_pkgdir / 'src/inverse_distortion.cpp')]
 
-    extra_compile_args = ['-O3', '-Wall', '-shared', '-std=c++20', '-funroll-loops']
+    extra_compile_args = ['-O3', '-Wall', '-shared', '-funroll-loops']
     if not sys.platform.startswith('win'):
         extra_compile_args.append('-fPIC')
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def get_cpp_extensions():
     cpp_transform_pkgdir = Path('hexrd') / 'transforms/cpp_sublibrary'
     src_files = [str(cpp_transform_pkgdir / 'src/transforms.cpp'), str(cpp_transform_pkgdir / 'src/inverse_distortion.cpp')]
 
-    extra_compile_args = ['-O3', '-Wall', '-shared', '-funroll-loops']
+    extra_compile_args = ['-O3', '-Wall', '-shared', '-std=c++11', '-funroll-loops']
     if not sys.platform.startswith('win'):
         extra_compile_args.append('-fPIC')
 

--- a/setup.py
+++ b/setup.py
@@ -70,12 +70,12 @@ def get_include_path(library_name):
         return env_var_hint
 
     possible_directories = [
+        sysconfig.get_path('include')+f'/../{library_name}'
         "/xsimd/include/xsimd",
         "/eigen3/eigen-3.4.0",
         "/",
         "/usr/include",
         "/usr/local/include",
-        sysconfig.get_path('include'),
     ]
 
     for directory in possible_directories:


### PR DESCRIPTION
This PR includes a number of significant performance improvements in most workflows, in particular due to the fact that it now leverages the C++ libraries xsimd and Eigen to perform efficient math.

- The function [_ge_41rt_inverse_distortion](https://github.com/HEXRD/hexrd/blob/master/hexrd/distortion/ge_41rt.py#L17-L57) previously attempted to solve for the roots of a 6th-degree polynomial. However, as @piguy1010 noticed, degrees 4, 5, and 6 are always 2. Therefore, this function can be simplified to solve for the roots of a 3rd-degree polynomial instead, yielding a 4x speedup. [The updated Python code](https://github.com/HEXRD/hexrd/blob/performance-tuning/hexrd/distortion/ge_41rt.py#L18-L27) which does this simpler computation is included. However, using [the C++ version](https://github.com/HEXRD/hexrd/blob/performance-tuning/hexrd/transforms/cpp_sublibrary/src/inverse_distortion.cpp#L11-L22) yields a 2x speedup over the Python version. This is used by default in this branch.
- The transforms module, previously written in C, has been [partly refactored into C++](https://github.com/HEXRD/hexrd/blob/32cb8418503c231852953a93e0c7214530b7e47c/hexrd/transforms/cpp_sublibrary/src/transforms.cpp), heavily leveraging SIMD instructions. Using this built library yields an expected 1.5-4x performance increase, depending on the functions used. Note, in particular, the combination function (which needs a less verbose name) [anglesToGvecToDetectorXYFromAngles](https://github.com/HEXRD/hexrd/blob/performance-tuning/hexrd/transforms/cpp_sublibrary/src/transforms.cpp#L297-L320) which combines the logic of `makeOscillRotMat`, `anglesToGvec`, and `gvecToDetectorXY` to avoid unnecessary data conversion between numpy arrays in Python and C++ arrays, yielding an additional 1.25x speedup by itself.

More specific benchmarking results to follow, but in my testing with the ruby dataset, this PR cuts out an estimated 40% of the runtime in the single ruby dataset from the examples repository. Further analysis is required, as this was only tested on one machine with 20 CPU threads, and may not reflect results on a more diverse compute field.

Anecdotally, the simple change of `_ge_41rt_inverse_distortion` in pure Python to solve a 3rd degree polynomial gave Chris Budrow a 1.5x speedup in his workflow. So, I'm very eager to see the results of a benchmark including all of the changes in this PR.

@psavery I would like your advice in generating more robust unit testing for these changes.