### PR TITLE
Try using libmamba solver for conda packaging

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -21,6 +21,10 @@ ${HOME}/miniconda3/bin/conda create --override-channels -c conda-forge -y -n hex
 ${HOME}/miniconda3/bin/activate hexrd
 ${HOME}/miniconda3/bin/conda activate hexrd
 
+# Install the libmamba solver (it is much faster)
+${HOME}/miniconda3/bin/conda install -n base -c conda-forge conda-libmamba-solver
+${HOME}/miniconda3/bin/conda config --set solver libmamba
+
 # Install conda build and create output directory
 ${HOME}/miniconda3/bin/conda install --override-channels -c conda-forge conda-build -y
 mkdir output

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,6 +46,9 @@ jobs:
     - name: Install build requirements
       run: |
           conda activate hexrd
+          # Change default solver to be libmamba, so that it runs much faster
+          conda install -n base -c conda-forge conda-libmamba-solver
+          conda config --set solver libmamba
           # FIXME: downgrade urllib3 until this issue is fixed:
           # https://github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install --override-channels -c conda-forge anaconda-client conda-build conda 'urllib3<2.0.0'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -62,15 +62,17 @@ jobs:
       if: ${{ matrix.config.name != 'Linux' }}
       run: |
           conda activate hexrd
-          conda install -n base -c conda-forge conda-libmamba-solver
+          # For some reason, we need to set this in the environment as well.
+          # It seems conda build sometimes needs the solver in the environment
+          # and sometimes in the base environment. I don't know why.
           conda install -c conda-forge conda-libmamba-solver
-          conda config --set solver libmamba
           conda config --env --set solver libmamba
           mkdir output
           # Conda build is ignoring the .condarc for some reason, so we need to
           # set this environment variable instead.
+          # Setting this variable via `env` did not seem to work for some reason.
           export CONDA_SOLVER=libmamba
-          CONDA_SOLVER=libmamba conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
+          conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,10 +45,11 @@ jobs:
 
     - name: Install build requirements
       run: |
-          conda activate hexrd
           # Change default solver to be libmamba, so that it runs much faster
           conda install -n base -c conda-forge conda-libmamba-solver
           conda config --set solver libmamba
+
+          conda activate hexrd
           # FIXME: downgrade urllib3 until this issue is fixed:
           # https://github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install --override-channels -c conda-forge anaconda-client conda-build conda 'urllib3<2.0.0'
@@ -61,8 +62,15 @@ jobs:
       if: ${{ matrix.config.name != 'Linux' }}
       run: |
           conda activate hexrd
+          conda install -n base -c conda-forge conda-libmamba-solver
+          conda install -c conda-forge conda-libmamba-solver
+          conda config --set solver libmamba
+          conda config --env --set solver libmamba
           mkdir output
-          conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
+          # Conda build is ignoring the .condarc for some reason, so we need to
+          # set this environment variable instead.
+          export CONDA_SOLVER=libmamba
+          CONDA_SOLVER=libmamba conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}


### PR DESCRIPTION
It is [officially supported by conda](https://www.anaconda.com/blog/conda-is-fast-now), and it is significantly faster.

Before this commit, Windows packaging usually takes 1 hour and 15 minutes. Mac packaging usually takes about 45 minutes. Linux usually takes about 35 minutes.

We'll see if there are any noticeable differences.

Fixes: #556