### PR TITLE
Fix sparsing from eiger stream files

### DIFF
--- a/hexrd/imageseries/load/eiger_stream_v1.py
+++ b/hexrd/imageseries/load/eiger_stream_v1.py
@@ -6,6 +6,7 @@ from dectris.compression import decompress
 import h5py
 import numpy as np
 
+from hexrd.utils.compatibility import h5py_read_string
 from hexrd.utils.hdf5 import unwrap_h5_to_dict
 
 from . import ImageSeriesAdapter
@@ -116,7 +117,7 @@ class EigerStreamV1ImageSeriesAdapter(ImageSeriesAdapter):
 
     @property
     def dtype(self):
-        return self._first_data_entry['dtype'][()]
+        return h5py_read_string(self._first_data_entry['dtype'])
 
     @property
     def shape(self):

--- a/hexrd/utils/yaml.py
+++ b/hexrd/utils/yaml.py
@@ -12,9 +12,13 @@ class NumpyToNativeDumper(yaml.SafeDumper):
     converted to a basic type.
     """
     def represent_data(self, data):
-        if isinstance(data, np.ndarray):
+        # Empty shape arrays should be treated as numbers, not arrays.
+        is_empty_shape_array = (
+            isinstance(data, np.ndarray) and data.shape == ()
+        )
+        if isinstance(data, np.ndarray) and not is_empty_shape_array:
             return self.represent_list(data.tolist())
-        elif isinstance(data, (np.generic, np.number)):
+        elif isinstance(data, (np.generic, np.number)) or is_empty_shape_array:
             item = data.item()
             if isinstance(item, (np.generic, np.number)):
                 # This means it was not converted successfully.


### PR DESCRIPTION
This fixes a few issues with creating sparse frame-cache arrays from eiger-stream-v1 files:

1. The dtype is now read correctly from the HDF5 file
2. Fixed treatment of arrays with empty shapes in the yaml dumper `NumpyToNativeDumper`
3. Save the nested eiger metadata as a yaml string, since frame caches do not yet support nested metadata