### PR TITLE
Imagefiles yaml text

### DIFF
--- a/hexrd/imageseries/load/imagefiles.py
+++ b/hexrd/imageseries/load/imagefiles.py
@@ -30,10 +30,8 @@ class ImageFilesImageSeriesAdapter(ImageSeriesAdapter):
 
         Parameters
         ----------
-        fname: string | path
+        fname: string | Path
            name of YAML file or bytestring of YAML contents
-
-
         """
         self._fname = fname
         self._load_yml()
@@ -93,15 +91,18 @@ number of files: %s
         MAXFILF = 'max-file-frames'
         DTYPE = 'dtype'
         #
-        # Check whether fname is a filename or YAML content. If it has multiple
-        # lines, we consider it to be content, otherwise a file name.
+        # Check whether fname is a pathlib Path, a filename or YAML content.
+        # If it has multiple lines, we consider it to be YAML content,
+        # otherwise a file name.
         #
-        nlines = len(self.fname.splitlines())
+        is_str = isinstance(self.fname, str)
+        nlines = len(self.fname.splitlines()) if is_str else 1
         if nlines > 1:
             d = yaml.safe_load(self.fname)
         else:
             with open(self._fname, "r") as f:
                 d = yaml.safe_load(f)
+
         imgsd = d['image-files']
         dname = imgsd['directory']
         fglob = imgsd['files']

--- a/hexrd/imageseries/load/imagefiles.py
+++ b/hexrd/imageseries/load/imagefiles.py
@@ -25,13 +25,15 @@ class ImageFilesImageSeriesAdapter(ImageSeriesAdapter):
 
     format = 'image-files'
 
-    def __init__(self, fname, **kwargs):
+    def __init__(self, fname):
         """Constructor for image files image series
 
-        *fname* - should be yaml file with files and metadata sections
-        *kwargs* - keyword arguments
-                 . 'files' = a list of image files
-                 . 'metadata' = a dictionary
+        Parameters
+        ----------
+        fname: string | path
+           name of YAML file or bytestring of YAML contents
+
+
         """
         self._fname = fname
         self._load_yml()
@@ -81,13 +83,25 @@ number of files: %s
             self.dtype, self.shape, self.singleframes)
         return s
 
+    @property
+    def fname(self):
+        return self._fname
+
     def _load_yml(self):
         EMPTY = 'empty-frames'
         MAXTOTF = 'max-total-frames'
         MAXFILF = 'max-file-frames'
         DTYPE = 'dtype'
-        with open(self._fname, "r") as f:
-            d = yaml.safe_load(f)
+        #
+        # Check whether fname is a filename or YAML content. If it has multiple
+        # lines, we consider it to be content, otherwise a file name.
+        #
+        nlines = len(self.fname.splitlines())
+        if nlines > 1:
+            d = yaml.safe_load(self.fname)
+        else:
+            with open(self._fname, "r") as f:
+                d = yaml.safe_load(f)
         imgsd = d['image-files']
         dname = imgsd['directory']
         fglob = imgsd['files']


### PR DESCRIPTION
This pull request allows you to load an imageseries of type `image-files` by passing the yaml text directly to the `open() `command instead of writing it to a file first and then loading the file.  This is just a convenience for writing raw data processing scripts.

I also have a test file that verifies this, but since it involves a large data file, I chose not to submit it here.  I suggest we add an imageseries directory to the hexrd-examples repository, where we can take advantage of existing large data files.

Here is the test script: 

```import numpy as np

import pytest


from hexrd import imageseries


@pytest.fixture
def image_files_fmt():
    return "image-files"


@pytest.fixture
def yaml_tmpl():
    return """image-files:
  directory: .
  files: RUBY_*
options:
  empty-frames: %(n_ef)d
  max-file-frames: %(maxff)d
  max-total-frames: %(maxtf)d
meta: {}
"""


def  test_yaml_text(image_files_fmt, yaml_tmpl, tmp_path):
    """Verify that yaml file and yaml text give same result"""
    d = dict(n_ef=1, maxff=10, maxtf=15)
    p = tmp_path / "image-files.yml"
    yaml_text = yaml_tmpl % d
    with open(p, "w") as f:
        f.write(yaml_text)
    ims_f = imageseries.open(p, image_files_fmt)
    ims_t = imageseries.open(yaml_text, image_files_fmt)

    assert len(ims_f) == len(ims_t)
    assert len(ims_f) == 15
    assert np.all(ims_f[0] == ims_t[0])
```
