### PR TITLE
Add ability to specify center of rotation

### DIFF
--- a/hexrd/fitting/calibration/instrument.py
+++ b/hexrd/fitting/calibration/instrument.py
@@ -192,6 +192,9 @@ class InstrumentCalibrator:
         self._relative_constraints = v
         self.params = self.make_lmfit_params()
 
+    def reset_lmfit_params(self):
+        self.params = self.make_lmfit_params()
+
     def reset_relative_constraint_params(self):
         # Set them back to zero.
         self.relative_constraints.reset()

--- a/hexrd/fitting/calibration/relative_constraints.py
+++ b/hexrd/fitting/calibration/relative_constraints.py
@@ -16,6 +16,15 @@ class RelativeConstraintsType(Enum):
     system = 'System'
 
 
+class RotationCenter(Enum):
+    """These are different centers for relative constraint rotations"""
+    # Rotate about the mean center of all the detectors
+    instrument_mean_center = 'InstrumentMeanCenter'
+
+    # Rotate about lab origin, which is (0, 0, 0)
+    lab_origin = 'Origin'
+
+
 class RelativeConstraints(ABC):
     @property
     @abstractmethod
@@ -25,6 +34,11 @@ class RelativeConstraints(ABC):
     @property
     @abstractmethod
     def params(self) -> dict:
+        pass
+
+    @property
+    @abstractmethod
+    def rotation_center(self) -> RotationCenter:
         pass
 
     @abstractmethod
@@ -39,6 +53,10 @@ class RelativeConstraintsNone(RelativeConstraints):
     @property
     def params(self) -> dict:
         return {}
+
+    @property
+    def rotation_center(self) -> RotationCenter:
+        return RotationCenter.instrument_mean_center
 
     def reset(self):
         pass
@@ -64,9 +82,19 @@ class RelativeConstraintsGroup(RelativeConstraints):
                 'translation': np.array([0, 0, 0], dtype=float),
             }
 
+        self._rotation_center = RotationCenter.instrument_mean_center
+
     @property
     def params(self) -> dict:
         return self.group_params
+
+    @property
+    def rotation_center(self):
+        return self._rotation_center
+
+    @rotation_center.setter
+    def rotation_center(self, v: RotationCenter):
+        self._rotation_center = v
 
 
 class RelativeConstraintsSystem(RelativeConstraints):
@@ -79,11 +107,28 @@ class RelativeConstraintsSystem(RelativeConstraints):
     def params(self) -> dict:
         return self._params
 
+    @property
+    def rotation_center(self):
+        return self._rotation_center
+
+    @rotation_center.setter
+    def rotation_center(self, v: RotationCenter):
+        self._rotation_center = v
+
     def reset(self):
         self._params = {
             'tilt': np.array([0, 0, 0], dtype=float),
             'translation': np.array([0, 0, 0], dtype=float),
         }
+        self._rotation_center = RotationCenter.instrument_mean_center
+
+    def center_of_rotation(self, instr: HEDMInstrument) -> np.ndarray:
+        if self.rotation_center == RotationCenter.instrument_mean_center:
+            return instr.mean_detector_center
+        elif self.rotation_center == RotationCenter.lab_origin:
+            return np.array([0.0, 0.0, 0.0])
+
+        raise NotImplementedError(self.rotation_center)
 
 
 def create_relative_constraints(type: RelativeConstraintsType,

--- a/hexrd/fitting/calibration/relative_constraints.py
+++ b/hexrd/fitting/calibration/relative_constraints.py
@@ -43,6 +43,12 @@ class RelativeConstraints(ABC):
 
     @abstractmethod
     def reset(self):
+        # Reset everything
+        pass
+
+    @property
+    @abstractmethod
+    def reset_params(self):
         # Reset the parameters
         pass
 
@@ -61,6 +67,9 @@ class RelativeConstraintsNone(RelativeConstraints):
     def reset(self):
         pass
 
+    def reset_params(self):
+        pass
+
 
 class RelativeConstraintsGroup(RelativeConstraints):
     type = RelativeConstraintsType.group
@@ -74,6 +83,10 @@ class RelativeConstraintsGroup(RelativeConstraints):
         self.reset()
 
     def reset(self):
+        self.reset_params()
+        self.reset_rotation_center()
+
+    def reset_params(self):
         self.group_params = {}
 
         for group in self._groups:
@@ -82,6 +95,7 @@ class RelativeConstraintsGroup(RelativeConstraints):
                 'translation': np.array([0, 0, 0], dtype=float),
             }
 
+    def reset_rotation_center(self):
         self._rotation_center = RotationCenter.instrument_mean_center
 
     @property
@@ -116,10 +130,16 @@ class RelativeConstraintsSystem(RelativeConstraints):
         self._rotation_center = v
 
     def reset(self):
+        self.reset_params()
+        self.reset_rotation_center()
+
+    def reset_params(self):
         self._params = {
             'tilt': np.array([0, 0, 0], dtype=float),
             'translation': np.array([0, 0, 0], dtype=float),
         }
+
+    def reset_rotation_center(self):
         self._rotation_center = RotationCenter.instrument_mean_center
 
     def center_of_rotation(self, instr: HEDMInstrument) -> np.ndarray:


### PR DESCRIPTION
For relative constraints, when tilts are applied to the detectors, the center of rotation is an additional setting that can be varied. Specifying a center of rotation that better matches what is expected in the experiment will result in calibrations with greater accuracy and speed.

For example, for FIDDLE, if there is any tilt whatsoever, then the detectors must have rotated about the lab origin (0, 0, 0). Requiring the detectors to be rotated about the origin ensures that the calibration will match what is expected from the experiment.

For other detector setups, such as the Eiger, the mean center of the instrument better matches what is expected if a tilt must be applied.