### PR TITLE
Docstrings

### DIFF
--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -45,23 +45,23 @@ def angles_to_gvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
     Parameters
     ----------
     angs : ndarray
-        The euler angles of diffraction. The last dimension must be 3.  In 
+        The euler angles of diffraction. The last dimension must be 3.  In
         (2*theta, eta, omega) format.
     beam_vec : ndarray, optional
-        Unit vector pointing towards the X-ray source in the lab frame.  
+        Unit vector pointing towards the X-ray source in the lab frame.
         Defaults to [0,0,-1]
     eta_vec : ndarray, optional
         Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
     chi : float, optional
         The inclination angle of the sample frame about the lab frame X.
     rmat_c : ndarray, optional
-        The change of basis matrix from the reciprocal frame to the crystal 
+        The change of basis matrix from the reciprocal frame to the crystal
         frame.  Defaults to the identity.
 
     Returns
     -------
     ndarray
-        (3,n) array of unit reciprocal lattice vectors, frame depends on the 
+        (3,n) array of unit reciprocal lattice vectors, frame depends on the
         input parameters
     """
 
@@ -101,23 +101,23 @@ def angles_to_dvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
     Parameters
     ----------
     angs : ndarray
-        The euler angles of diffraction. The last dimension must be 3.  In 
+        The euler angles of diffraction. The last dimension must be 3.  In
         (2*theta, eta, omega) format.
     beam_vec : ndarray, optional
-        Unit vector pointing towards the X-ray source in the lab frame.  
+        Unit vector pointing towards the X-ray source in the lab frame.
         Defaults to [0,0,-1]
     eta_vec : ndarray, optional
         Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
     chi : float, optional
         The inclination angle of the sample frame about the lab frame X.
     rmat_c : ndarray, optional
-        The change of basis matrix from the reciprocal frame to the crystal 
+        The change of basis matrix from the reciprocal frame to the crystal
         frame.  Defaults to the identity.
 
     Returns
     -------
     ndarray
-        (3,n) array of unit diffraction vectors, frame depends on the input 
+        (3,n) array of unit diffraction vectors, frame depends on the input
         parameters
     """
     # TODO: Improve capi to avoid multiplications when rmat_c is None
@@ -139,23 +139,24 @@ def angles_to_dvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
 
 def makeGVector(hkl, bMat):
     """
-    Take a crystal relative b matrix onto a list of hkls to output unit 
+    Take a crystal relative b matrix onto a list of hkls to output unit
     reciprocal latice vectors (a.k.a. lattice plane normals)
 
 
     Parameters
     ----------
     hkl : ndarray
-        (3,n) ndarray of n hstacked reciprocal lattice vector component triplets
+        (3,n) ndarray of n hstacked reciprocal lattice vector component
+        triplets
     bMat : ndarray
-        (3,3) ndarray of the change of basis matrix from the reciprocal 
+        (3,3) ndarray of the change of basis matrix from the reciprocal
         lattice to the crystal reference frame
 
     Returns
     -------
     ndarray
-        (3,n) ndarray of n unit reciprocal lattice vectors (a.k.a. lattice plane
-        normals)
+        (3,n) ndarray of n unit reciprocal lattice vectors (a.k.a. lattice
+        plane normals)
 
     """
     assert hkl.shape[0] == 3, 'hkl input must be (3, n)'
@@ -221,16 +222,16 @@ def gvec_to_xy(
     Returns
     -------
     array_like
-        The ([M, ][N, ] 2) array of [x, y] diffracted beam intersections for 
-        each of the N input G-vectors in the DETECTOR FRAME (all Z_d coordinates 
-        are 0 and excluded) and for each of the M candidate positions. For each
-        input G-vector that cannot satisfy a Bragg condition or intersect the
-        detector plane, [NaN, Nan] is returned.
+        The ([M, ][N, ] 2) array of [x, y] diffracted beam intersections for
+        each of the N input G-vectors in the DETECTOR FRAME (all Z_d
+        coordinates are 0 and excluded) and for each of the M candidate
+        positions. For each input G-vector that cannot satisfy a Bragg
+        condition or intersect the detector plane, [NaN, Nan] is returned.
 
     Notes
     -----
-        Previously only a single candidate position was allowed. This is in fact
-        a vectored version of the previous API function. It is backwards
+        Previously only a single candidate position was allowed. This is in
+        fact a vectored version of the previous API function. It is backwards
         compatible, as passing single tvec_c is supported and has the same
         result.
 
@@ -313,15 +314,15 @@ def xy_to_gvec(
     array_like, optional
         if output_ref is True
     """
-    # TODO: in the C library beam vector and eta vector are expected. However 
+    # TODO: in the C library beam vector and eta vector are expected. However
     # we receive rmat_b. Please check this!
     #
-    # It also seems that the output_ref version is not present as the argument 
+    # It also seems that the output_ref version is not present as the argument
     # gets ignored
 
     rmat_b = rmat_b if rmat_b is not None else cnst.identity_3x3
 
-    # the code seems to ignore this argument, assume output_ref == True not 
+    # the code seems to ignore this argument, assume output_ref == True not
     # implemented
     assert not output_ref, 'output_ref not implemented'
 
@@ -426,7 +427,7 @@ def make_oscill_rot_mat_array(chi, omeArray):
 def make_sample_rmat(chi, ome):
     # TODO: Check this docstring
     """
-    Make a rotation matrix representing the COB from sample frame to the lab 
+    Make a rotation matrix representing the COB from sample frame to the lab
     frame.
 
     Parameters
@@ -492,7 +493,7 @@ def make_beam_rmat(bvec_l, evec_l):
     Parameters
     ----------
     bvec_l : ndarray
-        The beam vector in the lab frame, The (3, ) incident beam propagation 
+        The beam vector in the lab frame, The (3, ) incident beam propagation
         vector components in the lab frame.
         the default is [0, 0, -1], which is the standard setting.
     evec_l : ndarray
@@ -517,7 +518,7 @@ def validate_angle_ranges(ang_list, start_angs, stop_angs, ccw=True):
     stop_angs : ndarray
         The stopping angles
     ccw : bool, optional
-        If True, the angles are in the CCW range from start to stop.  
+        If True, the angles are in the CCW range from start to stop.
         Defaults to True.
 
     Returns
@@ -562,7 +563,7 @@ def rotate_vecs_about_axis(angle, axis, vecs):
 @xf_api
 def quat_distance(q1, q2, qsym):
     """
-    Distance between two quaternions, taking quaternions of symmetry into 
+    Distance between two quaternions, taking quaternions of symmetry into
     account.
 
     Parameters

--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -348,7 +348,7 @@ def unit_vector(vec_in):
     Parameters
     ----------
     vec_in : ndarray
-        The input vector(s) (3,n) to normalize.
+        The input vector(s) (n,3) to normalize.
 
     Returns
     -------

--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -17,7 +17,8 @@ Currently, this implementation contains code for the following functions:
  - rotate_vecs_about_axis
  - quat_distance
 
-There are also some functions that maybe would be needed in the transforms module:
+There are also some functions that maybe would be needed in the transforms 
+module:
  - makeGVector
  - makeRotMatOfQuat
  - homochoricOfQuat
@@ -29,14 +30,10 @@ from hexrd.extensions import _new_transforms_capi as _impl
 import numpy as np
 
 
-
 @xf_api
-def angles_to_gvec(
-        angs,
-        beam_vec=None, eta_vec=None,
-        chi=None, rmat_c=None):
+def angles_to_gvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
     """
-    
+
     Takes triplets of angles in the beam frame (2*theta, eta, omega)
     to components of unit G-vectors in the LAB frame.  If the omega
     values are not trivial (i.e. angs[:, 2] = 0.), then the components
@@ -48,20 +45,24 @@ def angles_to_gvec(
     Parameters
     ----------
     angs : ndarray
-        The euler angles of diffraction. The last dimension must be 3.  In (2*theta, eta, omega) format.
+        The euler angles of diffraction. The last dimension must be 3.  In 
+        (2*theta, eta, omega) format.
     beam_vec : ndarray, optional
-        Unit vector pointing towards the X-ray source in the lab frame.  Defaults to [0,0,-1]
+        Unit vector pointing towards the X-ray source in the lab frame.  
+        Defaults to [0,0,-1]
     eta_vec : ndarray, optional
         Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
     chi : float, optional
         The inclination angle of the sample frame about the lab frame X.
     rmat_c : ndarray, optional
-        The change of basis matrix from the reciprocal frame to the crystal frame.  Defaults to the identity.
+        The change of basis matrix from the reciprocal frame to the crystal 
+        frame.  Defaults to the identity.
 
     Returns
     -------
     ndarray
-        (3,n) array of unit reciprocal lattice vectors, frame depends on the input parameters
+        (3,n) array of unit reciprocal lattice vectors, frame depends on the 
+        input parameters
     """
 
     orig_ndim = angs.ndim
@@ -69,15 +70,17 @@ def angles_to_gvec(
     # if only a pair is provided... convert to a triplet with omegas == 0
     # so that behavior is preserved.
     if angs.shape[-1] == 2:
-        angs = np.hstack((angs, np.zeros(angs.shape[:-1]+(1,))))
+        angs = np.hstack((angs, np.zeros(angs.shape[:-1] + (1,))))
 
-    angs = np.ascontiguousarray( np.atleast_2d(angs) )
+    angs = np.ascontiguousarray(np.atleast_2d(angs))
     beam_vec = beam_vec if beam_vec is not None else cnst.beam_vec
-    beam_vec = np.ascontiguousarray( beam_vec.flatten() )
+    beam_vec = np.ascontiguousarray(beam_vec.flatten())
     eta_vec = eta_vec if eta_vec is not None else cnst.eta_vec
-    eta_vec = np.ascontiguousarray( eta_vec.flatten() )
+    eta_vec = np.ascontiguousarray(eta_vec.flatten())
     chi = 0.0 if chi is None else float(chi)
-    rmat_c = cnst.identity_3x3 if rmat_c is None else np.ascontiguousarray( rmat_c )
+    rmat_c = (
+        cnst.identity_3x3 if rmat_c is None else np.ascontiguousarray(rmat_c)
+    )
 
     result = _impl.anglesToGVec(angs, beam_vec, eta_vec, chi, rmat_c)
 
@@ -85,12 +88,9 @@ def angles_to_gvec(
 
 
 @xf_api
-def angles_to_dvec(
-        angs,
-        beam_vec=None, eta_vec=None,
-        chi=None, rmat_c=None):
+def angles_to_dvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
     """
-    
+
     Takes triplets of angles in the beam frame (2*theta, eta, omega)
     to components of unit diffraction vectors in the LAB frame.  If the omega
     values are not trivial (i.e. angs[:, 2] = 0.), then the components
@@ -101,38 +101,46 @@ def angles_to_dvec(
     Parameters
     ----------
     angs : ndarray
-        The euler angles of diffraction. The last dimension must be 3.  In (2*theta, eta, omega) format.
+        The euler angles of diffraction. The last dimension must be 3.  In 
+        (2*theta, eta, omega) format.
     beam_vec : ndarray, optional
-        Unit vector pointing towards the X-ray source in the lab frame.  Defaults to [0,0,-1]
+        Unit vector pointing towards the X-ray source in the lab frame.  
+        Defaults to [0,0,-1]
     eta_vec : ndarray, optional
         Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
     chi : float, optional
         The inclination angle of the sample frame about the lab frame X.
     rmat_c : ndarray, optional
-        The change of basis matrix from the reciprocal frame to the crystal frame.  Defaults to the identity.
+        The change of basis matrix from the reciprocal frame to the crystal 
+        frame.  Defaults to the identity.
 
     Returns
     -------
     ndarray
-        (3,n) array of unit diffraction vectors, frame depends on the input parameters
+        (3,n) array of unit diffraction vectors, frame depends on the input 
+        parameters
     """
     # TODO: Improve capi to avoid multiplications when rmat_c is None
     beam_vec = beam_vec if beam_vec is not None else cnst.beam_vec
     eta_vec = eta_vec if eta_vec is not None else cnst.eta_vec
 
-    angs = np.ascontiguousarray( np.atleast_2d(angs) )
-    beam_vec = np.ascontiguousarray( beam_vec.flatten() )
-    eta_vec = np.ascontiguousarray( eta_vec.flatten() )
-    rmat_c = np.ascontiguousarray(rmat_c) if rmat_c is not None else cnst.identity_3x3
+    angs = np.ascontiguousarray(np.atleast_2d(angs))
+    beam_vec = np.ascontiguousarray(beam_vec.flatten())
+    eta_vec = np.ascontiguousarray(eta_vec.flatten())
+    rmat_c = (
+        np.ascontiguousarray(rmat_c)
+        if rmat_c is not None
+        else cnst.identity_3x3
+    )
     chi = 0.0 if chi is None else float(chi)
 
-    return _impl.anglesToDVec(angs,
-                                         beam_vec, eta_vec,
-                                         chi, rmat_c)
+    return _impl.anglesToDVec(angs, beam_vec, eta_vec, chi, rmat_c)
+
 
 def makeGVector(hkl, bMat):
     """
-    Take a crystal relative b matrix onto a list of hkls to output unit reciprocal latice vectors (a.k.a. lattice plane normals)
+    Take a crystal relative b matrix onto a list of hkls to output unit 
+    reciprocal latice vectors (a.k.a. lattice plane normals)
 
 
     Parameters
@@ -140,12 +148,14 @@ def makeGVector(hkl, bMat):
     hkl : ndarray
         (3,n) ndarray of n hstacked reciprocal lattice vector component triplets
     bMat : ndarray
-        (3,3) ndarray of the change of basis matrix from the reciprocal lattice to the crystal reference frame
+        (3,3) ndarray of the change of basis matrix from the reciprocal 
+        lattice to the crystal reference frame
 
     Returns
     -------
     ndarray
-        (3,n) ndarray of n unit reciprocal lattice vectors (a.k.a. lattice plane normals)
+        (3,n) ndarray of n unit reciprocal lattice vectors (a.k.a. lattice plane
+        normals)
 
     """
     assert hkl.shape[0] == 3, 'hkl input must be (3, n)'
@@ -153,13 +163,18 @@ def makeGVector(hkl, bMat):
 
 
 @xf_api
-def gvec_to_xy(gvec_c,
-               rmat_d, rmat_s, rmat_c,
-               tvec_d, tvec_s, tvec_c,
-               beam_vec=None,
-               vmat_inv=None,
-               bmat=None):
-    
+def gvec_to_xy(
+    gvec_c,
+    rmat_d,
+    rmat_s,
+    rmat_c,
+    tvec_d,
+    tvec_s,
+    tvec_c,
+    beam_vec=None,
+    vmat_inv=None,
+    bmat=None,
+):
     """
     Takes a concatenated list of reciprocal lattice vectors components in the
     CRYSTAL FRAME to the specified detector-relative frame, subject to the
@@ -206,9 +221,9 @@ def gvec_to_xy(gvec_c,
     Returns
     -------
     array_like
-        The ([M, ][N, ] 2) array of [x, y] diffracted beam intersections for each
-        of the N input G-vectors in the DETECTOR FRAME (all Z_d coordinates are
-        0 and excluded) and for each of the M candidate positions. For each
+        The ([M, ][N, ] 2) array of [x, y] diffracted beam intersections for 
+        each of the N input G-vectors in the DETECTOR FRAME (all Z_d coordinates 
+        are 0 and excluded) and for each of the M candidate positions. For each
         input G-vector that cannot satisfy a Bragg condition or intersect the
         detector plane, [NaN, Nan] is returned.
 
@@ -223,36 +238,39 @@ def gvec_to_xy(gvec_c,
     beam_vec = beam_vec if beam_vec is not None else cnst.beam_vec
 
     orig_ndim = gvec_c.ndim
-    gvec_c  = np.ascontiguousarray( np.atleast_2d(gvec_c) )
-    rmat_s  = np.ascontiguousarray( rmat_s )
-    tvec_d  = np.ascontiguousarray( tvec_d.flatten()  )
-    tvec_s  = np.ascontiguousarray( tvec_s.flatten()  )
-    tvec_c  = np.ascontiguousarray( tvec_c.flatten()  )
-    beam_vec = np.ascontiguousarray( beam_vec.flatten() )
+    gvec_c = np.ascontiguousarray(np.atleast_2d(gvec_c))
+    rmat_s = np.ascontiguousarray(rmat_s)
+    tvec_d = np.ascontiguousarray(tvec_d.flatten())
+    tvec_s = np.ascontiguousarray(tvec_s.flatten())
+    tvec_c = np.ascontiguousarray(tvec_c.flatten())
+    beam_vec = np.ascontiguousarray(beam_vec.flatten())
 
     # depending on the number of dimensions of rmat_s use either the array
     # version or the "scalar" (over rmat_s) version. Note that rmat_s is either
     # a 3x3 matrix (ndim 2) or an nx3x4 array of matrices (ndim 3)
     if rmat_s.ndim > 2:
-        result =  _impl.gvecToDetectorXYArray(gvec_c,
-                                              rmat_d, rmat_s, rmat_c,
-                                              tvec_d, tvec_s, tvec_c,
-                                              beam_vec)
+        result = _impl.gvecToDetectorXYArray(
+            gvec_c, rmat_d, rmat_s, rmat_c, tvec_d, tvec_s, tvec_c, beam_vec
+        )
     else:
-        result =  _impl.gvecToDetectorXY(gvec_c,
-                                         rmat_d, rmat_s, rmat_c,
-                                         tvec_d, tvec_s, tvec_c,
-                                         beam_vec)
+        result = _impl.gvecToDetectorXY(
+            gvec_c, rmat_d, rmat_s, rmat_c, tvec_d, tvec_s, tvec_c, beam_vec
+        )
     return result[0] if orig_ndim == 1 else result
 
 
 @xf_api
-def xy_to_gvec(xy_d,
-               rmat_d, rmat_s,
-               tvec_d, tvec_s, tvec_c,
-               rmat_b=None,
-               distortion=None,
-               output_ref=False):
+def xy_to_gvec(
+    xy_d,
+    rmat_d,
+    rmat_s,
+    tvec_d,
+    tvec_s,
+    tvec_c,
+    rmat_b=None,
+    distortion=None,
+    output_ref=False,
+):
     """
     Takes a list cartesian (x, y) pairs in the DETECTOR FRAME and calculates
     the associated reciprocal lattice (G) vectors and (bragg angle, azimuth)
@@ -295,37 +313,45 @@ def xy_to_gvec(xy_d,
     array_like, optional
         if output_ref is True
     """
-    # TODO: in the C library beam vector and eta vector are expected. However we receive
-    # rmat_b. Please check this!
+    # TODO: in the C library beam vector and eta vector are expected. However 
+    # we receive rmat_b. Please check this!
     #
-    # It also seems that the output_ref version is not present as the argument gets
-    # ignored
+    # It also seems that the output_ref version is not present as the argument 
+    # gets ignored
 
     rmat_b = rmat_b if rmat_b is not None else cnst.identity_3x3
 
-    # the code seems to ignore this argument, assume output_ref == True not implemented
-    assert not output_ref , 'output_ref not implemented'
+    # the code seems to ignore this argument, assume output_ref == True not 
+    # implemented
+    assert not output_ref, 'output_ref not implemented'
 
     if distortion is not None:
         xy_d = distortion.unwarp(xy_d)
 
-    xy_d  = np.ascontiguousarray( np.atleast_2d(xy_d) )
-    rmat_d = np.ascontiguousarray( rmat_d )
-    rmat_s = np.ascontiguousarray( rmat_s )
-    tvec_d  = np.ascontiguousarray( tvec_d.flatten() )
-    tvec_s  = np.ascontiguousarray( tvec_s.flatten() )
-    tvec_c  = np.ascontiguousarray( tvec_c.flatten() )
-    beam_vec = np.ascontiguousarray( (-rmat_b[:,2]).flatten() )
-    eta_vec  = np.ascontiguousarray( rmat_b[:,0].flatten() ) #check this!
-    return _impl.detectorXYToGvec(xy_det,
-                                  rmat_d, rmat_s,
-                                  tvec_d, tvec_s, tvec_c,
-                                  beam_vec, eta_vec)
+    xy_d = np.ascontiguousarray(np.atleast_2d(xy_d))
+    rmat_d = np.ascontiguousarray(rmat_d)
+    rmat_s = np.ascontiguousarray(rmat_s)
+    tvec_d = np.ascontiguousarray(tvec_d.flatten())
+    tvec_s = np.ascontiguousarray(tvec_s.flatten())
+    tvec_c = np.ascontiguousarray(tvec_c.flatten())
+    beam_vec = np.ascontiguousarray((-rmat_b[:, 2]).flatten())
+    eta_vec = np.ascontiguousarray(rmat_b[:, 0].flatten())  # check this!
+    return _impl.detectorXYToGvec(
+        xy_d, rmat_d, rmat_s, tvec_d, tvec_s, tvec_c, beam_vec, eta_vec
+    )
 
 
-#@xf_api
-def oscillAnglesOfHKLs(hkls, chi, rMat_c, bMat, wavelength,
-                       vInv=None, beamVec=cnst.beam_vec, etaVec=cnst.eta_vec):
+# @xf_api
+def oscillAnglesOfHKLs(
+    hkls,
+    chi,
+    rMat_c,
+    bMat,
+    wavelength,
+    vInv=None,
+    beamVec=cnst.beam_vec,
+    etaVec=cnst.eta_vec,
+):
     # this was oscillAnglesOfHKLs
     hkls = np.array(hkls, dtype=float, order='C')
     if vInv is None:
@@ -333,11 +359,11 @@ def oscillAnglesOfHKLs(hkls, chi, rMat_c, bMat, wavelength,
     else:
         vInv = np.ascontiguousarray(vInv.flatten())
     beamVec = np.ascontiguousarray(beamVec.flatten())
-    etaVec  = np.ascontiguousarray(etaVec.flatten())
+    etaVec = np.ascontiguousarray(etaVec.flatten())
     bMat = np.ascontiguousarray(bMat)
     return _impl.oscillAnglesOfHKLs(
         hkls, chi, rMat_c, bMat, wavelength, vInv, beamVec, etaVec
-        )
+    )
 
 
 @xf_api
@@ -372,7 +398,7 @@ def unit_vector(vec_in):
         )
 
 
-#@xf_api
+# @xf_api
 def makeDetectorRotMat(tiltAngles):
     arg = np.ascontiguousarray(np.r_[tiltAngles].flatten())
     return _impl.makeDetectorRotMat(arg)
@@ -381,7 +407,8 @@ def makeDetectorRotMat(tiltAngles):
 # make_sample_rmat in CAPI is split between makeOscillRotMat
 # and makeOscillRotMatArray...
 
-#@xf_api
+
+# @xf_api
 def make_oscill_rot_mat(oscillAngles):
     chi, ome = oscillAngles
     ome = np.atleast_1d(ome)
@@ -389,7 +416,7 @@ def make_oscill_rot_mat(oscillAngles):
     return result.reshape((3, 3))
 
 
-#@xf_api
+# @xf_api
 def make_oscill_rot_mat_array(chi, omeArray):
     arg = np.ascontiguousarray(omeArray)
     return _impl.makeOscillRotMat(chi, arg)
@@ -397,9 +424,10 @@ def make_oscill_rot_mat_array(chi, omeArray):
 
 @xf_api
 def make_sample_rmat(chi, ome):
-    #TODO: Check this docstring
+    # TODO: Check this docstring
     """
-    Make a rotation matrix representing the COB from sample frame to the lab frame. 
+    Make a rotation matrix representing the COB from sample frame to the lab 
+    frame.
 
     Parameters
     ----------
@@ -423,9 +451,10 @@ def make_sample_rmat(chi, ome):
         # to call ascontiguousarray, but need to remove
         # the outer dimension from the result
         result = _impl.makeOscillRotMat(chi, ome_array)
-        result = result.reshape(3,3)
+        result = result.reshape(3, 3)
 
     return result
+
 
 @xf_api
 def make_rmat_of_expmap(exp_map):
@@ -436,7 +465,7 @@ def make_rmat_of_expmap(exp_map):
     ----------
     exp_map : array_like
         A 3-element sequence representing the exponential map n*phi.
-    
+
     Returns
     -------
     ndarray
@@ -448,8 +477,8 @@ def make_rmat_of_expmap(exp_map):
 
 @xf_api
 def make_binary_rmat(axis):
-    #TODO: Make this docstring.
-    
+    # TODO: Make this docstring.
+
     arg = np.ascontiguousarray(axis.flatten())
     return _impl.makeBinaryRotMat(arg)
 
@@ -463,7 +492,8 @@ def make_beam_rmat(bvec_l, evec_l):
     Parameters
     ----------
     bvec_l : ndarray
-        The beam vector in the lab frame, The (3, ) incident beam propagation vector components in the lab frame
+        The beam vector in the lab frame, The (3, ) incident beam propagation 
+        vector components in the lab frame.
         the default is [0, 0, -1], which is the standard setting.
     evec_l : ndarray
         Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
@@ -487,7 +517,8 @@ def validate_angle_ranges(ang_list, start_angs, stop_angs, ccw=True):
     stop_angs : ndarray
         The stopping angles
     ccw : bool, optional
-        If True, the angles are in the CCW range from start to stop.  Defaults to True.
+        If True, the angles are in the CCW range from start to stop.  
+        Defaults to True.
 
     Returns
     -------
@@ -527,10 +558,12 @@ def rotate_vecs_about_axis(angle, axis, vecs):
     result = _impl.rotate_vecs_about_axis(angle, axis, vecs)
     return result.T
 
+
 @xf_api
 def quat_distance(q1, q2, qsym):
     """
-    Distance between two quaternions, taking quaternions of symmetry into account.
+    Distance between two quaternions, taking quaternions of symmetry into 
+    account.
 
     Parameters
     ----------
@@ -540,7 +573,7 @@ def quat_distance(q1, q2, qsym):
         Second quaternion.
     qsym : ndarray
         List of symmetry quaternions.
-    
+
     Returns
     -------
     float

--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -28,14 +28,45 @@ from hexrd.extensions import _new_transforms_capi as _impl
 
 import numpy as np
 
+
+
 @xf_api
 def angles_to_gvec(
         angs,
         beam_vec=None, eta_vec=None,
         chi=None, rmat_c=None):
+    """
+    
+    Takes triplets of angles in the beam frame (2*theta, eta, omega)
+    to components of unit G-vectors in the LAB frame.  If the omega
+    values are not trivial (i.e. angs[:, 2] = 0.), then the components
+    are in the SAMPLE frame.  If the crystal rmat is specified and
+    is not the identity, then the components are in the CRYSTAL frame.
+
+    G vectors here referes to the reciprocal lattice vectors.
+
+    Parameters
+    ----------
+    angs : ndarray
+        The euler angles of diffraction. The last dimension must be 3.  In (2*theta, eta, omega) format.
+    beam_vec : ndarray, optional
+        Unit vector pointing towards the X-ray source in the lab frame.  Defaults to [0,0,-1]
+    eta_vec : ndarray, optional
+        Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
+    chi : float, optional
+        The inclination angle of the sample frame about the lab frame X.
+    rmat_c : ndarray, optional
+        The change of basis matrix from the reciprocal frame to the crystal frame.  Defaults to the identity.
+
+    Returns
+    -------
+    ndarray
+        (3,n) array of unit reciprocal lattice vectors, frame depends on the input parameters
+    """
+
     orig_ndim = angs.ndim
 
-    # if only a pair is provided... converto to a triplet with omegas == 0
+    # if only a pair is provided... convert to a triplet with omegas == 0
     # so that behavior is preserved.
     if angs.shape[-1] == 2:
         angs = np.hstack((angs, np.zeros(angs.shape[:-1]+(1,))))
@@ -58,6 +89,33 @@ def angles_to_dvec(
         angs,
         beam_vec=None, eta_vec=None,
         chi=None, rmat_c=None):
+    """
+    
+    Takes triplets of angles in the beam frame (2*theta, eta, omega)
+    to components of unit diffraction vectors in the LAB frame.  If the omega
+    values are not trivial (i.e. angs[:, 2] = 0.), then the components
+    are in the SAMPLE frame.  If the crystal rmat is specified and
+    is not the identity, then the components are in the CRYSTAL frame.
+
+
+    Parameters
+    ----------
+    angs : ndarray
+        The euler angles of diffraction. The last dimension must be 3.  In (2*theta, eta, omega) format.
+    beam_vec : ndarray, optional
+        Unit vector pointing towards the X-ray source in the lab frame.  Defaults to [0,0,-1]
+    eta_vec : ndarray, optional
+        Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
+    chi : float, optional
+        The inclination angle of the sample frame about the lab frame X.
+    rmat_c : ndarray, optional
+        The change of basis matrix from the reciprocal frame to the crystal frame.  Defaults to the identity.
+
+    Returns
+    -------
+    ndarray
+        (3,n) array of unit diffraction vectors, frame depends on the input parameters
+    """
     # TODO: Improve capi to avoid multiplications when rmat_c is None
     beam_vec = beam_vec if beam_vec is not None else cnst.beam_vec
     eta_vec = eta_vec if eta_vec is not None else cnst.eta_vec
@@ -73,6 +131,23 @@ def angles_to_dvec(
                                          chi, rmat_c)
 
 def makeGVector(hkl, bMat):
+    """
+    Take a crystal relative b matrix onto a list of hkls to output unit reciprocal latice vectors (a.k.a. lattice plane normals)
+
+
+    Parameters
+    ----------
+    hkl : ndarray
+        (3,n) ndarray of n hstacked reciprocal lattice vector component triplets
+    bMat : ndarray
+        (3,3) ndarray of the change of basis matrix from the reciprocal lattice to the crystal reference frame
+
+    Returns
+    -------
+    ndarray
+        (3,n) ndarray of n unit reciprocal lattice vectors (a.k.a. lattice plane normals)
+
+    """
     assert hkl.shape[0] == 3, 'hkl input must be (3, n)'
     return unitVector(np.dot(bMat, hkl))
 
@@ -84,6 +159,67 @@ def gvec_to_xy(gvec_c,
                beam_vec=None,
                vmat_inv=None,
                bmat=None):
+    
+    """
+    Takes a concatenated list of reciprocal lattice vectors components in the
+    CRYSTAL FRAME to the specified detector-relative frame, subject to the
+    following:
+
+        1) it must be able to satisfy a bragg condition
+        2) the associated diffracted beam must intersect the detector plane
+
+    Parameters
+    ----------
+    gvec_c : array_like
+        ([N,] 3) G-vector components in the CRYSTAL FRAME.
+    rmat_d : array_like
+        The (3, 3) COB matrix taking components in the
+        DETECTOR FRAME to the LAB FRAME
+    rmat_s : array_like
+        The ([N,] 3, 3) COB matrix taking components in the SAMPLE FRAME to the
+        LAB FRAME. It may be a single (3, 3) rotation matrix to use for all
+        gvec_c, or just one rotation matrix per gvec.
+    rmat_c : array_like
+        The (3, 3) COB matrix taking components in the
+        CRYSTAL FRAME to the SAMPLE FRAME
+    tvec_d : array_like
+        The (3, ) translation vector connecting LAB FRAME to DETECTOR FRAME
+    tvec_s : array_like
+        The (3, ) translation vector connecting LAB FRAME to SAMPLE FRAME
+    tvec_c : array_like
+        The ([M,] 3, ) translation vector(s) connecting SAMPLE FRAME to
+        CRYSTAL FRAME
+    beam_vec : array_like, optional
+        The (3, ) incident beam propagation vector components in the LAB FRAME;
+        the default is [0, 0, -1], which is the standard setting.
+    vmat_inv : array_like, optional
+        The (3, 3) matrix of inverse stretch tensor components in the
+        SAMPLE FRAME.  The default is None, which implies a strain-free state
+        (i.e. V = I).
+    bmat : array_like, optional
+        The (3, 3) COB matrix taking components in the
+        RECIPROCAL LATTICE FRAME to the CRYSTAL FRAME; if supplied, it is
+        assumed that the input `gvecs` are G-vector components in the
+        RECIPROCL LATTICE FRAME (the default is None, which implies components
+        in the CRYSTAL FRAME)
+
+    Returns
+    -------
+    array_like
+        The ([M, ][N, ] 2) array of [x, y] diffracted beam intersections for each
+        of the N input G-vectors in the DETECTOR FRAME (all Z_d coordinates are
+        0 and excluded) and for each of the M candidate positions. For each
+        input G-vector that cannot satisfy a Bragg condition or intersect the
+        detector plane, [NaN, Nan] is returned.
+
+    Notes
+    -----
+        Previously only a single candidate position was allowed. This is in fact
+        a vectored version of the previous API function. It is backwards
+        compatible, as passing single tvec_c is supported and has the same
+        result.
+
+    """
     beam_vec = beam_vec if beam_vec is not None else cnst.beam_vec
 
     orig_ndim = gvec_c.ndim
@@ -117,7 +253,49 @@ def xy_to_gvec(xy_d,
                rmat_b=None,
                distortion=None,
                output_ref=False):
-    # in the C library beam vector and eta vector are expected. However we receive
+    """
+    Takes a list cartesian (x, y) pairs in the DETECTOR FRAME and calculates
+    the associated reciprocal lattice (G) vectors and (bragg angle, azimuth)
+    pairs with respect to the specified beam and azimth (eta) reference
+    directions.
+
+    Parameters
+    ----------
+    xy_d : array_like
+        (n, 2) array of n (x, y) coordinates in DETECTOR FRAME
+    rmat_d : array_like
+        (3, 3) COB matrix taking components in the
+        DETECTOR FRAME to the LAB FRAME
+    rmat_s : array_like
+        (3, 3) COB matrix taking components in the
+        SAMPLE FRAME to the LAB FRAME
+    tvec_d : array_like
+        (3, ) translation vector connecting LAB FRAME to DETECTOR FRAME
+    tvec_s : array_like
+        (3, ) translation vector connecting LAB FRAME to SAMPLE FRAME
+    tvec_c : array_like
+        (3, ) translation vector connecting SAMPLE FRAME to CRYSTAL FRAME
+    rmat_b : array_like, optional
+        (3, 3) COB matrix taking components in the BEAM FRAME to the LAB FRAME;
+        defaults to None, which implies the standard setting of identity.
+    distortion : distortion class, optional
+        Default is None
+    output_ref : bool, optional
+        If True, prepends the apparent bragg angle and azimuth with respect to
+        the SAMPLE FRAME (ignoring effect of non-zero tvec_c)
+
+    Returns
+    -------
+    array_like
+        (n, 2) ndarray containing the (tth, eta) pairs associated with each
+        (x, y) associated with gVecs
+    array_like
+        (n, 3) ndarray containing the associated G vector directions in the
+        LAB FRAME
+    array_like, optional
+        if output_ref is True
+    """
+    # TODO: in the C library beam vector and eta vector are expected. However we receive
     # rmat_b. Please check this!
     #
     # It also seems that the output_ref version is not present as the argument gets
@@ -126,7 +304,7 @@ def xy_to_gvec(xy_d,
     rmat_b = rmat_b if rmat_b is not None else cnst.identity_3x3
 
     # the code seems to ignore this argument, assume output_ref == True not implemented
-    assert not output_ref
+    assert not output_ref , 'output_ref not implemented'
 
     if distortion is not None:
         xy_d = distortion.unwarp(xy_d)
@@ -164,6 +342,24 @@ def oscillAnglesOfHKLs(hkls, chi, rMat_c, bMat, wavelength,
 
 @xf_api
 def unit_vector(vec_in):
+    """
+    Normalize the input vector(s) to unit length.
+
+    Parameters
+    ----------
+    vec_in : ndarray
+        The input vector(s) (3,n) to normalize.
+
+    Returns
+    -------
+    ndarray
+        The normalized vector(s) of the same shape as the input.
+
+    Raises
+    ------
+    ValueError
+        If the input vector(s) do not have the correct shape.
+    """
     vec_in = np.ascontiguousarray(vec_in)
     if vec_in.ndim == 1:
         return _impl.unitRowVector(vec_in)
@@ -201,6 +397,23 @@ def make_oscill_rot_mat_array(chi, omeArray):
 
 @xf_api
 def make_sample_rmat(chi, ome):
+    #TODO: Check this docstring
+    """
+    Make a rotation matrix representing the COB from sample frame to the lab frame. 
+
+    Parameters
+    ----------
+    chi : float
+        The inclination angle of the sample frame about the lab frame Y.
+    ome : float or ndarray
+        The oscillation angle(s) about the sample frame Y.
+
+    Returns
+    -------
+    ndarray
+        A 3x3 rotation matrix representing the input oscillation angles.
+
+    """
     ome_array = np.atleast_1d(ome)
     if ome is ome_array:
         ome_array = np.ascontiguousarray(ome_array)
@@ -216,18 +429,45 @@ def make_sample_rmat(chi, ome):
 
 @xf_api
 def make_rmat_of_expmap(exp_map):
+    """
+    Calculate the rotation matrix of an exponential map.
+
+    Parameters
+    ----------
+    exp_map : array_like
+        A 3-element sequence representing the exponential map n*phi.
+    
+    Returns
+    -------
+    ndarray
+        A 3x3 rotation matrix representing the input exponential map
+    """
     arg = np.ascontiguousarray(exp_map.flatten())
     return _impl.makeRotMatOfExpMap(arg)
 
 
 @xf_api
 def make_binary_rmat(axis):
+    #TODO: Make this docstring.
+    
     arg = np.ascontiguousarray(axis.flatten())
     return _impl.makeBinaryRotMat(arg)
 
 
 @xf_api
 def make_beam_rmat(bvec_l, evec_l):
+    """
+    Creates a COB matrix from the beam frame to the lab frame
+    Note: beam and eta vectors must not be colinear
+
+    Parameters
+    ----------
+    bvec_l : ndarray
+        The beam vector in the lab frame, The (3, ) incident beam propagation vector components in the lab frame
+        the default is [0, 0, -1], which is the standard setting.
+    evec_l : ndarray
+        Vector defining eta=0 in the lab frame.  Defaults to [1,0,0]
+    """
     arg1 = np.ascontiguousarray(bvec_l.flatten())
     arg2 = np.ascontiguousarray(evec_l.flatten())
     return _impl.makeEtaFrameRotMat(arg1, arg2)
@@ -235,6 +475,26 @@ def make_beam_rmat(bvec_l, evec_l):
 
 @xf_api
 def validate_angle_ranges(ang_list, start_angs, stop_angs, ccw=True):
+    """
+    Find out if angles are in the CCW or CW range from start to stop
+
+    Parameters
+    ----------
+    ang_list : ndarray
+        The list of angles to validate
+    start_angs : ndarray
+        The starting angles
+    stop_angs : ndarray
+        The stopping angles
+    ccw : bool, optional
+        If True, the angles are in the CCW range from start to stop.  Defaults to True.
+
+    Returns
+    -------
+    ndarray
+        List of bools indicating if the angles are in the correct range
+
+    """
     ang_list = ang_list.astype(np.double, order="C")
     start_angs = start_angs.astype(np.double, order="C")
     stop_angs = stop_angs.astype(np.double, order="C")
@@ -244,6 +504,23 @@ def validate_angle_ranges(ang_list, start_angs, stop_angs, ccw=True):
 
 @xf_api
 def rotate_vecs_about_axis(angle, axis, vecs):
+    """
+    Rotate vectors about an axis
+
+    Parameters
+    ----------
+    angle : array_like
+        Array of angles (len==1 or n)
+    axis : ndarray
+        Array of unit vectors (shape == (3,1) or (3,n))
+    vecs : ndarray
+        Array of vectors to rotate (shape == (3,n))
+
+    Returns
+    -------
+    ndarray
+        Array of rotated vectors (shape == (3,n))
+    """
     angle = np.asarray(angle)
     axis = np.ascontiguousarray(axis.T)
     vecs = np.ascontiguousarray(vecs.T)
@@ -252,6 +529,23 @@ def rotate_vecs_about_axis(angle, axis, vecs):
 
 @xf_api
 def quat_distance(q1, q2, qsym):
+    """
+    Distance between two quaternions, taking quaternions of symmetry into account.
+
+    Parameters
+    ----------
+    q1 : arary_like
+        First quaternion.
+    q2 : arary_like
+        Second quaternion.
+    qsym : ndarray
+        List of symmetry quaternions.
+    
+    Returns
+    -------
+    float
+        The distance between the two quaternions.
+    """
     q1 = np.ascontiguousarray(q1.flatten())
     q2 = np.ascontiguousarray(q2.flatten())
     # C module expects quaternions in row major, numpy code in column major.

--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -17,7 +17,7 @@ Currently, this implementation contains code for the following functions:
  - rotate_vecs_about_axis
  - quat_distance
 
-There are also some functions that maybe would be needed in the transforms 
+There are also some functions that maybe would be needed in the transforms
 module:
  - makeGVector
  - makeRotMatOfQuat

--- a/hexrd/transforms/new_capi/xf_new_capi.py
+++ b/hexrd/transforms/new_capi/xf_new_capi.py
@@ -34,7 +34,7 @@ import numpy as np
 def angles_to_gvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
     """
 
-    Takes triplets of angles in the beam frame (2*theta, eta, omega)
+    Takes triplets of angles in the beam frame (2*theta, eta, optional omega)
     to components of unit G-vectors in the LAB frame.  If the omega
     values are not trivial (i.e. angs[:, 2] = 0.), then the components
     are in the SAMPLE frame.  If the crystal rmat is specified and
@@ -45,8 +45,8 @@ def angles_to_gvec(angs, beam_vec=None, eta_vec=None, chi=None, rmat_c=None):
     Parameters
     ----------
     angs : ndarray
-        The euler angles of diffraction. The last dimension must be 3.  In
-        (2*theta, eta, omega) format.
+        The euler angles of diffraction. The last dimension must be 2 or 3.  In
+        (2*theta, eta, omega) or (2*theta, eta) format.
     beam_vec : ndarray, optional
         Unit vector pointing towards the X-ray source in the lab frame.
         Defaults to [0,0,-1]
@@ -356,6 +356,7 @@ def oscillAnglesOfHKLs(
     # this was oscillAnglesOfHKLs
     hkls = np.array(hkls, dtype=float, order='C')
     if vInv is None:
+        vInv_ref = np.array([[1., 1., 1., 0., 0., 0.]], order='C').T 
         vInv = np.ascontiguousarray(vInv_ref.flatten())
     else:
         vInv = np.ascontiguousarray(vInv.flatten())


### PR DESCRIPTION
Doc strings added in xf_new_capi.  Also fixed a bug in [xy_to_gvec](https://github.com/Verdant-Evolution/hexrd/blob/441912346cbea972f86b3f979d412befd7e4e2a8/hexrd/transforms/new_capi/xf_new_capi.py#L339C1-L342C1) where a variable name was incorrect.

The [make_binary_rmat](https://github.com/Verdant-Evolution/hexrd/blob/5287b0a553892ba111731d3f1864dff0a56666c0/hexrd/transforms/new_capi/xf_new_capi.py#L449C1-L454C39) function does not have a doc string as I could not find any documentation about it.  Is it necessary to keep around, or is it unused?

 Also, in some testing, I found that the [unit_vector](https://github.com/Verdant-Evolution/hexrd/blob/5287b0a553892ba111731d3f1864dff0a56666c0/hexrd/transforms/new_capi/xf_new_capi.py#L343-L373) function is transposed as to what it was in the old xf api, which is what most of the functions use (it's nx3 instead of 3xn).  Is this intended?