### PR TITLE
Add matplotlib as a dependency to HEXRD

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - fast-histogram
     - h5py
     - lmfit
+    - matplotlib-base
     - numba
     - {{ pin_compatible('numpy') }}
     - psutil

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_reqs = [
     'fast-histogram',
     'h5py',
     'lmfit',
+    'matplotlib',
     'numba',
     'numpy<1.27',  # noqa NOTE: bump this to support the latest version numba supports
     'psutil',


### PR DESCRIPTION
Nearly every HEXRD user plans to use matplotlib to visualize their data. In fact, we also use it as an optional dependency in several places in the code. Some users have been surprised, however, that they need to install matplotlib separately.

The near-field workflow will soon become a part of HEXRD, and visualizing via matplotlib is essential to the workflow. Users have requested that we add matplotlib as a dependency.

This adds about 50 MB to the disk space usage in a virtual environment (most of that is fonts and images). It won't add any disk space to HEXRDGUI, however, since HEXRDGUI already depends on matplotlib.

This will ultimately make HEXRD easier to use and analyze.