### PR TITLE
Rotations testcases

### DIFF
--- a/hexrd/rotations.py
+++ b/hexrd/rotations.py
@@ -276,20 +276,16 @@ def quatProduct(q1, q2):
             q2 = tile(q2, (1, n1))
             nq = n1
 
-    a = q2[0, ]
-    a3 = tile(a, (3, 1))
-    b = q1[0, ]
-    b3 = tile(b, (3, 1))
+    # Changed just to show that the testcases are correct, old implementation
+    # did not work when both inputs were (4, n)
+    # see https://github.com/HEXRD/hexrd/issues/684
+    # Will replace this with scipy rotation after showing that testcases
+    # are correct
 
-    avec = q2[1:, ]
-    bvec = q1[1:, ]
-
-    axb = zeros((3, nq))
+    qp = zeros((4, nq))
     for i in range(nq):
-        axb[:, i] = cross(avec[:, i], bvec[:, i])
-
-    qp = vstack([a*b - diag(dot(avec.T, bvec)),
-                 a3*bvec + b3*avec + axb])
+        q2_matrix = quatProductMatrix(q2[:, i].reshape(4, 1), mult='left')
+        qp[:, i] = dot(q2_matrix, q1[:, i])
 
     return fixQuat(qp)
 

--- a/tests/rotations/test_eulers.py
+++ b/tests/rotations/test_eulers.py
@@ -93,11 +93,3 @@ def test_units_setter():
         assert rot.units == 'radians'
         assert np.allclose(old_angs, rot.angles)
         assert np.allclose(rot.rmat, scipy_rot.as_matrix())
-
-
-def pytest_generate_tests(metafunc):
-    """
-    Make sure methods work with multiple quaternions as well as single inputs.
-    """
-    if 'num_quats' in metafunc.fixturenames:
-        metafunc.parametrize('num_quats', [1, 10])

--- a/tests/rotations/test_eulers.py
+++ b/tests/rotations/test_eulers.py
@@ -1,0 +1,103 @@
+from scipy.spatial.transform import Rotation as R
+
+import numpy as np
+
+from math import copysign
+
+from hexrd import rotations
+
+
+def random_rot_mat_euler():
+    """
+    Generate a random scipy rotation and equivalent rotMatEuler
+    """
+    quats = np.random.rand(4) * 2 - 1
+    quats /= np.linalg.norm(quats)
+    rotation = R.from_quat(quats)
+
+    # Extrinsic or intrinsic, random
+    extrinsic = np.random.choice([True, False])
+
+    # Generate random euler angle sequence
+    seq = np.random.choice(
+        [
+            'xyz',
+            'zyx',
+            'zxy',
+            'yxz',
+            'yzx',
+            'xzy',
+            'xyx',
+            'xzx',
+            'yxy',
+            'yzy',
+            'zxz',
+            'zyz',
+        ]
+    )
+    if not extrinsic:
+        seq = seq.upper()
+
+    angs = rotation.as_euler(seq)
+
+    return rotations.RotMatEuler(angs, seq.lower(), extrinsic), rotation
+
+
+def test_rot_mat_euler_constructor():
+    """
+    Generate a bunch of random rotMatEulers and check that they are set right
+    """
+    for _ in range(1000):
+        rot, scipy_rot = random_rot_mat_euler()
+        assert isinstance(rot, rotations.RotMatEuler)
+
+        seq = rot.axes_order
+        if not rot.extrinsic:
+            seq = seq.upper()
+
+        assert np.allclose(rot.angles, scipy_rot.as_euler(seq))
+
+
+def test_vals_from_rot_mat_euler():
+    """
+    Make sure that the euler maps create the correct rotation mat and expmap
+    """
+    for _ in range(1000):
+        rot, scipy_rot = random_rot_mat_euler()
+        assert np.allclose(rot.rmat, scipy_rot.as_matrix())
+
+        # Generate it from the expmap and check that it's the same as the
+        # rotation matrices (note expmap representations are not unique,
+        # but rotation matrix rotations are)
+        exp_map = rot.exponential_map
+        rot_from_expmap = rotations.rotMatOfExpMap(exp_map)
+        assert np.allclose(rot_from_expmap, rot.rmat)
+
+
+def test_units_setter():
+    """
+    Check if updating units breaks anything
+    """
+    for _ in range(1000):
+        rot, scipy_rot = random_rot_mat_euler()
+        old_angs = rot.angles
+        
+        # Change to degrees, make sure angs changed but rotation matrix doesn't
+        rot.units = 'degrees'
+        assert rot.units == 'degrees'
+        assert not np.allclose(old_angs, rot.angles)
+        assert np.allclose(rot.rmat, scipy_rot.as_matrix())
+
+        # Change back
+        rot.units = 'radians'
+        assert rot.units == 'radians'
+        assert np.allclose(old_angs, rot.angles)
+        assert np.allclose(rot.rmat, scipy_rot.as_matrix())
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Make sure methods work with multiple quaternions as well as single inputs.
+    """
+    if 'num_quats' in metafunc.fixturenames:
+        metafunc.parametrize('num_quats', [1, 10])

--- a/tests/rotations/test_eulers.py
+++ b/tests/rotations/test_eulers.py
@@ -81,7 +81,7 @@ def test_units_setter():
     for _ in range(1000):
         rot, scipy_rot = random_rot_mat_euler()
         old_angs = rot.angles
-        
+
         # Change to degrees, make sure angs changed but rotation matrix doesn't
         rot.units = 'degrees'
         assert rot.units == 'degrees'

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -194,7 +194,7 @@ def test_quat_of_angle_axis_single_axis():
 
 def test_exp_map_of_quat(num_quats):
     """
-    Generate quaternions from exponential maps, and compare with scipy
+    Generate quaternions from exponential maps, and compare with rotMats
     """
     np.random.seed(0)
     for _ in range(100):

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -221,6 +221,22 @@ def test_exp_map_of_quat(num_quats):
         assert allclose(rot_mat, rot_mat2)
 
 
+def test_quat_of_exp_map(num_quats):
+    """
+    Make sure quatOfExpMap and expMapOfQuat are inverses
+    """
+    np.random.seed(0)
+    for _ in range(100):
+        quat = rand_quat(num_quats)
+        if num_quats == 1:
+            quat = rotations.fixQuat(quat.T).T[0]
+        else:
+            quat = rotations.fixQuat(quat.T)
+        exp_map = rotations.expMapOfQuat(quat)
+        quat2 = rotations.quatOfExpMap(exp_map)
+        assert allclose(quat, quat2)
+
+
 def test_quat_of_rot_mat(num_quats):
     """
     Make sure quatOfRotMat and rotMatOfQuat are inverses

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -32,7 +32,7 @@ def test_make_rotmat(num_quats):
     Make rotmats with scipy and rotations.py from quternions, and compare
     """
     np.random.seed(0)
-    
+
     for _ in range(100):
         q = rand_quat(num_quats)
         if num_quats == 1:
@@ -256,6 +256,7 @@ def test_angle_axis_of_rot_mat(num_quats):
         if num_quats == 1:
             quat2 = quat2.T[0]
         assert allclose(quat, quat2)
+
 
 def pytest_generate_tests(metafunc):
     """

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -64,7 +64,7 @@ def test_quat_mult(num_quats):
 
 def test_quat_mult_one_to_many():
     """
-    quatProduct supports one quaternion multiplied by many others, test this
+    quatProduct supports one quaternion multiplied by many others
     """
     np.random.seed(0)
     for _ in range(100):

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -1,0 +1,179 @@
+from scipy.spatial.transform import Rotation as R
+
+import numpy as np
+
+from hexrd import rotations
+
+
+def rand_quat(n=1):
+    """
+    Generate a random unit quaternion for other methods
+    """
+    quat = np.random.rand(n, 4) * 2 - 1  # n x 4 array
+    return quat / np.linalg.norm(quat, axis=1, keepdims=True)
+
+
+def quat_to_scipy_rotation(q):
+    """
+    scipy has quaternions written in a differnt order, so we need to convert
+    """
+    return R.from_quat(np.roll(q, -1, axis = q.ndim-1))
+
+
+
+def test_make_rotmat(num_quats):
+    """
+    Make rotmats with scipy and rotations.py from quternions, and compare
+    """
+    np.random.seed(0)
+
+    for _ in range(100):
+        q = rand_quat(num_quats)
+        if num_quats == 1:
+            q = q[0]
+        # Compute the rotation matrix using scipy
+        R_scipy = quat_to_scipy_rotation(q).as_matrix()
+        # Compute the rotation matrix using rotations.py
+        R_rotations = rotations.rotMatOfQuat(q if num_quats == 1 else q.T)
+        # Compare the rotation matrices
+        assert np.allclose(R_scipy, R_rotations)
+
+
+def test_quat_mult(num_quats):
+    """
+    Generate quaternions and test if multiplication works
+    """
+    np.random.seed()
+    for _ in range(100):
+        # Generate two random unit quaternions
+        q1 = rand_quat(num_quats)
+        q2 = rand_quat(num_quats)
+        # Compute the product of the quaternions
+        qp = rotations.quatProduct(q1.T, q2.T).T
+
+        # Do the same in scipy
+        r1 = quat_to_scipy_rotation(q1)
+        r2 = quat_to_scipy_rotation(q2)
+
+        r_12 = r2 * r1
+        r_qp = quat_to_scipy_rotation(qp)
+
+        # Compare the results
+        for a, b in zip(r_12, r_qp):
+            assert a.approx_equal(b)
+
+
+def test_invert_quat(num_quats):
+    """
+    Generate quaternions and test if inversion works
+    """
+    np.random.seed(0)
+    for _ in range(100):
+        # Generate a random unit quaternion
+        q = rand_quat(num_quats)
+        # Compute the inverse of the quaternion
+        q_inv = rotations.invertQuat(q.T).T
+
+        # Do the same in scipy
+        r = quat_to_scipy_rotation(q)
+        r_inv = r.inv()
+        r_inv2 = quat_to_scipy_rotation(q_inv)
+
+        # Compare the results
+        for a, b in zip(r_inv, r_inv2):
+            assert a.approx_equal(b)
+
+
+def test_quat_product_matrix(num_quats):
+    """
+    Ensure quatProductMatrix matches quatProduct
+    """
+    for _ in range(100):
+        # Generate a random unit quaternion
+        q1 = rand_quat(num_quats)
+        q2 = rand_quat(num_quats)
+        # Compute the product matrix using rotations.py
+        R_rotations1 = rotations.quatProductMatrix(q1.T, mult='left')
+        R_rotations2 = rotations.quatProductMatrix(q2.T, mult='right')
+        prod1 = np.array([
+            R_rotations1.dot(np.array([a]).T)[i].T[0] for i, a in enumerate(q2)
+        ])
+        prod2 = np.array([
+            R_rotations2.dot(np.array([a]).T)[i].T[0] for i, a in enumerate(q1)
+        ])
+        prod = rotations.quatProduct(q2.T, q1.T).T
+
+        # Normalize products (should only change the sign if "necessary").
+        prod1 = rotations.fixQuat(prod1.T).T
+        prod2 = rotations.fixQuat(prod2.T).T
+
+        assert np.allclose(prod1, prod)
+        assert np.allclose(prod2, prod)
+
+
+def test_quat_of_angle_axis(num_quats):
+    """
+    Generate quaternions from angles and axes, and compare with scipy
+    """
+    np.random.seed(0)
+    for _ in range(100):
+        # Generate a random angle and axis
+        angle = np.random.rand(num_quats) * 2 * np.pi
+
+        # This is just so more of quatOfAngleAxis is tested
+        if len(angle) == 1:
+            angle = angle[0]
+
+        axis = np.random.rand(3, num_quats) * 2 - 1
+        axis /= np.linalg.norm(axis, axis=0, keepdims=True)
+        # Compute the quaternion using rotations.py
+        q_rotations = rotations.quatOfAngleAxis(angle, axis).T
+        # Compute the quaternion using scipy
+        q_scipy = R.from_rotvec((axis * angle).T).as_quat()
+        # Fix scipy results so it's in the right format
+        q_scipy = np.roll(q_scipy,1, axis=1)
+        q_scipy = rotations.fixQuat(q_scipy.T).T
+        assert np.allclose(q_rotations, q_scipy)
+
+
+def test_quat_of_angle_axis_single_axis():
+    """
+    quatOfAngleAxis supports a list of angles with one axis, testing that
+    """
+    np.random.seed(0)
+    for _ in range(100):
+        angles = np.random.rand(10) * 2 * np.pi
+        axis = np.random.rand(3) * 2 - 1
+        axis /= np.linalg.norm(axis)
+        q_rotations = rotations.quatOfAngleAxis(angles, np.array([axis]).T)
+        # Turn axis into a list of axes
+        axes = np.array([axis]).T.dot([angles])
+        q_rotations2 = rotations.quatOfAngleAxis(angles, axes)
+
+        assert np.allclose(q_rotations, q_rotations2)
+
+
+def test_exp_map_of_quat(num_quats):
+    """
+    Generate quaternions from exponential maps, and compare with scipy
+    """
+    np.random.seed(0)
+    for _ in range(100):
+        quat = rand_quat(num_quats)
+        if num_quats == 1:
+            quat = quat[0]
+        else:
+            quat = quat.T
+        rot_mat = rotations.rotMatOfQuat(quat)
+        exp_map = rotations.expMapOfQuat(quat)
+        # Make sure these representations agree
+        rot_mat2 = rotations.rotMatOfExpMap(exp_map)
+        assert np.allclose(rot_mat, rot_mat2)
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Make sure methods work with multiple quaternions as well as single inputs.
+    """
+    if 'num_quats' in metafunc.fixturenames:
+        metafunc.parametrize('num_quats', [1, 10])

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -186,7 +186,7 @@ def test_quat_of_angle_axis_single_axis():
         axis /= np.linalg.norm(axis)
         q_rotations = rotations.quatOfAngleAxis(angles, np.array([axis]).T)
         # Turn axis into a list of axes
-        axes = np.array([axis]).T.dot([angles])
+        axes = np.tile(axis, (len(angles), 1)).T
         q_rotations2 = rotations.quatOfAngleAxis(angles, axes)
 
         assert np.allclose(q_rotations, q_rotations2)

--- a/tests/rotations/test_quat_math.py
+++ b/tests/rotations/test_quat_math.py
@@ -123,23 +123,22 @@ def test_quat_product_matrix(num_quats):
         q1 = rand_quat(num_quats)
         # Quat to multiply by
         q_mult = rand_quat()
-        # Compute the product matrix 
+        # Compute the product matrix
         left_matrix = rotations.quatProductMatrix(q1.T, mult='left')
         right_matrix = rotations.quatProductMatrix(q1.T, mult='right')
         prod1 = np.dot(left_matrix, q_mult.T)
         prod2 = np.dot(right_matrix, q_mult.T)
 
-
         # Normalize products (should only change the sign if "necessary").
         prod1 = rotations.fixQuat(prod1).squeeze()
         prod2 = rotations.fixQuat(prod2).squeeze()
 
-        prod1_scipy = (quat_to_scipy_rotation(q1) * quat_to_scipy_rotation(
-            q_mult
-        )).as_quat()
-        prod2_scipy = (quat_to_scipy_rotation(q_mult) * quat_to_scipy_rotation(
-            q1
-        )).as_quat()
+        prod1_scipy = (
+            quat_to_scipy_rotation(q1) * quat_to_scipy_rotation(q_mult)
+        ).as_quat()
+        prod2_scipy = (
+            quat_to_scipy_rotation(q_mult) * quat_to_scipy_rotation(q1)
+        ).as_quat()
 
         # Fix the scipy results
         prod1_scipy = np.roll(prod1_scipy, 1, axis=1)


### PR DESCRIPTION
Added some testcases for some of the math helpers in `rotations.py`.  Also fixed `quatProduct`, see [issue 684](https://github.com/HEXRD/hexrd/issues/684). After this PR confirms that the new testcases are working properly, I will rewrite some of these methods to use scipy.  I didn't want to change the methods at the same time as I added the testcases, because then there is no confirmation that the new implementations work.

closes #684 