### PR TITLE
Only include "roi" in the config if it is not None

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -637,9 +637,12 @@ class Detector:
                 columns=int(self.cols),
                 size=[float(self.pixel_size_row),
                       float(self.pixel_size_col)],
-                roi=roi
             )
         )
+
+        if roi is not None:
+            # Only add roi if it is not None
+            det_dict['pixels']['roi'] = roi
 
         # distortion
         if self.distortion is not None:


### PR DESCRIPTION
The config is valid without the "roi". If the "roi" is None, we just should not include it at all.

This helps clean up the tree view a little bit in HEXRDGUI, so that there isn't an "roi" present when there is none.