### PR TITLE
fix arguments to cylindrical detector.

### DIFF
--- a/hexrd/projections/polar.py
+++ b/hexrd/projections/polar.py
@@ -197,7 +197,6 @@ class PolarView:
                detector.distortion)
         if detector.detector_type == 'cylindrical':
             arg = (gvec_angs,
-                   detector.rmat,
                    self.chi,
                    detector.tvec,
                    detector.caxis,


### PR DESCRIPTION
An extra argument to `cylindrical_detector` was being passed. Fixed it.