### PR TITLE
File placement improvements

### DIFF
--- a/hexrd/cli/find_orientations.py
+++ b/hexrd/cli/find_orientations.py
@@ -51,14 +51,8 @@ def configure_parser(sub_parsers):
 
 
 def write_scored_orientations(results, cfg):
-    # grab working directory from config
-    wdir = cfg.working_dir
-
-    scored_quats_filename = os.path.join(
-        wdir, '_'.join(['scored_orientations', cfg.analysis_id])
-    )
     np.savez_compressed(
-        scored_quats_filename,
+        cfg.find_orientations.orientation_maps.scored_orientations_file,
         **results['scored_orientations']
     )
 

--- a/hexrd/cli/find_orientations.py
+++ b/hexrd/cli/find_orientations.py
@@ -134,14 +134,9 @@ def execute(args, parser):
             quats_f
         )
         sys.exit()
-    if not os.path.exists(cfg.working_dir):
-        os.makedirs(cfg.working_dir)
 
     # configure logging to file
-    logfile = os.path.join(
-        cfg.working_dir,
-        'find-orientations_%s.log' % cfg.analysis_id
-        )
+    logfile = cfg.find_orientations.logfile
     fh = logging.FileHandler(logfile, mode='w')
     fh.setLevel(log_level)
     fh.setFormatter(

--- a/hexrd/cli/find_orientations.py
+++ b/hexrd/cli/find_orientations.py
@@ -1,11 +1,16 @@
 from __future__ import print_function, division, absolute_import
 
 import os
+import logging
+import sys
+
 import numpy as np
 
 from hexrd import constants as const
+from hexrd import config
 from hexrd import instrument
 from hexrd.transforms import xfcapi
+from hexrd.findorientations import find_orientations, write_scored_orientations
 
 
 descr = 'Process rotation image series to find grain orientations'
@@ -52,10 +57,7 @@ def configure_parser(sub_parsers):
 
 def write_results(results, cfg):
     # Write scored orientations.
-    np.savez_compressed(
-        cfg.find_orientations.orientation_maps.scored_orientations_file,
-        **results['scored_orientations']
-    )
+    write_scored_orientations(results, cfg)
 
     # Write accepted orientations.
     qbar_filename = str(cfg.find_orientations.accepted_orientations_file)
@@ -73,12 +75,6 @@ def write_results(results, cfg):
 
 
 def execute(args, parser):
-    import logging
-    import sys
-
-    from hexrd import config
-    from hexrd.findorientations import find_orientations
-
     # make sure hkls are passed in as a list of ints
     try:
         if args.hkls is not None:

--- a/hexrd/cli/find_orientations.py
+++ b/hexrd/cli/find_orientations.py
@@ -58,7 +58,7 @@ def write_results(results, cfg):
     )
 
     # Write accepted orientations.
-    qbar_filename = str(cfg.find_orientations.accepted_orientations_file())
+    qbar_filename = str(cfg.find_orientations.accepted_orientations_file)
     np.savetxt(qbar_filename, results['qbar'].T,
                fmt='%.18e', delimiter='\t')
 
@@ -105,7 +105,7 @@ def execute(args, parser):
     cfg = config.open(args.yml)[0]
 
     # prepare the analysis directory
-    quats_f = cfg.find_orientations.accepted_orientations_file(to_load=True)
+    quats_f = cfg.find_orientations.accepted_orientations_file
 
     if (quats_f is not None) and not (args.force or args.clean):
         logger.error(

--- a/hexrd/cli/find_orientations.py
+++ b/hexrd/cli/find_orientations.py
@@ -107,7 +107,7 @@ def execute(args, parser):
     # prepare the analysis directory
     quats_f = cfg.find_orientations.accepted_orientations_file
 
-    if (quats_f is not None) and not (args.force or args.clean):
+    if (quats_f.exists()) and not (args.force or args.clean):
         logger.error(
             '%s already exists. Change yml file or specify "force" or "clean"',
             quats_f

--- a/hexrd/cli/fit_grains.py
+++ b/hexrd/cli/fit_grains.py
@@ -183,7 +183,6 @@ def execute(args, parser):
                 raise(RuntimeError,
                       "error loading indexing results '%s'" % quats_f)
         else:
-            quats_f = cfg.find_orientations.accepted_orientations_file
             logger.info("Missing %s, running find-orientations", quats_f)
             logger.removeHandler(ch)
             results = find_orientations(cfg)

--- a/hexrd/cli/fit_grains.py
+++ b/hexrd/cli/fit_grains.py
@@ -162,10 +162,10 @@ def execute(args, parser):
     grains_filename = cfg.find_orientations.grains_file
 
     # path to accepted_orientations
-    quats_f = cfg.find_orientations.accepted_orientations_file(to_load = True)
+    quats_f = cfg.find_orientations.accepted_orientations_file
 
     # some conditionals for arg handling
-    have_orientations = quats_f is not None
+    have_orientations = quats_f.exists()
     existing_analysis = grains_filename.exists()
     fit_estimate = cfg.fit_grains.estimate
     force_without_estimate = args.force and fit_estimate is None
@@ -183,7 +183,7 @@ def execute(args, parser):
                 raise(RuntimeError,
                       "error loading indexing results '%s'" % quats_f)
         else:
-            quats_f = cfg.find_orientations.accepted_orientations_file()
+            quats_f = cfg.find_orientations.accepted_orientations_file
             logger.info("Missing %s, running find-orientations", quats_f)
             logger.removeHandler(ch)
             results = find_orientations(cfg)

--- a/hexrd/config/config.py
+++ b/hexrd/config/config.py
@@ -8,11 +8,22 @@ from .utils import null
 logger = logging.getLogger('hexrd.config')
 
 class Config(object):
+    """Access a level of the YAML configuration file
 
+    PARAMETERS
+    ----------
+    cfg: Config instance or a (pyyaml) YAMLObject
+       config representings a level of the YAML input
+    """
     _dirty = False
 
     def __init__(self, cfg):
         self._cfg = cfg
+
+    @property
+    def parent(self):
+        """Parent Config file or None for root (top) level"""
+        return self._cfg  if isinstance(self._cfg, type(self)) else None
 
     @property
     def dirty(self):

--- a/hexrd/config/config.py
+++ b/hexrd/config/config.py
@@ -23,7 +23,7 @@ class Config(object):
     @property
     def parent(self):
         """Parent Config file or None for root (top) level"""
-        return self._cfg  if isinstance(self._cfg, type(self)) else None
+        return self._cfg if isinstance(self._cfg, Config) else None
 
     @property
     def dirty(self):

--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -290,7 +290,9 @@ class OrientationMapsConfig(Config):
             'find_orientations:orientation_maps:file',
             default=None
         )
-        if temp is not None:
+        if temp is None:
+            return None
+        else:
             ptemp = Path(temp)
             if ptemp.is_absolute():
                 mapf = ptemp

--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -32,15 +32,17 @@ class FindOrientationsConfig(Config):
     @property
     def logfile(self):
         """Name of log file"""
+        root = self.parent
         if self.parent.new_file_placement:
             fname = f"{self._find_ori}-{self._active_material_str()}.log"
-            pth = self.parent.analysis_dir / fname
+            pth = root.analysis_dir / fname
         else:
-            fname = f"{self._find_ori}_{cfg.analysis_id}.log"
-            pth = self.parent.working_dir / name
+            fname = f"{self._find_ori}_{root.analysis_id}.log"
+            pth = self.parent.working_dir / fname
 
         return pth
 
+    @property
     def accepted_orientations_file(self):
         """Path of accepted_orientations file"""
         actmat = self._active_material_str()

--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -23,6 +23,14 @@ seed_search_methods = {
 
 class FindOrientationsConfig(Config):
 
+    _find_ori = "find-orientations"
+
+    @property
+    def logfile(self):
+        """Name of log file"""
+        actmat = self.parent.material.active.strip().replace(' ', '-')
+        return self.parent.analysis_dir() / f"{self._find_ori}-{actmat}.log"
+
     # Subsections
     @property
     def orientation_maps(self):
@@ -250,20 +258,31 @@ class OrientationMapsConfig(Config):
         Path:
            the path to an existing file or where to write a new file or None
         """
-        temp = Path(self._cfg.get(
+        #
+        # Get file name.  Because users often set file to "null", which
+        # returns a valid value of None, we have to check twice before setting
+        # it to the default value.
+        #
+        dflt = "eta-ome_maps.npz"
+        temp = self._cfg.get(
             'find_orientations:orientation_maps:file',
-            default="eta-ome_maps.npz"
-        ))
+            default=dflt
+        )
+        if temp is None:
+            temp = dflt
+        temp = Path(temp)
+
+        # Now, we put the file in the analysis directory.
         if temp.suffix != ".npz":
             temp = temp.with_suffix(".npz")
 
-        oem_path = oem_new = self.parent.analysis_dir / temp
+        oem_path = ome_new = self.parent.analysis_dir() / temp
         if temp.is_absolute():
             oem_path = temp
         else:
             ome_old = self.parent.working_dir / temp
-            if loading and not ome_new.exists():
-                oem_path = ome_old if oeme_old.exists() else None
+            if to_load and not ome_new.exists():
+                oem_path = ome_old if ome_old.exists() else None
 
         return oem_path
 

--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -307,7 +307,7 @@ class OrientationMapsConfig(Config):
             actmat = root.find_orientations._active_material_str()
             sof = Path(adir) / f'scored-orientations-{actmat}.npz'
         else:
-            fname = '_'.join(['scored_orientations', cfg.analysis_id])
+            fname = '_'.join(['scored_orientations', root.analysis_id])
             sof = root.working_dir / fname
 
         return sof

--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -1,5 +1,5 @@
 import os
-
+from pathlib import Path
 import logging
 
 import numpy as np
@@ -229,14 +229,43 @@ class OrientationMapsConfig(Config):
             'find_orientations:orientation_maps:eta_step', default=0.25
             )
 
-    @property
-    def file(self):
-        temp = self._cfg.get('find_orientations:orientation_maps:file',
-                             default=None)
-        if temp is not None:
-            if not os.path.isabs(temp):
-                temp = os.path.join(self._cfg.working_dir, temp)
-        return temp
+    def file(self, to_load):
+        """Path of eta-omega maps file
+
+        This function implements the newer file placement for the eta-omega
+        maps file in the analysis directory, instead of the old placement in
+        the working directory. New files will be saved using the new
+        placement. For loading existing files, the new placement will be
+        checked first, and then the old placement. This ensures that old
+        data sets will still find existing map files.
+
+        PARAMETERS
+        ----------
+        to_load: bool
+           if True, the filename with the eta-omega maps; otherwise, it
+           returns the filename to save the eta-omega maps
+
+        RETURNS
+        -------
+        Path:
+           the path to an existing file or where to write a new file or None
+        """
+        temp = Path(self._cfg.get(
+            'find_orientations:orientation_maps:file',
+            default="eta-ome_maps.npz"
+        ))
+        if temp.suffix != ".npz":
+            temp = temp.with_suffix(".npz")
+
+        oem_path = oem_new = self.parent.analysis_dir / temp
+        if temp.is_absolute():
+            oem_path = temp
+        else:
+            ome_old = self.parent.working_dir / temp
+            if loading and not ome_new.exists():
+                oem_path = ome_old if oeme_old.exists() else None
+
+        return oem_path
 
     @property
     def threshold(self):

--- a/hexrd/config/fitgrains.py
+++ b/hexrd/config/fitgrains.py
@@ -34,10 +34,24 @@ class ToleranceConfig(Config):
 
 class FitGrainsConfig(Config):
 
+    _fit_grains = "fit-grains"
+
+    def _active_material_str(self):
+        return self.parent.material.active.strip().replace(' ', '-')
+
     def __init__(self, cfg):
         super().__init__(cfg)
         re, ep = get_exclusion_parameters(self._cfg, 'fit_grains')
         self._reset_exclusions, self._exclusion_parameters = re, ep
+
+    @property
+    def logfile(self):
+        """Name of log file"""
+        return self.parent.analysis_dir / f"fit-grains.log"
+
+    @property
+    def grains_file(self):
+        return self.parent.analysis_dir / "grains.out"
 
     @property
     def reset_exclusions(self):

--- a/hexrd/config/fitgrains.py
+++ b/hexrd/config/fitgrains.py
@@ -34,8 +34,6 @@ class ToleranceConfig(Config):
 
 class FitGrainsConfig(Config):
 
-    _fit_grains = "fit-grains"
-
     def _active_material_str(self):
         return self.parent.material.active.strip().replace(' ', '-')
 
@@ -47,7 +45,7 @@ class FitGrainsConfig(Config):
     @property
     def logfile(self):
         """Name of log file"""
-        return self.parent.analysis_dir / f"fit-grains.log"
+        return self.parent.analysis_dir / "fit-grains.log"
 
     @property
     def grains_file(self):

--- a/hexrd/config/material.py
+++ b/hexrd/config/material.py
@@ -31,8 +31,8 @@ class MaterialConfig(Config):
         if os.path.exists(temp):
             return temp
         raise IOError(
-            '"material:definitions": "%s" does not exist'
-            )
+            f'"material:definitions": "{temp}" does not exist'
+        )
 
     @property
     def active(self):

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -40,9 +40,9 @@ class RootConfig(Config):
 
     @working_dir.setter
     def working_dir(self, val):
-        val = os.path.abspath(val)
-        if not os.path.isdir(val):
-            raise IOError('"working_dir": "%s" does not exist' % val)
+        val = Path(val)
+        if not val.is_dir():
+            raise IOError('"working_dir": "%s" does not exist' % str(val))
         self.set('working_dir', val)
 
     @property
@@ -60,7 +60,7 @@ class RootConfig(Config):
         self.set('analysis_name', val)
 
     @property
-    def analysis_dir(self, mkdirs=False):
+    def analysis_dir(self):
         """Analysis directory, where output files go
 
         The name is derived from `working_dir` and `analysis_name`. This
@@ -78,6 +78,15 @@ class RootConfig(Config):
             [self.analysis_name.strip().replace(' ', '-'),
              self.material.active.strip().replace(' ', '-')]
         )
+
+    @property
+    def new_file_placement(self):
+        """Use new file placements for find-orientations and fit-grains
+
+        The new file placement rules put several files in the `analysis_dir`
+        instead of the `work
+        """
+        return self.get('new_file_placement', default=False)
 
     @property
     def find_orientations(self):

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -21,22 +21,23 @@ class RootConfig(Config):
     def working_dir(self):
         """Working directory, either specified in file or current directory
 
-        This directory is certain to exist. If the specified directory does
-        not exist, it defaults to the current working directory.
+        If the directory is not specified in the config file, then it will
+        default to the current working directory. If it is specified, the
+        director must exist, or it will throw and IOError.
         """
-        try:
-            temp = Path(self.get('working_dir'))
-            if not temp.exists():
-                raise IOError(f'"working_dir": {temp} does not exist')
-            return temp
-
-        except RuntimeError:
-            temp = Path.cwd()
-            self.working_dir = temp
+        wdir = self.get('working_dir', default=None)
+        if wdir is not None:
+            wdir = Path(wdir)
+            if not wdir.exists():
+                raise IOError(f'"working_dir": {str(wdir)} does not exist')
+        else:
+            # Working directory has not been specified, so we use current
+            # directory.
+            wdir = Path.cwd()
             logger.info(
-                '"working_dir" not specified, defaulting to "%s"' % temp
-                )
-            return temp
+                '"working_dir" not specified, defaulting to "%s"' % wdir
+            )
+        return wdir
 
     @working_dir.setter
     def working_dir(self, val):
@@ -47,7 +48,7 @@ class RootConfig(Config):
 
     @property
     def analysis_name(self):
-        """Name (Path) of the analysis
+        """Name of the analysis
 
         This will be used to set up the output directory. The name can
         contain slash ("/") characters, which will generate a subdirectory
@@ -64,7 +65,7 @@ class RootConfig(Config):
         """Analysis directory, where output files go
 
         The name is derived from `working_dir` and `analysis_name`. This
-        propetry returns a Path object. The directory and any intermediate
+        property returns a Path object. The directory and any intermediate
         directories can be created with the `mkdir()` method, e.g.
 
         >>> analysis_dir.mkdir(parents=True, exist_ok=True)

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -47,7 +47,7 @@ class RootConfig(Config):
 
     @property
     def analysis_name(self):
-        """Name of the analysis
+        """Name (Path) of the analysis
 
         This will be used to set up the output directory. The name can
         contain slash ("/") characters, which will generate a subdirectory
@@ -59,14 +59,17 @@ class RootConfig(Config):
     def analysis_name(self, val):
         self.set('analysis_name', val)
 
-    def analysis_dir(self):
+    @property
+    def analysis_dir(self, mkdirs=False):
         """Analysis directory, where output files go
 
-        The name is derived from `working_dir` and `analysis_name`.
-        Intermediate directories will be created.
+        The name is derived from `working_dir` and `analysis_name`. This
+        propetry returns a Path object. The directory and any intermediate
+        directories can be created with the `mkdir()` method, e.g.
+
+        >>> analysis_dir.mkdir(parents=True, exist_ok=True)
         """
         adir = Path(self.working_dir) / self.analysis_name
-        Path.mkdir(adir, parents=True, exist_ok=True)
         return adir
 
     @property

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -405,7 +405,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
         list of eta-omega map arrays
 
     """
-    fn = cfg.find_orientations.orientation_maps.file(to_load := True)
+    fn = cfg.find_orientations.orientation_maps.file
     if clean:
         logger.info(
             'clean option specified; recomputing eta/ome orientation maps'
@@ -415,7 +415,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
         try:
             res = EtaOmeMaps(str(fn))
             pd = res.planeData
-            logger.info(f'loaded eta/ome orientation maps from {fn}')
+            logger.info(f'loaded eta/ome orientation maps from {str(fn)}')
             shkls = pd.getHKLs(*res.iHKLList, asStr=True)
             logger.info(
                 'hkls used to generate orientation maps: %s',
@@ -423,7 +423,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
             )
         except (AttributeError, IOError):
             logger.info(
-                f"specified maps file '{fn}' not found "
+                f"specified maps file '{str(fn)}' not found "
                 f"and clean option not specified; "
                 f"recomputing eta/ome orientation maps"
             )

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -563,7 +563,7 @@ def generate_eta_ome_maps(cfg, hkls=None, save=True):
 
     if save:
         # save maps
-        fn = cfg.find_orientations.orientation_maps.file(False)
+        fn = cfg.find_orientations.orientation_maps.file()
         eta_ome.save(fn)
 
         logger.info(f'saved eta/ome orientation maps to "{fn}"', fn)
@@ -705,6 +705,7 @@ def find_orientations(cfg,
 
     """
     # grab objects from config
+    cfg.analysis_dir.mkdir(parents=True, exist_ok=True)
     plane_data = cfg.material.plane_data
     imsd = cfg.image_series
     instr = cfg.instrument.hedm

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -563,7 +563,7 @@ def generate_eta_ome_maps(cfg, hkls=None, save=True):
 
     if save:
         # save maps
-        fn = cfg.find_orientations.orientation_maps.file()
+        fn = cfg.find_orientations.orientation_maps.file
         eta_ome.save(fn)
 
         logger.info(f'saved eta/ome orientation maps to "{fn}"', fn)

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -42,6 +42,22 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
+def write_scored_orientations(results, fname):
+    """Write scored orientations to a file
+
+    PARAMETERS
+    ----------
+    results: dict
+       output of main `find_orientations` function
+    cfg: Config instance
+       the main Config input file for `find-orientations`
+    """
+    np.savez_compressed(
+        cfg.find_orientations.orientation_maps.scored_orientations_file,
+        **results['scored_orientations']
+    )
+
+
 def _process_omegas(omegaimageseries_dict):
     """Extract omega period and ranges from an OmegaImageseries dictionary."""
     oims = next(iter(omegaimageseries_dict.values()))
@@ -384,7 +400,10 @@ def run_cluster(compl, qfib, qsym, cfg,
 
 def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
     """
-    Load the eta-ome maps specified by the config and CLI flags.
+    Load the eta-ome maps specified by the config and CLI flags. If the
+    maps file exists, it will return those values. If the file does not exist,
+    it will generate them using the passed HKLs (if not None) or the HKLs
+    specified in the config file (if passed HKLs are Noe).
 
     Parameters
     ----------
@@ -395,7 +414,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
     image_series: ImageSeries instance
         stack of images
     hkls: list, default = None
-        list of HKLs used in the eta-omega maps.
+        list of HKLs used to generate the eta-omega maps
     clean: bool, default = False
         flag indicating whether (if True) to overwrite existing maps file
 
@@ -415,7 +434,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
         try:
             res = EtaOmeMaps(str(fn))
             pd = res.planeData
-            logger.info(f'loaded eta/ome orientation maps from {str(fn)}')
+            logger.info(f'loaded eta/ome orientation maps from {fn}')
             shkls = pd.getHKLs(*res.iHKLList, asStr=True)
             logger.info(
                 'hkls used to generate orientation maps: %s',
@@ -429,7 +448,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
             )
             res = generate_eta_ome_maps(cfg, hkls=hkls)
 
-            filter_maps_if_requested(res, cfg)
+        filter_maps_if_requested(res, cfg)
     return res
 
 

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -566,7 +566,7 @@ def generate_eta_ome_maps(cfg, hkls=None, save=True):
         fn = cfg.find_orientations.orientation_maps.file
         eta_ome.save(fn)
 
-        logger.info(f'saved eta/ome orientation maps to "{fn}"', fn)
+        logger.info(f'saved eta/ome orientation maps to "{fn}"')
 
     return eta_ome
 

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -413,7 +413,7 @@ def load_eta_ome_maps(cfg, pd, image_series, hkls=None, clean=False):
         res = generate_eta_ome_maps(cfg, hkls=hkls)
     else:
         try:
-            res = EtaOmeMaps(fn)
+            res = EtaOmeMaps(str(fn))
             pd = res.planeData
             logger.info(f'loaded eta/ome orientation maps from {fn}')
             shkls = pd.getHKLs(*res.iHKLList, asStr=True)
@@ -563,7 +563,7 @@ def generate_eta_ome_maps(cfg, hkls=None, save=True):
 
     if save:
         # save maps
-        map_fname = cfg.find_orientations.orientation_maps.file(False)
+        fn = cfg.find_orientations.orientation_maps.file(False)
         eta_ome.save(fn)
 
         logger.info(f'saved eta/ome orientation maps to "{fn}"', fn)

--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -365,7 +365,7 @@ def fit_grains(cfg,
             eta_ranges=eta_ranges,
             ome_period=ome_period,
             analysis_dirname=cfg.analysis_dir,
-            spots_filename=spots_filename)
+            spots_filename=SPOTS_OUT_FILE)
 
     # =====================================================================
     # EXECUTE MP FIT

--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -19,6 +19,13 @@ from hexrd.fitting import fitGrain, objFuncFitGrain, gFlag_ref
 
 logger = logging.getLogger(__name__)
 
+# These are file names that were hardwired in the code. I am putting them
+# here so they will be easier to find if we want to make them user inputs
+# at some point later.
+
+OVERLAP_TABLE_FILE = 'overlap_table.npz'
+SPOTS_OUT_FILE = "spots_%05d.out"
+
 
 # multiprocessing fit funcs
 def fit_grain_FF_init(params):
@@ -157,7 +164,7 @@ def fit_grain_FF_reduced(grain_id):
                 ot = np.load(
                     os.path.join(
                         analysis_dirname, os.path.join(
-                            det_key, 'overlap_table.npz'
+                            det_key, OVERLAP_TABLE_FILE
                         )
                     )
                 )
@@ -343,7 +350,7 @@ def fit_grains(cfg,
 
     if ids_to_refine is not None:
         grains_table = np.atleast_2d(grains_table[ids_to_refine, :])
-    spots_filename = "spots_%05d.out" if write_spots_files else None
+        spots_filename = SPOTS_OUT_FILE if write_spots_files else None
     params = dict(
             grains_table=grains_table,
             plane_data=cfg.material.plane_data,

--- a/tests/config/test_find_orientations.py
+++ b/tests/config/test_find_orientations.py
@@ -9,6 +9,9 @@ reference_data = \
 """
 analysis_name: analysis
 working_dir: %(tempdir)s
+material:
+  definitions: %(existing_file)s
+  active: actmat
 ---
 find_orientations:
   orientation_maps:
@@ -326,11 +329,11 @@ class TestOrientationMapsConfig(TestConfig):
             self.cfgs[0].find_orientations.orientation_maps.file is None
         )
         self.assertEqual(
-            self.cfgs[1].find_orientations.orientation_maps.file,
+            str(self.cfgs[1].find_orientations.orientation_maps.file),
             os.path.join(test_data['tempdir'], test_data['nonexistent_file'])
             )
         self.assertEqual(
-            self.cfgs[2].find_orientations.orientation_maps.file,
+            str(self.cfgs[2].find_orientations.orientation_maps.file),
             test_data['existing_file']
             )
 

--- a/tests/config/test_root.py
+++ b/tests/config/test_root.py
@@ -40,7 +40,7 @@ class TestRootConfig(TestConfig):
 
     def test_analysis_dir(self):
         self.assertEqual(
-            self.cfgs[0].analysis_dir,
+            str(self.cfgs[0].analysis_dir),
             os.path.join(os.getcwd(), 'analysis')
             )
 
@@ -56,11 +56,15 @@ class TestRootConfig(TestConfig):
         self.assertEqual(self.cfgs[2].analysis_name, 'analysis_2')
 
     def test_working_dir(self):
-        self.assertEqual(self.cfgs[0].working_dir, os.getcwd())
-        self.assertEqual(self.cfgs[1].working_dir, test_data['existing_path'])
+        self.assertEqual(str(self.cfgs[0].working_dir), os.getcwd())
+        self.assertEqual(
+            str(self.cfgs[1].working_dir), test_data['existing_path']
+        )
         self.assertRaises(IOError, getattr, self.cfgs[2], 'working_dir')
         self.cfgs[7].working_dir = test_data['existing_path']
-        self.assertEqual(self.cfgs[7].working_dir, test_data['existing_path'])
+        self.assertEqual(
+            str(self.cfgs[7].working_dir), test_data['existing_path']
+        )
         self.assertRaises(
             IOError, setattr, self.cfgs[7], 'working_dir',
             test_data['nonexistent_path']


### PR DESCRIPTION
The intention of this pull request is to make the output file placement in `find-orientations` and `fit-grains` cleaner and simpler while cleaning up computational code that has hardwired file names and file handling that would be better done elsewhere, _i. e._ the config module.

Roughly, this is what has been done:
- put output files in the `analysis_dir` instead of in the `working_dir` with long names based on the `analysis_name`
- allow for slashes in `analysis_name` and automatically create subdirectories as needed for the `analysis_dir`
    - this is particularly useful when the config file has multiple (YAML) documents
- move path manipulations and hardwired file names from computational modules to the config module
- use pathlib for handling file and directory names
- update docstrings where useful (for affected modules/functions)

You activate the new file placement with the `new_file_placement` keyword in the root level of the config file, e.g.

```
analysis_name: ruby/scan-0  

# working_dir:
new_file_placement: on

```
If the `new_file_placement`  is False (the default), then nothing is changed; the old file placement is used.

Originally, this was intended mainly for `find-orientations`, but `fit-grains` is slightly affected since it looks for a file written by `find-orientations`, _i.e._ the accepted orientations.

Running this on the multiruby and single_GE NIST_Ruby examples, I get the exact same results using the new or the old file placement. 