### PR TITLE
Add fch5 an hdf5-based format for storing framecaches

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - lxml >=4.9.2
     - fast-histogram
     - h5py
+    - hdf5plugin
     - lmfit
     - matplotlib-base
     - numba

--- a/hexrd/imageseries/load/framecache.py
+++ b/hexrd/imageseries/load/framecache.py
@@ -12,6 +12,7 @@ from . import ImageSeriesAdapter
 from ..imageseriesiter import ImageSeriesIterator
 from .metadata import yamlmeta
 from hexrd.utils.hdf5 import unwrap_h5_to_dict
+from hexrd.utils.compatibility import h5py_read_string
 
 import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
@@ -81,7 +82,7 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
 
             self._shape = file["shape"][()]
             self._nframes = file["nframes"][()]
-            self._dtype = np.dtype(file["dtype"][()])
+            self._dtype = np.dtype(h5py_read_string(file["dtype"]))
             self._meta = {}
             unwrap_h5_to_dict(file["metadata"], self._meta)
 

--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -398,7 +398,7 @@ class WriteFrameCache(Writer):
             h5f.attrs['HEXRD_FRAMECACHE_VERSION'] = 1
             h5f["shape"] = shape
             h5f["nframes"] = nframes
-            h5f["dtype"] = str(self._ims.dtype).encode()
+            h5f["dtype"] = str(np.dtype(self._ims.dtype)).encode("utf-8")
             metadata = h5f.create_group("metadata")
             unwrap_dict_to_h5(metadata, self._meta.copy())
 

--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -9,11 +9,13 @@ import warnings
 
 import numpy as np
 import h5py
+import hdf5plugin
 import yaml
 
 from hexrd.matrixutil import extract_ijv
+from hexrd.utils.hdf5 import unwrap_dict_to_h5
 
-MAX_NZ_FRACTION = 0.1    # 10% sparsity trigger for frame-cache write
+MAX_NZ_FRACTION = 0.1  # 10% sparsity trigger for frame-cache write
 
 
 # =============================================================================
@@ -42,7 +44,6 @@ def write(ims, fname, fmt, **kwargs):
 
 # Registry
 class _RegisterWriter(abc.ABCMeta):
-
     def __init__(cls, name, bases, attrs):
         abc.ABCMeta.__init__(cls, name, bases, attrs)
         _Registry.register(cls)
@@ -50,6 +51,7 @@ class _RegisterWriter(abc.ABCMeta):
 
 class _Registry(object):
     """Registry for imageseries writers"""
+
     writer_registry = dict()
 
     @classmethod
@@ -76,6 +78,7 @@ class Writer(object, metaclass=_RegisterWriter):
     kwargs: dict
        options specific to format
     """
+
     fmt = None
 
     def __init__(self, ims, fname, **kwargs):
@@ -111,6 +114,7 @@ class Writer(object, metaclass=_RegisterWriter):
     def opts(self):
         return self._opts
 
+
 class WriteH5(Writer):
     """Write imageseries in HDF5 file
 
@@ -129,6 +133,7 @@ class WriteH5(Writer):
     shuffle: bool
        shuffle HDF5 data
     """
+
     fmt = 'hdf5'
     dflt_gzip = 1
     dflt_chrows = 0
@@ -151,8 +156,9 @@ class WriteH5(Writer):
         g = f.create_group(self._path)
         s0, s1 = self._shape
 
-        ds = g.create_dataset('images', (self._nframes, s0, s1), self._dtype,
-                              **self.h5opts)
+        ds = g.create_dataset(
+            'images', (self._nframes, s0, s1), self._dtype, **self.h5opts
+        )
 
         for i in range(self._nframes):
             ds[i, :, :] = self._ims[i]
@@ -218,6 +224,7 @@ class WriteFrameCache(Writer):
        The max number of worker threads for multithreading. Defaults to
        the number of CPUs.
     """
+
     fmt = 'frame-cache'
 
     def __init__(self, ims, fname, style='npz', **kwargs):
@@ -227,13 +234,17 @@ class WriteFrameCache(Writer):
 
         ncpus = multiprocessing.cpu_count()
         self.max_workers = kwargs.get('max_workers', ncpus)
-        supported_formats = ['npz','cfh5']
+        supported_formats = ['npz', 'fch5']
         if style not in supported_formats:
-          raise TypeError(f"Unknown file style for writing framecache: {style}. Supported formats are  {supported_formats}")
+            raise TypeError(
+                f"Unknown file style for writing framecache: {style}. "
+                f"Supported formats are {supported_formats}"
+            )
         self.style = style
 
-    def _set_cache(self):
+        self.hdf5_compression = hdf5plugin.Blosc(cname="zstd", clevel=5)
 
+    def _set_cache(self):
         cf = self.opts.get('cache_file')
 
         if cf is None:
@@ -274,19 +285,40 @@ class WriteFrameCache(Writer):
         return d
 
     def _write_yml(self):
-        datad = {'file': self._cachename, 'dtype': str(self._ims.dtype),
-                 'nframes': len(self._ims), 'shape': list(self._ims.shape)}
+        datad = {
+            'file': self._cachename,
+            'dtype': str(self._ims.dtype),
+            'nframes': len(self._ims),
+            'shape': list(self._ims.shape),
+        }
         info = {'data': datad, 'meta': self._process_meta(save_omegas=True)}
         with open(self._fname, "w") as f:
             yaml.safe_dump(info, f)
 
     def _write_frames(self):
         if self.style == 'npz':
-          self._write_frames_npz()
+            self._write_frames_npz()
+        elif self.style == 'fch5':
+            self._write_frames_fch5()
+
+    def _check_sparsity(self, frame_id, count, buff_size):
+        # check the sparsity
+        #
+        # FIXME: formalize this a little better
+        # ???: maybe set a hard limit of total nonzeros for the imageseries
+        # ???: could pass as a kwarg on open
+        fullness = count / float(buff_size)
+        if fullness > MAX_NZ_FRACTION:
+            sparseness = 100.0 * (1 - fullness)
+            msg = "frame %d is %4.2f%% sparse (cutoff is 95%%)" % (
+                frame_id,
+                sparseness,
+            )
+            warnings.warn(msg)
 
     def _write_frames_npz(self):
         """also save shape array as originally done (before yaml)"""
-        buff_size = self._ims.shape[0]*self._ims.shape[1]
+        buff_size = self._ims.shape[0] * self._ims.shape[1]
         arrd = {}
 
         num_workers = min(self.max_workers, len(self._ims))
@@ -308,20 +340,9 @@ class WriteFrameCache(Writer):
             vals = val_buffers[buffer_id]
 
             # wrapper to find (sparse) pixels above threshold
-            count = extract_ijv(self._ims[i], self._thresh,
-                                rows, cols, vals)
+            count = extract_ijv(self._ims[i], self._thresh, rows, cols, vals)
 
-            # check the sparsity
-            #
-            # FIXME: formalize this a little better
-            # ???: maybe set a hard limit of total nonzeros for the imageseries
-            # ???: could pass as a kwarg on open
-            fullness = count / float(buff_size)
-            if fullness > MAX_NZ_FRACTION:
-                sparseness = 100.*(1 - fullness)
-                msg = "frame %d is %4.2f%% sparse (cutoff is 95%%)" \
-                    % (i, sparseness)
-                warnings.warn(msg)
+            self._check_sparsity(i, count, buff_size)
 
             arrd[f'{i}_row'] = rows[:count].copy()
             arrd[f'{i}_col'] = cols[:count].copy()
@@ -342,6 +363,117 @@ class WriteFrameCache(Writer):
         arrd.update(self._process_meta())
         np.savez_compressed(self.cache, **arrd)
 
+    def _write_frames_fch5(self):
+        """Write framecache into an hdf5 file. The file will use three
+        datasets for the framecache:
+        - 'data': (m,1) array holding the datavalues of all frames. `m` is
+          evaluated upon runtime
+        - 'indices': (m,2) array holding the row& col information for the
+          values in data. 'data' together within 'indices' represent tha data
+          using the CSR format for sparse matrices.
+        - 'frame_ids`: (2*nframes)  holds the range that the i-th frame
+          occupies in the above arrays. i.e. the information of the i-th frame
+          can be accessed using:
+
+          data_i = data[frame_ids[2*i]:frame_ids[2*i+1]] and
+          indices_i = indices[frame_ids[2*i]:frame_ids[2*i+1]]
+        """
+        max_frame_size = self._ims.shape[0] * self._ims.shape[1]
+        nframes = len(self._ims)
+        shape = self._ims.shape
+        data_dtype = self._ims.dtype
+
+        frame_indices = np.empty((2 * nframes,), dtype=np.uint64)
+        data_dataset = None
+        indices_dataset = None
+        file_position = 0
+        total_size = 0
+
+        common_lock = threading.Lock()
+        thread_local = threading.local()
+
+        # creating an array in memory will fail if data is too big or threshold
+        # too low, so we write to the file while iterating the frames
+        with h5py.File(self.cache, "w") as h5f:
+            h5f.attrs['HEXRD_FRAMECACHE_VERSION'] = 1
+            h5f["shape"] = shape
+            h5f["nframes"] = nframes
+            h5f["dtype"] = str(self._ims.dtype).encode()
+            metadata = h5f.create_group("metadata")
+            unwrap_dict_to_h5(metadata, self._meta.copy())
+
+            def initialize_buffers():
+                thread_local.data = np.empty(
+                    (max_frame_size, 1), dtype=self._ims.dtype
+                )
+                thread_local.indices = np.empty(
+                    (max_frame_size, 2), dtype=np.uint16
+                )
+
+            def single_array_write_thread(i):
+                nonlocal file_position, total_size
+                im = self._ims[i]
+                row_slice = thread_local.indices[:, 0]
+                col_slice = thread_local.indices[:, 1]
+                data_slice = thread_local.data[:, 0]
+                count = extract_ijv(
+                    im, self._thresh, row_slice, col_slice, data_slice
+                )
+
+                self._check_sparsity(i, count, max_frame_size)
+
+                # get the range this thread is doing to write into the file
+                start_file = 0
+                end_file = 0
+                with common_lock:
+                    start_file = file_position
+                    file_position += count
+                    end_file = file_position
+                    total_size += end_file - start_file
+                # write within the appropriate ranges
+                data_dataset[start_file:end_file, :] = thread_local.data[
+                    :count, :
+                ]
+                indices_dataset[start_file:end_file, :] = thread_local.indices[
+                    :count, :
+                ]
+                frame_indices[2 * i] = start_file
+                frame_indices[2 * i + 1] = end_file
+
+            kwargs = {
+                "max_workers": self.max_workers,
+                "initializer": initialize_buffers,
+            }
+
+            data_dataset = h5f.create_dataset(
+                "data",
+                shape=(nframes * max_frame_size, 1),
+                dtype=data_dtype,
+                compression=self.hdf5_compression,
+            )
+            indices_dataset = h5f.create_dataset(
+                "indices",
+                shape=(nframes * max_frame_size, 2),
+                dtype=np.uint16,
+                compression=self.hdf5_compression,
+            )
+            with ThreadPoolExecutor(**kwargs) as executor:
+                # Evaluate the results via `list()`, so that if an exception is
+                # raised in a thread, it will be re-raised and visible to
+                # the user.
+                list(executor.map(single_array_write_thread, range(nframes)))
+
+                # update the sizes of the dataset to match the amount of data
+                # that have been actually written
+                data_dataset.resize(total_size, axis=0)
+                indices_dataset.resize(total_size, axis=0)
+
+            h5f.create_dataset(
+                "frame_ids",
+                data=frame_indices,
+                compression=self.hdf5_compression,
+            )
+
     def write(self, output_yaml=False):
         """writes frame cache for imageseries
 
@@ -350,7 +482,6 @@ class WriteFrameCache(Writer):
         self._write_frames()
         if output_yaml:
             warnings.warn(
-                "YAML output for frame-cache is deprecated",
-                DeprecationWarning
+                "YAML output for frame-cache is deprecated", DeprecationWarning
             )
             self._write_yml()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_reqs = [
     'fast-histogram',
     'h5py<3.12',  # Currently, h5py 3.12 on Windows fails to import.
                   # We can remove this version pin when that is fixed.
+    'hdf5plugin',
     'lmfit',
     'matplotlib',
     'numba',

--- a/tests/imageseries/test_formats.py
+++ b/tests/imageseries/test_formats.py
@@ -85,6 +85,7 @@ class TestFormatFrameCache(ImageSeriesFormatTest):
         self.fcfile = os.path.join(self.tmpdir,  'frame-cache.npz')
         self.fmt = 'frame-cache'
         self.thresh = 0.5
+        self.style = 'npz'
         self.cache_file='frame-cache.npz'
         _, self.is_a = make_array_ims()
 
@@ -93,9 +94,9 @@ class TestFormatFrameCache(ImageSeriesFormatTest):
 
     def test_fmtfc(self):
         """save/load frame-cache format"""
-        imageseries.write(self.is_a, self.fcfile, self.fmt,
+        imageseries.write(self.is_a, self.fcfile, self.fmt, style=self.style,
             threshold=self.thresh, cache_file=self.cache_file)
-        is_fc = imageseries.open(self.fcfile, self.fmt)
+        is_fc = imageseries.open(self.fcfile, self.fmt, style=self.style)
         diff = compare(self.is_a, is_fc)
         self.assertAlmostEqual(diff, 0., "frame-cache reconstruction failed")
         self.assertTrue(compare_meta(self.is_a, is_fc))
@@ -104,9 +105,9 @@ class TestFormatFrameCache(ImageSeriesFormatTest):
         """save/load frame-cache format with no cache_file arg"""
         imageseries.write(
             self.is_a, self.fcfile, self.fmt,
-            threshold=self.thresh
+            threshold=self.thresh, style=self.style
         )
-        is_fc = imageseries.open(self.fcfile, self.fmt)
+        is_fc = imageseries.open(self.fcfile, self.fmt, style=self.style)
         diff = compare(self.is_a, is_fc)
         self.assertAlmostEqual(diff, 0., "frame-cache reconstruction failed")
         self.assertTrue(compare_meta(self.is_a, is_fc))
@@ -117,11 +118,22 @@ class TestFormatFrameCache(ImageSeriesFormatTest):
         npa = np.array([0,2.0,1.3])
         self.is_a.metadata[key] = npa
 
-        imageseries.write(self.is_a, self.fcfile, self.fmt,
+        imageseries.write(self.is_a, self.fcfile, self.fmt, style=self.style,
             threshold=self.thresh, cache_file=self.cache_file
         )
-        is_fc = imageseries.open(self.fcfile, self.fmt)
+        is_fc = imageseries.open(self.fcfile, self.fmt, style=self.style)
         meta = is_fc.metadata
         diff = np.linalg.norm(meta[key] - npa)
         self.assertAlmostEqual(diff, 0.,
                                "frame-cache numpy array metadata failed")
+
+
+class TestFormatFrameCache_FCH5(TestFormatFrameCache):
+
+    def setUp(self):
+        self.fcfile = os.path.join(self.tmpdir,  'frame-cache.fch5')
+        self.fmt = 'frame-cache'
+        self.style = 'fch5'
+        self.thresh = 0.5
+        self.cache_file = 'frame-cache.fch5'
+        _, self.is_a = make_array_ims()

--- a/tests/imageseries/test_formats.py
+++ b/tests/imageseries/test_formats.py
@@ -137,3 +137,13 @@ class TestFormatFrameCache_FCH5(TestFormatFrameCache):
         self.thresh = 0.5
         self.cache_file = 'frame-cache.fch5'
         _, self.is_a = make_array_ims()
+
+    def test_fmtfc_nested_metadata(self):
+        """frame-cache format with nested metadata"""
+        metadata = {'int': 1, 'array': np.array([1, 2, 3])}
+        self.is_a.metadata["key"] = metadata
+
+        imageseries.write(self.is_a, self.fcfile, self.fmt, style=self.style,
+                          threshold=self.thresh, cache_file=self.cache_file)
+        is_fc = imageseries.open(self.fcfile, self.fmt, style=self.style)
+        self.assertTrue(compare_meta(self.is_a, is_fc))


### PR DESCRIPTION
The new format allows to store more complex datasets including  metadata at multiple levels.

The new fch5 file contains the following fields:
- `shape`,`nframes`,`dtype`  similar to before storing shape as tuple, nframes as integer and dtype of the imageseries as an encoded string.
- `data` an (m,1) array of type `dtype` holding the datavalues of all frames. `m` is evaluated on runtime based on `threshold` value
- `indices` an (m,2) array of type `np.uint16` holding the row and column indices of the datavalues for each frame.
- `frame_ids`: (2*nframes,1) holds the range that the i-th frame occupies in the above, i.e. the information of the i-th frame  can be accessed using:
```
data_i = data[frame_ids[2*i]:frame_ids[2*i+1]]
indices_i = indices[frame_ids[2*i]:frame_ids[2*i+1]]
```

Both the reader and the writer are multi-threaded and perform better in terms of space efficiency, speed and memory consumption during writes.

Improvements:

- memory consumption: During saving we write the framecache of each frame once it is ready instead of holding everything in memory. This reduces significantly the amount of memory required while processing a dataset for writing:

Maximum memory usage (as reported by GNU time) saving a raw 7.2G file: 
- npz  format: 18.63 Gb
- fch5 format: 1.8 Gb

- in terms of space efficiency, npz uses `zip`. For `fch5` we bring the [hdf5plugin](http://www.silx.org/doc/hdf5plugin/latest/index.html) package and chose the `blosc` compression filter with `zstd` as the underlying compression algorithm and `5` as the compression level. The choice of the compression configuration was based on trading off between size and speed while being competitive against the current `npz` writer. 

This results in the following sizes for the same raw file:

- npz: 816 Mb
- fch5: 661 Mb

and their corresponding saving time:

- npz: 177.43 s
- fch5: 106.45 s



 
 Note that similar to the npz case we store datavalues in their native format so they can be either integers or floats.