### PR TITLE
Add property for point group number to material

### DIFF
--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -1159,6 +1159,9 @@ SYM_GL_PG = {
     'td': '2dm',
     'oh': '3dgh'
 }
+# The above dict must be in the correct order for this to work
+SYM_PG_to_PGNUM = {pg: i + 1 for i, pg in enumerate(SYM_GL_PG)}
+SYM_PGNUM_to_PG = {v: k for k, v in SYM_PG_to_PGNUM.items()}
 
 # Set the __version__ variable
 try:

--- a/hexrd/material.py
+++ b/hexrd/material.py
@@ -852,6 +852,11 @@ class Material(object):
 
     sgnum = property(_get_sgnum, _set_sgnum, None,
                      "Space group number")
+
+    @property
+    def pgnum(self):
+        return self.unitcell.pgnum
+
     # property:  beamEnergy
 
     def _get_beamEnergy(self):

--- a/hexrd/unitcell.py
+++ b/hexrd/unitcell.py
@@ -1662,6 +1662,14 @@ class unitcell:
         self.calc_absorption_length()
 
     @property
+    def pgnum(self):
+        return constants.SYM_PG_to_PGNUM[self.point_group]
+
+    @property
+    def point_group(self):
+        return self._pointGroup
+
+    @property
     def atom_pos(self):
         return self._atom_pos
 


### PR DESCRIPTION
The material's (or unitcell's) point group can now be accessed via a `pgnum` property.

This also adds some dicts that store this info.