### PR TITLE
Remove transform section from these detectors

### DIFF
--- a/hexrd/resources/detector_templates/dexela-2923-detector-subpanel.yml
+++ b/hexrd/resources/detector_templates/dexela-2923-detector-subpanel.yml
@@ -5,12 +5,3 @@ Dexela 2923 Subpanel:
     columns: 1536
     rows: 1944
     size: [0.0748, 0.0748]
-  transform:
-    tilt:
-      - 0
-      - 0
-      - 0
-    translation:
-      - 0
-      - 0
-      - 0

--- a/hexrd/resources/detector_templates/dexela-2923-detector.yml
+++ b/hexrd/resources/detector_templates/dexela-2923-detector.yml
@@ -5,12 +5,3 @@ Dexela 2923:
     columns: 3072
     rows: 3888
     size: [0.0748, 0.0748]
-  transform:
-    tilt:
-      - 0
-      - 0
-      - 0
-    translation:
-      - 0
-      - 0
-      - 0


### PR DESCRIPTION
The current translation of [0, 0, 0] doesn't work well with HEXRDGUI, since it indicates that the detector is on top of the sample.

We should make the transform section optional instead. If it is not provided, then HEXRDGUI will insert the default transform section. This will make the views work better...

If some detectors typically have a certain transform, it can still be provided and that will be used instead of the default.