### PR TITLE
Update ca certificates for centos Linux build

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -2,7 +2,7 @@
 cd /github/workspace/
 
 # Install dependencies
-yum install -y wget git centos-release-scl
+yum install -y wget git centos-release-scl ca-certificates
 
 # Need to install packages that depend on centos-release-scl on a different line.
 # This will use gcc==10, which is the same as what manylinux2014 uses.


### PR DESCRIPTION
Otherwise, wget is complaining that the certificates are expired when it tries to download miniconda from the anaconda website...