### PR TITLE
Update rawimage.py

### DIFF
--- a/hexrd/imageseries/load/rawimage.py
+++ b/hexrd/imageseries/load/rawimage.py
@@ -109,6 +109,7 @@ class RawImageSeriesAdapter(ImageSeriesAdapter):
             self.iframe = 0
         if key == 0:
             self.f.seek(0, 0)
+            _ = np.fromfile(self.f, np.byte, count=self.skipbytes) #dcp fix to make sure bytes are properly skipped
             self.iframe = 0
         if key != self.iframe:
             msg = "frame %d not available, series must be read in sequence!"


### PR DESCRIPTION
Bug found that when using this images series 'raw-images' option and calling the first image, the skip bytes wasn't being properly accounted for.

This change fixes it.