### PR TITLE
Try to not install libarchive separately

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install build requirements
       run: |
           # Change default solver to be libmamba, so that it runs much faster
-          conda install -n base -c conda-forge conda-libmamba-solver
+          conda install -n base --override-channels -c conda-forge conda-libmamba-solver
           conda config --set solver libmamba
 
           conda activate hexrd
@@ -63,7 +63,7 @@ jobs:
           # For some reason, we need to set this in the environment as well.
           # It seems conda build sometimes needs the solver in the environment
           # and sometimes in the base environment. I don't know why.
-          conda install -c conda-forge conda-libmamba-solver
+          conda install --override-channels -c conda-forge conda-libmamba-solver
           conda config --env --set solver libmamba
           conda list
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,10 +67,6 @@ jobs:
           conda config --env --set solver libmamba
           conda list
 
-          # Mac is having an issue with libarchive. We need to make sure that it
-          # comes from conda-forge. See here: https://github.com/conda/conda-libmamba-solver/issues/283
-          conda update -c conda-forge libarchive
-
           mkdir output
           # Conda build is ignoring the .condarc for some reason, so we need to
           # set this environment variable instead.


### PR DESCRIPTION
The packaging on Mac is currently broken on master. There is an issue with the compatibility between libmamba and the version of libarchive.

See if we can fix it by removing the libarchive installation.