### PR TITLE
cast only non-nan numbers to integers. 

### DIFF
--- a/hexrd/gridutil.py
+++ b/hexrd/gridutil.py
@@ -87,7 +87,9 @@ def cellIndices(edges, points_1d):
     #     idx[off_lo] = np.nan
     # if np.any(off_hi):
     #     idx[off_hi] = np.nan
-    return np.array(idx, dtype=int)
+    idx = np.array(idx)
+    idx[np.isnan(idx)] = 0
+    return np.array(idx).astype(int)
 
 
 @numba.njit(nogil=True, cache=True)

--- a/hexrd/gridutil.py
+++ b/hexrd/gridutil.py
@@ -87,9 +87,8 @@ def cellIndices(edges, points_1d):
     #     idx[off_lo] = np.nan
     # if np.any(off_hi):
     #     idx[off_hi] = np.nan
-    idx = np.array(idx)
-    idx[np.isnan(idx)] = 0
-    return np.array(idx).astype(int)
+    idx[np.isnan(idx)] = -1
+    return idx.astype(int)
 
 
 @numba.njit(nogil=True, cache=True)


### PR DESCRIPTION
Suppresses an annoying error that kept popping up.

`/Users/soderlind3/hexrd/hexrd/gridutil.py:90: RuntimeWarning: invalid value encountered in cast
  return np.array(idx, dtype=int)`