### PR TITLE
Fix integer overflow issue in fabio

### DIFF
--- a/hexrd/imageseries/load/imagefiles.py
+++ b/hexrd/imageseries/load/imagefiles.py
@@ -227,7 +227,10 @@ number of files: %s
             if frame is None:
                 data = img.data
             else:
-                data = img.getframe(frame).data
+                # Fabio does some arithmetic with the frame number.
+                # This can cause overflows if np.uint32 is used, so
+                # make sure we convert to a Python int before passing to fabio.
+                data = img.getframe(int(frame)).data
 
         return _process_data(filename, data)
 


### PR DESCRIPTION
fabio would perform some arithmetic with the frame number we provided it to compute byte offsets for GE images. On Windows, an `int` times a `np.int32` is an `np.int32`. If our frame number was `np.int32`, for large datasets, this would cause an overflow error, since int32 would be used for the byte offset. 

Instead, ensure a python integer is passed, which *cannot* overflow.