### PR TITLE
Eigen based anglesToGvec implementation

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,8 +22,9 @@ requirements:
     - numba                                  # [build_platform != target_platform]
     - pybind11                               # [build_platform != target_platform]
   host:
-    - python {{ python }}
+    - eigen3
     - numpy >=1.20
+    - python {{ python }}
     - setuptools
     - setuptools_scm
     # Numba is only here to make sure we use a version of numpy that is compatible

--- a/hexrd/transforms/cpp_sublibrary/Makefile
+++ b/hexrd/transforms/cpp_sublibrary/Makefile
@@ -1,18 +1,27 @@
 CXX = c++
-CXXFLAGS = -O3 -Wall -shared -fPIC -funroll-loops -Wno-maybe-uninitialized -Wno-attributes -fopenmp
-INCLUDES = -I/${CONDA_PREFIX}/include -I/${CONDA_PREFIX}/include/python3.11/ -I/${CONDA_PREFIX}/lib/python3.11/site-packages/numpy/core/include
+CXXFLAGS = -O3 -Wall -shared -fPIC -flto -funroll-loops -Wno-maybe-uninitialized -Wno-attributes -ffast-math
+LDFLAGS = -L${CONDA_PREFIX}/lib
+INCLUDES = -I${CONDA_PREFIX}/include -I${CONDA_PREFIX}/include/python3.11/ -I${CONDA_PREFIX}/include/eigen3 -I${CONDA_PREFIX}/envs/hexrd/include/ -I${CONDA_PREFIX}/lib/python3.11/site-packages/numpy/core/include
 SRCS_INVERSE_DISTORTION = src/inverse_distortion.cpp
+SRCS_TRANSFORMS = src/transforms.cpp
 TARGET_DIR = ../../extensions/
 TARGET_NAME_INVERSE_DISTORTION = inverse_distortion
+TARGET_NAME_TRANSFORMS = transforms
 EXTENSION_SUFFIX = $(shell python3-config --extension-suffix)
 
-all: inverse_distortion
+all: inverse_distortion transforms
 
 inverse_distortion: $(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX)
 
-$(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX): $(SRCS_INVERSE_DISTORTION)
-	$(CXX) $(CXXFLAGS) $(PYBIND_INCLUDES) $< -o $@ $(INCLUDES)
+transforms: $(TARGET_DIR)$(TARGET_NAME_TRANSFORMS)$(EXTENSION_SUFFIX)
 
-.PHONY: clean inverse_distortion
+$(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX): $(SRCS_INVERSE_DISTORTION)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
+
+$(TARGET_DIR)$(TARGET_NAME_TRANSFORMS)$(EXTENSION_SUFFIX): $(SRCS_TRANSFORMS)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
+
+.PHONY: clean inverse_distortion transforms
 clean:
 	rm -f $(TARGET_DIR)$(TARGET_NAME_INVERSE_DISTORTION)$(EXTENSION_SUFFIX)
+	rm -f $(TARGET_DIR)$(TARGET_NAME_TRANSFORMS)$(EXTENSION_SUFFIX)

--- a/hexrd/transforms/cpp_sublibrary/src/transforms.cpp
+++ b/hexrd/transforms/cpp_sublibrary/src/transforms.cpp
@@ -1,0 +1,49 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <Eigen/Geometry>
+#include <Eigen/Core>
+#include <cmath>
+
+namespace py = pybind11;
+
+using MatrixXdR = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+Eigen::MatrixX3d anglesToGVec(const MatrixXdR &angs,
+                              const Eigen::Vector3d &bHat,
+                              const Eigen::Vector3d &eHat, double chi,
+                              const Eigen::Matrix3d &rMat_c) noexcept {
+  const size_t vec_size = angs.rows();
+  Eigen::MatrixX3d gVec_c(vec_size, 3);
+
+  const Eigen::Vector3d yHat = eHat.cross(bHat);
+  const Eigen::Vector3d xHat = bHat.cross(yHat);
+  Eigen::Matrix3d rotMat = (Eigen::Matrix3d() << xHat, yHat, -bHat).finished();
+
+  double cchi, schi;
+  sincos(chi, &schi, &cchi);
+  Eigen::Matrix3d preComputedMatrix = rMat_c * Eigen::DiagonalMatrix<double, 3>(1.0, cchi, cchi) * rotMat.transpose();
+
+  for (ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(vec_size); ++i) {
+    double cosAlpha, sinAlpha, cosBeta, sinBeta, cosGamma, sinGamma;
+    sincos(angs(i, 0) / 2.0, &sinAlpha, &cosAlpha);
+    sincos(angs(i, 1), &sinBeta, &cosBeta);
+    sincos(angs(i, 2), &sinGamma, &cosGamma);
+
+    Eigen::Vector3d preMult_gVec(cosAlpha * cosBeta, cosAlpha * sinBeta, sinAlpha);
+
+    Eigen::Vector3d postRot(
+      cosGamma * preMult_gVec.x() + sinGamma * preMult_gVec.y(),
+      schi * (sinGamma * preMult_gVec.x() + preMult_gVec.z()) + cchi * preMult_gVec.y(),
+      cchi * (preMult_gVec.z() - sinGamma * preMult_gVec.x()) - schi * preMult_gVec.y()
+    );
+
+    gVec_c.row(i).noalias() = preComputedMatrix * postRot;
+  }
+
+  return gVec_c;
+}
+
+PYBIND11_MODULE(transforms, m) {
+  m.doc() = "HEXRD transforms plugin";
+  m.def("anglesToGVec", &anglesToGVec, "Convert angles to g-vectors with optimized memory handling and computational efficiency using sincos.");
+}

--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -25,6 +25,7 @@ There are also some functions that maybe would be needed in the transforms modul
 from . import constants as cnst
 from .transforms_definitions import xf_api
 from hexrd.extensions import _new_transforms_capi as _impl
+from hexrd.extensions import transforms as _impl_new
 
 import numpy as np
 
@@ -48,7 +49,7 @@ def angles_to_gvec(
     chi = 0.0 if chi is None else float(chi)
     rmat_c = cnst.identity_3x3 if rmat_c is None else np.ascontiguousarray( rmat_c )
 
-    result = _impl.anglesToGVec(angs, beam_vec, eta_vec, chi, rmat_c)
+    result = _impl_new.anglesToGVec(angs, beam_vec, eta_vec, chi, rmat_c)
 
     return result[0] if orig_ndim == 1 else result
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,9 @@ def get_pybind11_include_path():
 
 def get_cpp_extensions():
     cpp_transform_pkgdir = Path('hexrd') / 'transforms/cpp_sublibrary'
-    src_files = [str(cpp_transform_pkgdir / 'src/inverse_distortion.cpp')]
+
+    inverse_distortion_files = [str(cpp_transform_pkgdir / 'src/inverse_distortion.cpp')]
+    transforms_files = [str(cpp_transform_pkgdir / 'src/transforms.cpp')]
 
     extra_compile_args = ['-O3', '-Wall', '-shared', '-std=c++14',
                           '-funroll-loops']
@@ -122,6 +124,7 @@ def get_cpp_extensions():
 
     # Define include directories
     include_dirs = [
+        get_include_path('eigen3'),
         get_include_path('xsimd'),
         get_include_path('xtensor'),
         get_include_path('xtensor-python'),
@@ -132,13 +135,21 @@ def get_cpp_extensions():
 
     inverse_distortion_ext = Extension(
         name='hexrd.extensions.inverse_distortion',
-        sources=src_files,
+        sources=inverse_distortion_files,
         extra_compile_args=extra_compile_args,
         include_dirs=include_dirs,
         language='c++',
     )
 
-    return [inverse_distortion_ext]
+    transforms_ext = Extension(
+        name='hexrd.extensions.transforms',
+        sources=transforms_files,
+        extra_compile_args=extra_compile_args,
+        include_dirs=include_dirs,
+        language='c++',
+    )
+
+    return [inverse_distortion_ext, transforms_ext]
 
 
 def get_old_xfcapi_extension_modules():


### PR DESCRIPTION
Convert the C implementation of anglesToGvec to C++, using the Eigen library for optimized matrix performance.

Expected single-thread performance increase: 10%

Future improvements can be made by building and optimizing for different CPU architectures, using the `march` option at compile time.