### PR TITLE
Remove point selection from WPPF

### DIFF
--- a/hexrd/material/material.py
+++ b/hexrd/material/material.py
@@ -1157,6 +1157,19 @@ class Material(object):
             self._newUnitcell()
             self._hkls_changed()
 
+    @property
+    def sgsetting(self):
+        return self._sgsetting
+
+    @sgsetting.setter
+    def sgsetting(self, val):
+        if val in [0, 1]:
+            self._sgsetting = val
+        else:
+            msg = (f'space group setting must be either 0'
+                   f' or 1.')
+            raise ValueError(msg)
+
     sgnum = property(_get_sgnum, _set_sgnum, None, "Space group number")
 
     @property

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -210,8 +210,14 @@ class LeBail:
 
         elif "spline" in self.bkgmethod.keys():
             self._background = []
-            self.selectpoints()
-            for i, pts in enumerate(self.points):
+
+            points = self.bkgmethod["spline"]
+            if not points:
+                raise RuntimeError(
+                    "Background points must be set to use spline"
+                )
+
+            for i, pts in enumerate(np.asarray(points)):
                 tth = self._spectrum_expt[i]._x
                 x = pts[:, 0]
                 y = pts[:, 1]
@@ -300,31 +306,6 @@ class LeBail:
         for i, s in enumerate(self._spectrum_expt):
             tth = self._tth_list[i]
             self._background.append(Spectrum(x=tth, y=self.init_bkg(tth)))
-
-    def selectpoints(self):
-        """
-        03/08/2021 SS spectrum_expt is a list now. accounting
-        for that change
-        """
-        # Keep matplotlib as an optional dependency
-        # FIXME: move this function to where it is needed
-        from pylab import plot, ginput, close, title, xlabel, ylabel
-
-        self.points = []
-        for i, s in enumerate(self._spectrum_expt):
-            txt = (
-                f"Select points for background estimation\n"
-                f"click middle mouse button when done. segment # {i}"
-            )
-            title(txt)
-
-            plot(s.x, s.y, "-k")
-            xlabel(r"2$\theta$")
-            ylabel("intensity (a.u.)")
-
-            self.points.append(np.asarray(ginput(0, timeout=-1)))
-
-            close()
 
     # cubic spline fit of background using custom points chosen from plot
     def splinefit(self, x, y, tth):
@@ -1751,8 +1732,14 @@ class Rietveld:
 
         elif "spline" in self.bkgmethod.keys():
             self._background = []
-            self.selectpoints()
-            for i, pts in enumerate(self.points):
+
+            points = self.bkgmethod["spline"]
+            if not points:
+                raise RuntimeError(
+                    "Background points must be set to use spline"
+                )
+
+            for i, pts in enumerate(np.asarray(points)):
                 tth = self._spectrum_expt[i]._x
                 x = pts[:, 0]
                 y = pts[:, 1]
@@ -1841,31 +1828,6 @@ class Rietveld:
         for i, s in enumerate(self._spectrum_expt):
             tth = self._tth_list[i]
             self._background.append(Spectrum(x=tth, y=self.init_bkg(tth)))
-
-    def selectpoints(self):
-        """
-        03/08/2021 SS spectrum_expt is a list now. accounting
-        for that change
-        """
-
-        # Keep matplotlib as an optional dependency
-        from pylab import plot, ginput, close, title, xlabel, ylabel
-
-        self.points = []
-        for i, s in enumerate(self._spectrum_expt):
-            txt = (
-                f"Select points for background estimation\n"
-                f"click middle mouse button when done. segment # {i}"
-            )
-            title(txt)
-
-            plot(s.x, s.y, "-k")
-            xlabel(r"2$\theta$")
-            ylabel("intensity (a.u.)")
-
-            self.points.append(np.asarray(ginput(0, timeout=-1)))
-
-            close()
 
     # cubic spline fit of background using custom points chosen from plot
     def splinefit(self, x, y, tth):

--- a/hexrd/wppf/parameters.py
+++ b/hexrd/wppf/parameters.py
@@ -242,6 +242,10 @@ class Parameter:
     def max(self, maxval):
         self._max = maxval
 
+    # Make "lb" and "ub" references to the min/max properties
+    lb = min
+    ub = max
+
     @property
     def vary(self):
         return self._vary


### PR DESCRIPTION
This removes the need to import matplotlib from the code.
    
Now, it expects the background points to have been pre-selected elsewhere,
and the background points is the single argument for the `spline` background
method.

Corresponding branch in the GUI: hexrd/hexrdgui#1728