### PR TITLE
Do not set values to 0 that are not referenced.

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -878,10 +878,9 @@ class Detector:
 
                 idx = np.logical_or(roff, coff)
 
-                pix[idx, :] = 0
-
-                on_panel = self.panel_buffer[pix[:, 0], pix[:, 1]]
-                on_panel[idx] = False
+                on_panel = np.full(pix.shape[0], False)
+                valid_pix = pix[~idx, :]
+                on_panel[~idx] = self.panel_buffer[valid_pix[:, 0], valid_pix[:, 1]]
             else:
                 xlim -= self.panel_buffer[0]
                 ylim -= self.panel_buffer[1]
@@ -931,6 +930,7 @@ class Detector:
         int_xy[on_panel] = int_vals
         return int_xy
 
+    @profile
     def interpolate_bilinear(self, xy, img, pad_with_nans=True):
         """
         Interpolate an image array at the specified cartesian points.

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -930,7 +930,7 @@ class Detector:
         int_xy[on_panel] = int_vals
         return int_xy
 
-    @profile
+
     def interpolate_bilinear(self, xy, img, pad_with_nans=True):
         """
         Interpolate an image array at the specified cartesian points.


### PR DESCRIPTION
Removed unnecessary setting of large arrays, roughly 6% estimated speedup for caking scripts.