### PR TITLE
Use scipy's `convolve` for snip1d

### DIFF
--- a/hexrd/imageutil.py
+++ b/hexrd/imageutil.py
@@ -54,7 +54,7 @@ def fast_snip1d(y, w=4, numiter=2):
                 kernel = np.zeros(p*2 + 1)
                 kernel[0] = 0.5
                 kernel[-1] = 0.5
-                b = np.minimum(b, signal.fftconvolve(z, kernel, mode='same'))
+                b = np.minimum(b, signal.convolve(z, kernel, mode='same'))
             z = b
         bkg[k, :] = _scale_image_snip(b, min_val, invert=True)
     return bkg


### PR DESCRIPTION
According to the [scipy documentation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.convolve.html#scipy.signal.convolve), `convolve` will automatically pick which method to use depending on which method it thinks will be faster.

We were forcing it to use `fftconvolve` before, which, for our example, took about 1.588 seconds to run. Switching to `convolve` now takes about 0.468 seconds instead, so it is noticeably faster.

In our example, the final snip1d result had a max difference of `2.6e-13` compared to using `fftconvolve`, so it appears to have a minimal impact on the results.