### PR TITLE
fixes eta_ome.save() call in findorientaions.py

### DIFF
--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -583,7 +583,7 @@ def generate_eta_ome_maps(cfg, hkls=None, save=True):
             map_fname
         )
 
-        eta_ome.save_eta_ome_maps(fn)
+        eta_ome.save(fn)
 
         logger.info('saved eta/ome orientation maps to "%s"', fn)
 


### PR DESCRIPTION
This is a one-line fix. The line
```
       eta_ome.save(fn)
```
was changed to 
```
        eta_ome.save_eta_ome_maps(fn)
```
in #663, which broke the `findorientations` example in NIST_RUBY/single_GE because, giving this error:
```
Traceback (most recent call last):
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/findorientations.py", line 422, in load_eta_ome_maps
    res = EtaOmeMaps(fn)
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/xrdutil/utils.py", line 86, in __init__
    ome_eta: np.ndarray = np.load(ome_eta_archive, allow_pickle=True)
  File "/Users/deboyce/miniconda3/envs/hexrd-dev/lib/python3.9/site-packages/numpy/lib/npyio.py", line 427, in load
    fid = stack.enter_context(open(os_fspath(file), "rb"))
FileNotFoundError: [Errno 2] No such file or directory: '/Users/deboyce/Source/hexrd/examples/NIST_ruby/single_GE/docrun/cstudy_ruby_eta-ome_maps.npz'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/deboyce/miniconda3/envs/hexrd-dev/bin/hexrd", line 8, in <module>
    sys.exit(main())
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/cli/main.py", line 85, in main
    args.func(args, p)
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/cli/find_orientations.py", line 164, in execute
    results = find_orientations(
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/findorientations.py", line 817, in find_orientations
    eta_ome = load_eta_ome_maps(cfg, plane_data, imsd,
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/findorientations.py", line 435, in load_eta_ome_maps
    res = generate_eta_ome_maps(cfg, hkls=hkls)
  File "/Users/deboyce/Source/hexrd/pkg/hexrd/findorientations.py", line 586, in generate_eta_ome_maps
    eta_ome.save_eta_ome_maps(fn)
AttributeError: 'GenerateEtaOmeMaps' object has no attribute 'save_eta_ome_maps'

```

Changing it back fixes it.
