### PR TITLE
simple fixes 

### DIFF
--- a/hexrd/config/findorientations.py
+++ b/hexrd/config/findorientations.py
@@ -291,12 +291,13 @@ class OrientationMapsConfig(Config):
             default=None
         )
         if temp is None:
-            return None
+            return mapf
         else:
             ptemp = Path(temp)
             if ptemp.is_absolute():
                 mapf = ptemp
             else:
+                # Path is relative to working directory.
                 mapf = root.working_dir / ptemp
 
         return mapf

--- a/hexrd/config/root.py
+++ b/hexrd/config/root.py
@@ -23,20 +23,11 @@ class RootConfig(Config):
 
         If the directory is not specified in the config file, then it will
         default to the current working directory. If it is specified, the
-        director must exist, or it will throw and IOError.
+        directory must exist, or it will throw an IOError.
         """
-        wdir = self.get('working_dir', default=None)
-        if wdir is not None:
-            wdir = Path(wdir)
-            if not wdir.exists():
-                raise IOError(f'"working_dir": {str(wdir)} does not exist')
-        else:
-            # Working directory has not been specified, so we use current
-            # directory.
-            wdir = Path.cwd()
-            logger.info(
-                '"working_dir" not specified, defaulting to "%s"' % wdir
-            )
+        wdir = Path(self.get('working_dir', default=Path.cwd()))
+        if not wdir.exists():
+            raise IOError(f'"working_dir": {str(wdir)} does not exist')
         return wdir
 
     @working_dir.setter
@@ -85,7 +76,7 @@ class RootConfig(Config):
         """Use new file placements for find-orientations and fit-grains
 
         The new file placement rules put several files in the `analysis_dir`
-        instead of the `work
+        instead of the `working_dir`.
         """
         return self.get('new_file_placement', default=False)
 

--- a/hexrd/findorientations.py
+++ b/hexrd/findorientations.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-def write_scored_orientations(results, fname):
+def write_scored_orientations(results, cfg):
     """Write scored orientations to a file
 
     PARAMETERS

--- a/tests/config/test_find_orientations.py
+++ b/tests/config/test_find_orientations.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -57,6 +58,11 @@ find_orientations:
     algorithm: foo
   omega:
     period: [-60, 60]
+---
+new_file_placemnt: on
+find_orientations:
+  orientation_maps:
+    file: null
 """ % test_data
 
 
@@ -325,18 +331,18 @@ class TestOrientationMapsConfig(TestConfig):
 
 
     def test_file(self):
-        self.assertTrue(
-            self.cfgs[0].find_orientations.orientation_maps.file is None
+        self.assertEqual(
+            self.cfgs[0].find_orientations.orientation_maps.file,
+            Path(test_data['tempdir']) / "analysis_actmat_eta-ome_maps.npz"
         )
         self.assertEqual(
-            str(self.cfgs[1].find_orientations.orientation_maps.file),
-            os.path.join(test_data['tempdir'], test_data['nonexistent_file'])
+            self.cfgs[1].find_orientations.orientation_maps.file,
+            Path(test_data['tempdir']) / test_data['nonexistent_file']
             )
         self.assertEqual(
             str(self.cfgs[2].find_orientations.orientation_maps.file),
             test_data['existing_file']
             )
-
 
     def test_threshold(self):
         self.assertRaises(


### PR DESCRIPTION
This fixes some problems introduced in pull request #733. Fixes include:

1. default eta-omega maps filename
2. fixes argument name in `write_scored_orientations` function
3. cleans up the `working_dir` property in config.root
