### PR TITLE
Add support for detector "group" key

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -165,7 +165,7 @@ class Detector:
                  saturation_level=None,
                  panel_buffer=None,
                  tth_distortion=None,
-                 roi=None,
+                 roi=None, group=None,
                  distortion=None,
                  max_workers=max_workers_DFLT):
         """
@@ -196,6 +196,8 @@ class Detector:
             in mm. If an array with shape (nrows, ncols), interpretation is a
             boolean with True marking valid pixels.  The default is None.
         roi : TYPE, optional
+            DESCRIPTION. The default is None.
+        group : TYPE, optional
             DESCRIPTION. The default is None.
         distortion : TYPE, optional
             DESCRIPTION. The default is None.
@@ -238,6 +240,8 @@ class Detector:
         self._distortion = distortion
 
         self.max_workers = max_workers
+
+        self.group = group
 
         #
         # set up calibration parameter list and refinement flags
@@ -643,6 +647,10 @@ class Detector:
         if roi is not None:
             # Only add roi if it is not None
             det_dict['pixels']['roi'] = roi
+
+        if self.group is not None:
+            # Only add group if it is not None
+            det_dict['group'] = self.group
 
         # distortion
         if self.distortion is not None:

--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -589,7 +589,7 @@ class HEDMInstrument(object):
                     xrs_dist=self._source_distance,
                     evec=self._eta_vector,
                     distortion=None,
-                    roi=None,
+                    roi=None, group=None,
                     max_workers=self.max_workers),
                 )
 
@@ -631,6 +631,7 @@ class HEDMInstrument(object):
             detectors_config = instrument_config['detectors']
             det_dict = dict.fromkeys(detectors_config)
             for det_id, det_info in detectors_config.items():
+                det_group = det_info.get('group')  # optional detector group
                 pixel_info = det_info['pixels']
                 affine_info = det_info['transform']
                 detector_type = det_info.get('detector_type', 'planar')
@@ -702,6 +703,7 @@ class HEDMInstrument(object):
                     evec=self._eta_vector,
                     distortion=distortion,
                     roi=roi,
+                    group=det_group,
                     max_workers=self.max_workers,
                 )
 


### PR DESCRIPTION
For use cases (like ROI) where a single image may be associated with multiple detectors the "group" key can be included to indicate which detectors should be grouped together.