### PR TITLE
remove unused functions in unitcell

### DIFF
--- a/hexrd/material/unitcell.py
+++ b/hexrd/material/unitcell.py
@@ -120,7 +120,6 @@ class unitcell:
             constants.cCharge / \
             self.voltage
         self.wavelength *= 1e9
-        # self.CalcAnomalous()
 
     def calcBetaij(self):
 
@@ -679,7 +678,6 @@ class unitcell:
         initialize interpolation from table for anomalous scattering
         '''
         self.InitializeInterpTable()
-        # self.CalcAnomalous()
         self.CalcPositions()
         self.CalcDensity()
         self.calc_absorption_length()

--- a/hexrd/material/unitcell.py
+++ b/hexrd/material/unitcell.py
@@ -780,54 +780,6 @@ class unitcell:
             self.f_anomalous_data_sizes[i] = nd
             self.f_anomalous_data[i, :nd, :] = f_anomalous_data[i]
 
-    def CalcAnomalous(self):
-
-        self.f_anam = {}
-        for i in range(self.atom_ntype):
-
-            Z = self.atom_type[i]
-            elem = constants.ptableinverse[Z]
-            f1 = self.f1[elem](self.wavelength)
-            f2 = self.f2[elem](self.wavelength)
-            frel = constants.frel[elem]
-            Z = constants.ptable[elem]
-            self.f_anam[elem] = complex(f1+frel-Z, f2)
-
-    def CalcXRFormFactor(self, Z, charge, s):
-        '''
-        we are using the following form factors for x-aray scattering:
-        1. coherent x-ray scattering, f0 tabulated in Acta Cryst. (1995). A51,416-431
-        2. Anomalous x-ray scattering (complex (f'+if")) tabulated in J. Phys. Chem. Ref. Data, 24, 71 (1995)
-        and J. Phys. Chem. Ref. Data, 29, 597 (2000).
-        3. Thompson nuclear scattering, fNT tabulated in Phys. Lett. B, 69, 281 (1977).
-
-        the anomalous scattering is a complex number (f' + if"), where the two terms are given by
-        f' = f1 + frel - Z
-        f" = f2
-
-        f1 and f2 have been tabulated as a function of energy in Anomalous.h5 in hexrd folder
-
-        overall f = (f0 + f' + if" +fNT)
-        '''
-        elem = constants.ptableinverse[Z]
-        if charge == '0':
-            sfact = constants.scatfac[elem]
-        else:
-            cs = f"{elem}{charge}"
-            if cs in constants.scatfac:
-                sfact = constants.scatfac[f"{elem}{charge}"]
-            else:
-                sfact = constants.scatfac[elem]
-        fe = sfact[5]
-        fNT = constants.fNT[elem]
-        frel = constants.frel[elem]
-        f_anomalous = self.f_anam[elem]
-
-        for i in range(5):
-            fe += sfact[i] * np.exp(-sfact[i+6]*s)
-
-        return (fe+fNT+f_anomalous)
-
     def CalcXRSF(self, hkl):
         from hexrd.wppf.xtal import _calcxrsf
         '''

--- a/hexrd/material/unitcell.py
+++ b/hexrd/material/unitcell.py
@@ -1673,12 +1673,6 @@ class unitcell:
                self.atom_ntype), 'shape of numat is not consistent'
         self._numat = val
 
-    # different atom types; read only
-    @property
-    def Z(self):
-        sz = self.atom_ntype
-        return self.atom_type[0:atom_ntype]
-
     # direct metric tensor is read only
     @property
     def dmt(self):

--- a/hexrd/wppf/xtal.py
+++ b/hexrd/wppf/xtal.py
@@ -69,6 +69,20 @@ def _calcxrayformfactor(
     f_anomalous_data,
     f_anomalous_data_sizes,
 ):
+    """we are using the following form factors for x-aray scattering:
+        1. coherent x-ray scattering, f0 tabulated in Acta Cryst. (1995). A51,416-431
+        2. Anomalous x-ray scattering (complex (f'+if")) tabulated in J. Phys. Chem. Ref. Data, 24, 71 (1995)
+        and J. Phys. Chem. Ref. Data, 29, 597 (2000).
+        3. Thompson nuclear scattering, fNT tabulated in Phys. Lett. B, 69, 281 (1977).
+
+        the anomalous scattering is a complex number (f' + if"), where the two terms are given by
+        f' = f1 + frel - Z
+        f" = f2
+
+        f1 and f2 have been tabulated as a function of energy in Anomalous.h5 in hexrd folder
+
+        overall f = (f0 + f' + if" +fNT)
+    """
 
     f_anomalous = _calcanomalousformfactor(
         atom_type, wavelength, frel, f_anomalous_data, f_anomalous_data_sizes

--- a/hexrd/wppf/xtal.py
+++ b/hexrd/wppf/xtal.py
@@ -69,17 +69,23 @@ def _calcxrayformfactor(
     f_anomalous_data,
     f_anomalous_data_sizes,
 ):
-    """we are using the following form factors for x-aray scattering:
-        1. coherent x-ray scattering, f0 tabulated in Acta Cryst. (1995). A51,416-431
-        2. Anomalous x-ray scattering (complex (f'+if")) tabulated in J. Phys. Chem. Ref. Data, 24, 71 (1995)
-        and J. Phys. Chem. Ref. Data, 29, 597 (2000).
-        3. Thompson nuclear scattering, fNT tabulated in Phys. Lett. B, 69, 281 (1977).
+    """we are using the following form factors for 
+       x-aray scattering:
+        1. coherent x-ray scattering, f0 tabulated in 
+           Acta Cryst. (1995). A51,416-431
+        2. Anomalous x-ray scattering (complex (f'+if")) 
+           tabulated in J. Phys. Chem. Ref. Data, 24, 71 (1995)
+           and J. Phys. Chem. Ref. Data, 29, 597 (2000).
+        3. Thompson nuclear scattering, fNT tabulated in 
+           Phys. Lett. B, 69, 281 (1977).
 
-        the anomalous scattering is a complex number (f' + if"), where the two terms are given by
+        the anomalous scattering is a complex number (f' + if"), 
+        where the two terms are given by:
         f' = f1 + frel - Z
         f" = f2
 
-        f1 and f2 have been tabulated as a function of energy in Anomalous.h5 in hexrd folder
+        f1 and f2 have been tabulated as a function of energy in 
+        Anomalous.h5 in hexrd folder
 
         overall f = (f0 + f' + if" +fNT)
     """


### PR DESCRIPTION
remove unitcell.CalcAnomalous and unitcell.CalcXRayFormFactor. These functions have been replaced by numba function wppf.xtal._calcanomalousformfactor and wppf.xtal._calcxrayformfactor. Also removes the property `unitcell.Z`. 
Fixes: #683 
Fixes: #685