### PR TITLE
Remove panel buffers from detector templates

### DIFF
--- a/hexrd/resources/detector_templates/GE-detector.yml
+++ b/hexrd/resources/detector_templates/GE-detector.yml
@@ -1,6 +1,5 @@
 GE:
   saturation_level: 14500
-  buffer: [2, 2]
   pixels:
     columns: 2048
     rows: 2048

--- a/hexrd/resources/detector_templates/Pilatus3X_2M-detector.yml
+++ b/hexrd/resources/detector_templates/Pilatus3X_2M-detector.yml
@@ -1,6 +1,5 @@
 Pilatus3X_2M:
   saturation_level: 1000000
-  buffer: [2, 2]
   pixels:
     columns: 1679
     rows: 1475

--- a/hexrd/resources/detector_templates/Pixirad2-detector.yml
+++ b/hexrd/resources/detector_templates/Pixirad2-detector.yml
@@ -3,7 +3,6 @@
 # pixel density: 323 pixels/mm2, equivalent to 55 μm on square arrangement
 Pixirad2:
   saturation_level: 32768
-  buffer: [2, 2]
   pixels:
     columns: 1024
     rows: 402

--- a/hexrd/resources/detector_templates/Varex_4343CT-detector.yml
+++ b/hexrd/resources/detector_templates/Varex_4343CT-detector.yml
@@ -1,6 +1,5 @@
 Varex_4343CT:
   saturation_level: 65535
-  buffer: [2, 2]
   pixels:
     columns: 2880
     rows: 2880

--- a/hexrd/resources/detector_templates/dexela-2923-detector-subpanel.yml
+++ b/hexrd/resources/detector_templates/dexela-2923-detector-subpanel.yml
@@ -1,6 +1,5 @@
 Dexela 2923 Subpanel:
   saturation_level: 15800
-  buffer: [1, 1]
   pixels:
     columns: 1536
     rows: 1944

--- a/hexrd/resources/detector_templates/dexela-2923-detector.yml
+++ b/hexrd/resources/detector_templates/dexela-2923-detector.yml
@@ -1,6 +1,5 @@
 Dexela 2923:
   saturation_level: 15800
-  buffer: [2, 2]
   pixels:
     columns: 3072
     rows: 3888

--- a/hexrd/resources/instrument_templates/dual_dexelas.yml
+++ b/hexrd/resources/instrument_templates/dual_dexelas.yml
@@ -6,10 +6,6 @@ beam:
     polar_angle: 90.0
 detectors:
   ff1:
-    buffer:
-    - 2.0
-    - 2.0
-    detector_type: planar
     pixels:
       columns: 3072
       rows: 3888
@@ -27,10 +23,6 @@ detectors:
       - 3.325955053634411
       - -670.7508650125019
   ff2:
-    buffer:
-    - 2.0
-    - 2.0
-    detector_type: planar
     pixels:
       columns: 3072
       rows: 3888


### PR DESCRIPTION
Panel buffers of 1-2 mm are too big to use by default. We were running into some issues with these on another dataset.

It seems better to just not have a default panel buffer, so remove them.