### PR TITLE
Single grain fitting

### DIFF
--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -318,6 +318,7 @@ def fit_grains(cfg,
     even if there is only one grain or one process, so that it will be
     cancelable.
     """
+    grains_table = np.atleast_2d(grains_table)
 
     # grab imageseries dict
     imsd = cfg.image_series


### PR DESCRIPTION
Confirm this correctly understands what `grain_table` is.  This still passes the testcases, and if test_fitgrains is changed to remove the ndmin=2 (and making other necessary changes), it also passes, implying that this change does what it's supposed to do.

closes #677 