### PR TITLE
Downgrade packaging macos to 12

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-latest
+            os: macos-12
           }
         - {
             name: "Windows",


### PR DESCRIPTION
This is the last version to use x86_64. The runners are starting to, by default, use arm64 (Apple silicon).