### PR TITLE
Change "hexrd-prerelease" label to "prerelease"

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -102,7 +102,7 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
           conda activate hexrd
-          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD --label hexrd-prerelease output/**/*.tar.bz2
+          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD --label prerelease output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ conda install -c hexrd -c conda-forge hexrd
 To install the latest changes on master, do the following (Note that this release may be unstable!):
 
 ```bash
-conda install -c hexrd/label/hexrd-prerelease -c hexrd -c conda-forge hexrd
+conda install -c hexrd/label/prerelease -c conda-forge hexrd
 ```
 
 # Run
@@ -87,7 +87,7 @@ conda activate hexrd-dev
 conda install -c conda-forge python=3.9
 
 # Install deps using conda package
-conda install -c hexrd/label/hexrd-prerelease -c hexrd -c conda-forge hexrd
+conda install -c hexrd/label/prerelease -c conda-forge hexrd
 
 # Now using pip to link repo's into environment for development
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
@@ -100,7 +100,7 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 conda install -c conda-forge python=3.9
 
 # Install deps using conda package
-conda install -c hexrd/label/hexrd-prerelease -c hexrd -c conda-forge hexrd
+conda install -c hexrd/label/prerelease -c conda-forge hexrd
 
 # Now using pip to link repo's into environment for development
 set CONDA_BUILD=1


### PR DESCRIPTION
We are planning to combine the "hexrd-prerelease" and "hexrdgui-prerelease" channels into just "prerelease", so that the installations are simpler:

```bash
 # HEXRD
conda install -c hexrd/label/prerelease -c conda-forge hexrd

 # HEXRDGUI
conda install -c hexrd/label/prerelease -c conda-forge hexrdgui
```