### PR TITLE
ProcessedImageseries with frame_list automatically updates omega metadata

### DIFF
--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -32,6 +32,8 @@ class ProcessedImageSeries(ImageSeries):
         self._oplist = oplist
         self._frames = kwargs.pop('frame_list', None)
         self._hasframelist = (self._frames is not None)
+        if self._hasframelist:
+            self._update_omega()
         self._opdict = {}
 
         self.addop(self.DARK, self._subtract_dark)
@@ -109,6 +111,11 @@ class ProcessedImageSeries(ImageSeries):
     def _gauss_laplace(self, img, sigma):
         return scipy.ndimage.gaussian_laplace(img, sigma)
 
+    def _update_omega(self):
+        """Update omega if there is a framelist"""
+        if "omega" in self.metadata:
+            omega = self.metadata["omega"]
+            self.metadata["omega"] = omega[self._frames]
     #
     # ==================== API
     #

--- a/tests/imageseries/common.py
+++ b/tests/imageseries/common.py
@@ -41,6 +41,15 @@ def make_array_ims():
     return random_array, is_a
 
 
+def make_meta():
+    md = {'testing': '1,2,3'}
+    return {'testing': np.array([1, 2, 3])}
+
+
+def make_omega_meta(n):
+    return np.linspace((0,0), (1, 1), n)
+
+
 def compare(ims1, ims2):
     """compare two imageseries"""
     if len(ims1) != len(ims2):
@@ -60,11 +69,6 @@ def compare(ims1, ims2):
         maxdiff = np.maximum(maxdiff, fdiff)
 
     return maxdiff
-
-
-def make_meta():
-    md = {'testing': '1,2,3'}
-    return {'testing': np.array([1, 2, 3])}
 
 
 def compare_meta(ims1, ims2):

--- a/tests/imageseries/test_process.py
+++ b/tests/imageseries/test_process.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .common import ImageSeriesTest, make_array_ims, compare
+from .common import ImageSeriesTest, make_array_ims, make_omega_meta, compare
 
 from hexrd import imageseries
 from hexrd.imageseries import process, ImageSeries
@@ -81,12 +81,15 @@ class TestImageSeriesProcess(ImageSeriesTest):
     def test_process_framelist(self):
         a, _ = make_array_ims()
         is_a = imageseries.open(None, 'array', data=a)
+        is_a.metadata["omega"] = make_omega_meta(len(is_a))
         ops = []
         frames = [0, 2]
         is_p = process.ProcessedImageSeries(is_a, ops, frame_list=frames)
         is_a2 = imageseries.open(None, 'array', data=a[tuple(frames), ...])
         diff = compare(is_a2, is_p)
         self.assertAlmostEqual(diff, 0., msg="frame list failed")
+        self.assertEqual(len(is_p), len(is_p.metadata["omega"]))
+
 
     def test_process_shape(self):
         a, _ = make_array_ims()


### PR DESCRIPTION
When a `ProcessedImageSeries` is instantiated with a `frame_list`, it now checks the metadata for an `omega` key. If `omega` is present, then the metadata is updated appropriately.