### PR TITLE
Gvec xy test

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -128,15 +128,20 @@ class TestGvecXY:
            azimuthal angle in degrees
         """
         ThetaEta = namedtuple("ThetaEta", ["theta_deg", "eta_deg"])
+        nan_tests = [
+            ThetaEta(0, 0), ThetaEta(46, 0),
+        ]
+
         tests = [
-            ThetaEta(0, 0), ThetaEta(10, 0), ThetaEta(44.9, 0),
-            ThetaEta(46, 0), ThetaEta(10, 45), ThetaEta(10, -45),
+            ThetaEta(10, 0), ThetaEta(44.9, 0),
+            ThetaEta(10, 45), ThetaEta(10, -45),
         ]
 
         p0_l = (0, 0, 0)
         d0_l = cls.base.tvec_d
         nv_l = (0, 0, 1)
         for t in tests:
+            print("test: ", t)
             gvec, dvec = cls.gvec_dvec(t.theta_deg, t.eta_deg)
             det_x = line_plane_intersect(
                 p0_l, dvec, d0_l, nv_l

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -297,6 +297,52 @@ class TestGvecXY:
                 gvec_c=gvec, rmat_d=rmat_d, xy=x_d[:2]
             ))
 
+    @classmethod
+    def test_sample_crystal_orientations(cls):
+        """Vary sample and crystal orientations
+
+        TEST PARAMETERS
+        ----------
+        data: named_tuple
+           angle/axis pairs for sample and crystal rotation
+        """
+        _flds = ["aa_s", "aa_c"]
+        SampleCrystalData = namedtuple("SampleCrystalData", _flds)
+
+        ex, ey, ez = (1, 0, 0), (0, 1, 0), (0, 0, 1)
+        ang = 10
+        tests =[
+            SampleCrystalData((0, ex), (0, ex)),
+            SampleCrystalData((ang, ex), (-ang, ex)),
+            SampleCrystalData((ang, ey), (-ang, ey)),
+            SampleCrystalData((ang, ez), (-ang, ez)),
+            SampleCrystalData((ang, ex), (0, ex)),
+            SampleCrystalData((ang, ey), (0, ey)),
+            SampleCrystalData((ang, ez), (0, ez)),
+            SampleCrystalData((0, ex), (ang, ex)),
+            SampleCrystalData((0, ey), (ang, ey)),
+            SampleCrystalData((0, ez), (ang, ez)),
+        ]
+
+        theta_deg, eta_deg = 5, 90
+        gvec_l, dvec_l  = cls.gvec_dvec(theta_deg, eta_deg)
+        for t in tests:
+            print(t)
+            ang_s, ax_s = t.aa_s
+            rmat_s = cls.make_rmat(ang_s, ax_s)
+            ang_c, ax_c = t.aa_c
+            rmat_c = cls.make_rmat(ang_c, ax_c)
+
+            gvec_c = rmat_c.T @ rmat_s.T @ gvec_l
+            det_x = line_plane_intersect(
+                (0, 0, 0), dvec_l, cls.base.tvec_d, (0, 0, 1)
+            )
+            xy = det_x[:2]
+
+            cls.run_test(cls.base._replace(
+                gvec_c=gvec_c, rmat_s=rmat_s, rmat_c=rmat_c, xy=xy
+            ))
+
 def unit_vector(v):
     return v/np.linalg.norm(v)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -136,6 +136,35 @@ class TestGvecXY:
             np.array(axis), np.radians(angle_deg)
         )
 
+    @staticmethod
+    def line_plane_intersect(p0, dvec, d0, nvec):
+        """Solve line/plane intersection
+
+        PARAMETERS
+        ----------
+        p0: array/3-tuple of floats
+            a point on the line
+        dvec: array/3-tuple of floats
+            direction (unit) vector of line
+        d0: array/3-tuple of floats
+            origin of detector
+        nvec: array/3-tuple of floats
+            normal vector to detector
+
+        RETURNS
+        -------
+        xyz: 3-tuple
+            intersection point
+
+        NOTES
+        -----
+        From geometry, t = (d0 - p0).n/(d.n), and x = p0 + td
+        """
+        p0_, d = np.array([p0, dvec])
+        t = np.dot((d0 - p0_), nvec)/np.dot(d, nvec)
+        x = p0_ + t * d
+        return x
+
     @classmethod
     def test_theta_eta(cls):
         """Vary diffraction angle in simple case
@@ -163,7 +192,7 @@ class TestGvecXY:
         for t in tests:
             print("test: ", t)
             gvec, dvec = cls.gvec_dvec(t.theta_deg, t.eta_deg)
-            det_x = line_plane_intersect(
+            det_x = cls.line_plane_intersect(
                 p0_l, dvec, d0_l, nv_l
             )
             if t.theta_deg <= 0:
@@ -208,7 +237,7 @@ class TestGvecXY:
             dvec_l = rmat_d @ dvec
             tvec_l = rmat_d @ cls.base.tvec_d
             beam = rmat_d @ cls.base.beam_vec
-            det_x = line_plane_intersect(
+            det_x = cls.line_plane_intersect(
                 p0_l, dvec_l, tvec_l, rmat_d @ nv_d
             )
             x_d = rmat_d.T @ (det_x - tvec_l)
@@ -250,7 +279,7 @@ class TestGvecXY:
             ts = np.array(t.ts)
             tc = np.array(t.tc)
             p0_l = ts + tc
-            det_x = line_plane_intersect(
+            det_x = cls.line_plane_intersect(
                 p0_l, dvec, td, nv_l
             )
             xy = det_x[:2] - td[:2]
@@ -289,7 +318,7 @@ class TestGvecXY:
             print(t)
             tvec_l= -cls.base.tvec_d
             rmat_d = cls.make_rmat(t.angle_deg, t.axis)
-            det_x = line_plane_intersect(
+            det_x = cls.line_plane_intersect(
                 p0_l, dvec, d0_l, rmat_d @ nv_l
             )
             x_d = rmat_d.T @ (det_x - d0_l)
@@ -334,7 +363,7 @@ class TestGvecXY:
             rmat_c = cls.make_rmat(ang_c, ax_c)
 
             gvec_c = rmat_c.T @ rmat_s.T @ gvec_l
-            det_x = line_plane_intersect(
+            det_x = cls.line_plane_intersect(
                 (0, 0, 0), dvec_l, cls.base.tvec_d, (0, 0, 1)
             )
             xy = det_x[:2]
@@ -342,55 +371,3 @@ class TestGvecXY:
             cls.run_test(cls.base._replace(
                 gvec_c=gvec_c, rmat_s=rmat_s, rmat_c=rmat_c, xy=xy
             ))
-
-def unit_vector(v):
-    return v/np.linalg.norm(v)
-
-
-def make_unit_vector(theta, phi):
-    """Make a unit vector from spherical coordinates
-
-    PARAMETERS
-    ----------
-    theta: float
-       azimuth angle
-    phi: float
-       angle with north pole
-
-    RETURNS
-    -------
-    array(3)
-       unit vector
-    """
-    return (
-        np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)
-    )
-
-
-def line_plane_intersect(p0, dvec, d0, nvec):
-    """Solve line/plane intersection
-
-    PARAMETERS
-    ----------
-    p0: array/3-tuple of floats
-        a point on the line
-    dvec: array/3-tuple of floats
-        direction (unit) vector of line
-    d0: array/3-tuple of floats
-        origin of detector
-    nvec: array/3-tuple of floats
-        normal vector to detector
-
-    RETURNS
-    -------
-    xyz: 3-tuple
-        intersection point
-
-    NOTES
-    -----
-    From geometry, t = (d0 - p0).n/(d.n), and x = p0 + td
-    """
-    p0_, d = np.array([p0, dvec])
-    t = np.dot((d0 - p0_), nvec)/np.dot(d, nvec)
-    x = p0_ + t * d
-    return x

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import copy
 import json
 
@@ -6,6 +7,13 @@ import numpy as np
 from hexrd.transforms.xfcapi import gvec_to_xy
 
 from common import convert_axis_angle_to_rmat
+
+
+_flds = [
+    "tvec_c", "tvec_d", "tvec_s","rmat_c", "rmat_d", "rmat_s",
+    "gvec_c", "beam_vec", "xy"
+]
+GvecXYData = namedtuple("GvecData", _flds)
 
 
 def test_gvec_to_xy(test_data_dir):
@@ -36,3 +44,187 @@ def test_gvec_to_xy(test_data_dir):
 
         result = gvec_to_xy(**rotated_kwargs)
         assert np.allclose(result, expected)
+
+
+class TestGvecXY:
+    """Test gvec_to_xy and xy_to_gvec"""
+
+    # Base Case: sample and crystal align with lab frame;
+    # detector distance = 10; gvec = beam, no diffraction.
+    base = GvecXYData(
+        tvec_c = np.zeros(3),
+        tvec_d = np.array([0., 0., -10]),
+        tvec_s = np.zeros(3),
+        rmat_c = np.identity(3),
+        rmat_d = np.identity(3),
+        rmat_s = np.identity(3),
+        gvec_c = np.array([0, 0, -1.0]),
+        beam_vec = np.array([0, 0, -1.0]),
+        xy = np.array((np.nan, np.nan))
+    )
+
+    @staticmethod
+    def to_array(a):
+        return np.array(a, dtype=float)
+
+    def run_test(prob):
+        """Run a test problem"""
+        xy_d = gvec_to_xy(
+            np.array(prob.gvec_c),
+            np.array(prob.rmat_d),
+            np.array(prob.rmat_s),
+            np.array(prob.rmat_c),
+            np.array(prob.tvec_d),
+            np.array(prob.tvec_s),
+            np.array(prob.tvec_c),
+            beam_vec=np.array(prob.beam_vec),
+        )
+        assert np.allclose(xy_d, prob.xy, equal_nan=True)
+
+
+    @staticmethod
+    def gvec_dvec(theta_deg, eta_deg=0):
+        """Return diffraction vector
+
+        PARAMETERS
+        ----------
+        theta_deg: float
+           diffraction angle theta, in degrees
+        eta_degrees: float
+           azimuthal angle, in degrees
+
+        RETURNS
+        -------
+        gvec: array(3):
+           diffraction vector relative to beam in -z-direction
+        dvec: array(3):
+           direction (unit vector) of diffracted beam
+        """
+        eta = np.radians(eta_deg)
+        ce, se = np.cos(eta), np.sin(eta)
+
+        # Diffraction vector makes angle theta with plane normal.
+        normal_ang = np.radians(90 - theta_deg)
+        cna, sna = np.cos(normal_ang), np.sin(normal_ang)
+        gvec = np.array((ce * sna, se * sna, cna))
+
+        # Diffracted beam direction makes angle 2-theta with beam.
+        two_theta = np.radians(2 * theta_deg)
+        c2t, s2t = np.cos(two_theta), np.sin(two_theta)
+        dvec = np.array((ce * s2t, se * s2t, -c2t))
+
+        return gvec, dvec
+
+
+    @classmethod
+    def test_theta_eta(cls):
+        """Vary diffraction angle in simple case
+
+        TEST PARAMETERS
+        ---------------
+        theta_deg: float
+           diffraction angle in degrees
+        eta_deg: float, default=0
+           azimuthal angle in degrees
+        """
+        ThetaEta = namedtuple("ThetaEta", ["theta_deg", "eta_deg"])
+        tests = [
+            ThetaEta(0, 0), ThetaEta(10, 0), ThetaEta(44.9, 0),
+            ThetaEta(46, 0), ThetaEta(10, 45), ThetaEta(10, -45),
+        ]
+
+        p0_l = (0, 0, 0)
+        d0_l = cls.base.tvec_d
+        nv_l = (0, 0, 1)
+        for t in tests:
+            gvec, dvec = cls.gvec_dvec(t.theta_deg, t.eta_deg)
+            det_x = line_plane_intersect(
+                p0_l, dvec, d0_l, nv_l
+            )
+            if t.theta_deg <= 0:
+                answer =  np.array((np.nan, np.nan))
+            else:
+                answer = det_x[:2]
+
+            cls.run_test(cls.base._replace(
+                gvec_c=gvec, xy=answer
+            ))
+
+
+
+def unit_vector(v):
+    return v/np.linalg.norm(v)
+
+
+def make_unit_vector(theta, phi):
+    """Make a unit vector from spherical coordinates
+
+    PARAMETERS
+    ----------
+    theta: float
+       azimuth angle
+    phi: float
+       angle with north pole
+
+    RETURNS
+    -------
+    array(3)
+       unit vector
+    """
+    return (
+        np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)
+    )
+
+
+def make_rmat(angle, axis):
+    """Make a rotation matrix
+
+    PARAMETERS
+    ----------
+    angle: float
+       rotation angle in degrees
+    axis: array(3)
+       axis of rotation (not normalized to unit vector)
+
+    RETURNS
+    -------
+    array(3, 3):
+       rotation matrix
+    """
+    n = unit_vector(np.array(axis, dtype=float))
+    ang = np.radians(angle)
+    c, s = np.cos(0.5 * ang), np.sin(0.5 * ang)
+    q = np.array((c, s * n[0], s * n[1], s * n[2]))
+    rmat = rotMatOfQuat(q.reshape(4, 1))
+    # check_rmat(rmat.T)
+    return rmat
+
+
+
+def line_plane_intersect(p0, dvec, d0, nvec):
+    """Solve line/plane intersection
+
+    PARAMETERS
+    ----------
+    p0: array/3-tuple of floats
+        a point on the line
+    dvec: array/3-tuple of floats
+        direction (unit) vector of line
+    d0: array/3-tuple of floats
+        origin of detector
+    nvec: array/3-tuple of floats
+        normal vector to detector
+
+    RETURNS
+    -------
+    xyz: 3-tuple
+        intersection point
+
+    NOTES
+    -----
+    From geometry, t = (d0 - p0).n/(d.n), and x = p0 + td
+    """
+    p0_, d = np.array([p0, dvec])
+    t = np.dot((d0 - p0_), nvec)/np.dot(d, nvec)
+    x = p0_ + t * d
+    return x

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -70,7 +70,6 @@ class TestGvecXY:
     @classmethod
     def run_test(cls, prob):
         """Run a test problem"""
-        print("prob: ", prob)
         xy_d = gvec_to_xy(
             cls.to_array(prob.gvec_c),
             cls.to_array(prob.rmat_d),
@@ -261,6 +260,42 @@ class TestGvecXY:
                 xy=xy
             ))
 
+    @classmethod
+    def test_detector_orientation(cls):
+        """Vary detector orientation
+
+        TEST PARAMETERS
+        ---------------
+        rd: 2-tuple
+           angle/axis pairs
+        """
+        RmatData = namedtuple("RmatData", ["angle_deg", "axis"])
+        nan_tests = [
+            RmatData(90, (0, 1, 0)),
+        ]
+        tests =[
+            RmatData(90, (1, 0, 0)),
+            RmatData(45, (1, 0, 0)),
+            RmatData(45, (0, 0, 1))
+        ]
+
+        theta_deg, eta_deg = 5, 0
+        gvec, dvec = cls.gvec_dvec(theta_deg, eta_deg)
+
+        p0_l = (0, 0, 0)
+        d0_l = cls.base.tvec_d
+        nv_l = (0, 0, 1)
+        for t in tests:
+            print(t)
+            tvec_l= -cls.base.tvec_d
+            rmat_d = cls.make_rmat(t.angle_deg, t.axis)
+            det_x = line_plane_intersect(
+                p0_l, dvec, d0_l, rmat_d @ nv_l
+            )
+            x_d = rmat_d.T @ (det_x - d0_l)
+            cls.run_test(cls.base._replace(
+                gvec_c=gvec, rmat_d=rmat_d, xy=x_d[:2]
+            ))
 
 def unit_vector(v):
     return v/np.linalg.norm(v)


### PR DESCRIPTION
This is a work in progress. It adds several groups of tests for `gvec_to_xy` could easily be extended to test `xy_to_gvec`.  The tests in include varying beam direction, theta and eta angles, translation vectors, detector orientation, sample and crystal orientations. 

It also includes tests that should return `nan`s, but these are inactivated due to Issue #704. 