### PR TITLE
Make __getitem__ for raw imageseries threadsafe

### DIFF
--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -1257,7 +1257,10 @@ class HEDMInstrument(object):
                     func(task)
             else:
                 with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                    executor.map(func, tasks)
+                    # Evaluate the results via `list()`, so that if an
+                    # exception is raised in a thread, it will be re-raised
+                    # and visible to the user.
+                    list(executor.map(func, tasks))
 
             ring_maps_panel[det_key] = ring_maps
 


### PR DESCRIPTION
This ensures that for multithreaded situations (such as writing out a frame cache), `__getitem__` will be thread-safe. The change ensures that the frame will be obtained immediately after seeking, and no other thread can seek until the frame is obtained.

When I test the example Darren gave us (#608) on the master branch with no multithreading, it ran in 5m 37s. With this change, and using multithreading, it ran in 5m 13s. So the multithreading produced a minor speed increase.

Fixes: #608