### PR TITLE
Frame cache writer

### DIFF
--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -85,8 +85,17 @@ class Writer(object, metaclass=_RegisterWriter):
         self._fname_base = tmp[0]
         self._fname_suff = tmp[1]
 
-    pass  # end class
+    @property
+    def fname(self):
+        return self._fname
 
+    @property
+    def fname_dir(self):
+        return self._fname_dir
+
+    @property
+    def opts(self):
+        return self._opts
 
 class WriteH5(Writer):
     fmt = 'hdf5'
@@ -170,21 +179,46 @@ class WriteFrameCache(Writer):
     def __init__(self, ims, fname, **kwargs):
         """write yml file with frame cache info
 
-        kwargs has keys:
+        The default write option is to save image data and metadata all
+        in a single npz file. The original option was to have a YAML file
+        as the primary file and a specified cache file for the images; this
+        method is deprecated.
 
-        cache_file - name of array cache file
-        meta - metadata dictionary
+        Parameters
+        ----------
+        ims: Imageseries instance
+           the imageseries to write
+        fname: str or Path
+           name of file to write;
+        cache_file: str or Path, optional
+           name of the npz file to save the image data, if not given in the
+           `fname` argument; for YAML format (deprecated), this is required
         """
         Writer.__init__(self, ims, fname, **kwargs)
         self._thresh = self._opts['threshold']
         cf = kwargs['cache_file']
-        if os.path.isabs(cf):
-            self._cache = cf
-        else:
-            cdir = os.path.dirname(fname)
-            self._cache = os.path.join(cdir, cf)
-        self._cachename = cf
+        self._cache, self.cachename = self._set_cache()
         self.max_workers = kwargs.get('max_workers', None)
+
+    def _set_cache(self):
+
+        cf = self.opts.get('cache_file')
+
+        if cf is None:
+            cachename = cache = self.fname
+        else:
+            if os.path.isabs(cf):
+                self._cache = cf
+            else:
+                cdir = os.path.dirname(fname)
+                self._cache = os.path.join(cdir, cf)
+            cachename = cf
+
+        return cache, cachename
+
+    @property
+    def cache(self):
+        return self._cache
 
     def _process_meta(self, save_omegas=False):
         d = {}
@@ -273,7 +307,7 @@ class WriteFrameCache(Writer):
         arrd['nframes'] = len(self._ims)
         arrd['dtype'] = str(self._ims.dtype).encode()
         arrd.update(self._process_meta())
-        np.savez_compressed(self._cache, **arrd)
+        np.savez_compressed(self.cache, **arrd)
 
     def write(self, output_yaml=False):
         """writes frame cache for imageseries
@@ -282,4 +316,8 @@ class WriteFrameCache(Writer):
         """
         self._write_frames()
         if output_yaml:
+            warnings.warn(
+                "YAML output for frame-cache is deprecated",
+                DeprecationWarning
+            )
             self._write_yml()

--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -190,13 +190,14 @@ class WriteFrameCache(Writer):
            the imageseries to write
         fname: str or Path
            name of file to write;
+        threshold: float
+           threshold value for image, at or below which values are zeroed
         cache_file: str or Path, optional
            name of the npz file to save the image data, if not given in the
            `fname` argument; for YAML format (deprecated), this is required
         """
         Writer.__init__(self, ims, fname, **kwargs)
         self._thresh = self._opts['threshold']
-        cf = kwargs['cache_file']
         self._cache, self.cachename = self._set_cache()
         self.max_workers = kwargs.get('max_workers', None)
 
@@ -208,10 +209,10 @@ class WriteFrameCache(Writer):
             cachename = cache = self.fname
         else:
             if os.path.isabs(cf):
-                self._cache = cf
+                cache = cf
             else:
-                cdir = os.path.dirname(fname)
-                self._cache = os.path.join(cdir, cf)
+                cdir = os.path.dirname(self.fname)
+                cache = os.path.join(cdir, cf)
             cachename = cf
 
         return cache, cachename

--- a/tests/imageseries/test_formats.py
+++ b/tests/imageseries/test_formats.py
@@ -95,7 +95,17 @@ class TestFormatFrameCache(ImageSeriesFormatTest):
         """save/load frame-cache format"""
         imageseries.write(self.is_a, self.fcfile, self.fmt,
             threshold=self.thresh, cache_file=self.cache_file)
-        # is_fc = imageseries.open(self.fcfile, self.fmt, style='yml')
+        is_fc = imageseries.open(self.fcfile, self.fmt)
+        diff = compare(self.is_a, is_fc)
+        self.assertAlmostEqual(diff, 0., "frame-cache reconstruction failed")
+        self.assertTrue(compare_meta(self.is_a, is_fc))
+
+    def test_fmtfc_nocache_file(self):
+        """save/load frame-cache format with no cache_file arg"""
+        imageseries.write(
+            self.is_a, self.fcfile, self.fmt,
+            threshold=self.thresh
+        )
         is_fc = imageseries.open(self.fcfile, self.fmt)
         diff = compare(self.is_a, is_fc)
         self.assertAlmostEqual(diff, 0., "frame-cache reconstruction failed")


### PR DESCRIPTION
This allows you to write an imageseries in `frame-cache` format without specfying the `cache_file` keyword argument.

Before this change, you would pass the `filename` argument as well as the the `cache_file`  keyword arg, usually the same value in both places. Now, the cache_file is determined from the filename.  

The history of this is that the original format for `frame-cache` was a YAML file for the metadata, and the imagefiles were stored as sparse arrays in a numpy npz file, the cache file.  Currently the default format is to save all image data and metadata both in the same file, so a separate cache file is not necessary.  

For the YAML format, the cache file (if not an absolute path) is taken relative to the YAML file, so any directory  is prepended to the cache file.  For the single npz file format, this has the annoying affect that if you specify a directory in the YAML file and also in the cache file, the directory gets prepended again to the cache file, invalidating the path.  

I also added a `DeprecationWarning` for writing to the YAML format, since the single file format is concise, efficient and general enough for the metadata likely to be needed with the imageseries.