### PR TITLE
Integrate preprocess scripts

### DIFF
--- a/hexrd/cli/main.py
+++ b/hexrd/cli/main.py
@@ -16,6 +16,7 @@ from hexrd.utils import profiler
 from hexrd.cli import find_orientations
 from hexrd.cli import fit_grains
 from hexrd.cli import pickle23
+from hexrd.cli import preprocess
 
 
 try:
@@ -66,6 +67,7 @@ def main():
     find_orientations.configure_parser(sub_parsers)
     fit_grains.configure_parser(sub_parsers)
     pickle23.configure_parser(sub_parsers)
+    preprocess.configure_parser(sub_parsers)
 
     try:
         import argcomplete

--- a/hexrd/cli/preprocess.py
+++ b/hexrd/cli/preprocess.py
@@ -1,0 +1,15 @@
+"""Entry point for hexrd command line interface"""
+_description = 'Preprocess detector images'
+
+def configure_parser(sub_parsers):
+    parser = sub_parsers.add_parser('preprocess', description=_description, help=_description)
+
+    subparsers = parser.add_subparsers(
+        dest="profile", required=True, help="Select detector profile"
+    )
+
+    parser.set_defaults(func=execute)
+
+
+def execute(args, parser):
+    pass

--- a/hexrd/cli/preprocess.py
+++ b/hexrd/cli/preprocess.py
@@ -1,23 +1,25 @@
 import dataclasses
-from hexrd.preprocess.profiles import HexrdScript_Arguments
+from hexrd.preprocess.profiles import HexrdPPScript_Arguments
 from hexrd.preprocess.preprocessors import preprocess
 from dataclasses import fields
 
 import argparse
 
 _description = 'Preprocess detector images'
-_help =  "Preprocess data from detector and attach metadata"
+_help = "Preprocess data from detector and attach metadata"
 
 
 def configure_parser(sub_parsers):
-    parser = sub_parsers.add_parser('preprocess', description=_description, help=_help)
+    parser = sub_parsers.add_parser(
+        'preprocess', description=_description, help=_help
+    )
 
     subparsers = parser.add_subparsers(
         dest="profile", required=True, help="Select detector profile"
     )
 
-    for fmt in HexrdScript_Arguments.known_formats():
-        klass = HexrdScript_Arguments.create_args(fmt)
+    for fmt in HexrdPPScript_Arguments.known_formats():
+        klass = HexrdPPScript_Arguments.create_args(fmt)
         add_profile_subparser(subparsers, fmt, klass)
 
     parser.set_defaults(func=execute)
@@ -27,14 +29,16 @@ def execute(args, parser):
     kwargs, extra = _remove_non_dataclass_args(vars(args))
 
     if extra["generate_default_config"]:
-        s = HexrdScript_Arguments.create_default_config(extra["profile"])
+        s = HexrdPPScript_Arguments.create_default_config(extra["profile"])
         print(s)
     else:
         if extra["config"] is not None:
-            args_object = HexrdScript_Arguments.load_from_config(extra["config"].read())
+            args_object = HexrdPPScript_Arguments.load_from_config(
+                extra["config"].read()
+            )
         else:
-            args_object = HexrdScript_Arguments.create_args(
-            extra["profile"], **kwargs
+            args_object = HexrdPPScript_Arguments.create_args(
+                extra["profile"], **kwargs
             )
         preprocess(args_object)
 
@@ -82,12 +86,16 @@ def add_profile_subparser(subparsers, name, klass):
         help="Read arguments from .pp config file",
     )
 
+
 def _remove_non_dataclass_args(args_dict):
-    """Remove args that do not belong to any dataclass. These are standard args we manually inserted and now remove to allows the rest initialize dataclass"""
-    d = {}
+    """Remove args that do not belong to any dataclass. These are standard args
+    we manually inserted and now remove to allow the rest of the arguments to
+    initialize dataclass"""
+
+    extra = {}
     for key in ["profile", "config", "generate_default_config"]:
         v = args_dict.get(key, None)
-        d[key] = v
+        extra[key] = v
         if v is not None:
             del args_dict[key]
-    return args_dict, d
+    return args_dict, extra

--- a/hexrd/cli/preprocess.py
+++ b/hexrd/cli/preprocess.py
@@ -2,6 +2,7 @@ import dataclasses
 from hexrd.preprocess.profiles import HexrdPPScript_Arguments
 from hexrd.preprocess.preprocessors import preprocess
 from dataclasses import fields
+from typing import Any
 
 import argparse
 
@@ -9,7 +10,7 @@ _description = 'Preprocess detector images'
 _help = "Preprocess data from detector and attach metadata"
 
 
-def configure_parser(sub_parsers):
+def configure_parser(sub_parsers: argparse._SubParsersAction) -> None:
     parser = sub_parsers.add_parser(
         'preprocess', description=_description, help=_help
     )
@@ -25,7 +26,7 @@ def configure_parser(sub_parsers):
     parser.set_defaults(func=execute)
 
 
-def execute(args, parser):
+def execute(args: argparse.Namespace, _: argparse.ArgumentParser) -> None:
     kwargs, extra = _remove_non_dataclass_args(vars(args))
 
     if extra["generate_default_config"]:
@@ -40,10 +41,15 @@ def execute(args, parser):
             args_object = HexrdPPScript_Arguments.create_args(
                 extra["profile"], **kwargs
             )
+        args_object.validate_arguments()
         preprocess(args_object)
 
 
-def add_profile_subparser(subparsers, name, klass):
+def add_profile_subparser(
+    subparsers: argparse._SubParsersAction,
+    name: str,
+    klass: HexrdPPScript_Arguments,
+) -> None:
     """Create a subparser with the options related to detector `name` using
     `klass` to retrieve default values"""
 
@@ -87,7 +93,7 @@ def add_profile_subparser(subparsers, name, klass):
     )
 
 
-def _remove_non_dataclass_args(args_dict):
+def _remove_non_dataclass_args(args_dict: dict) -> tuple[dict, dict]:
     """Remove args that do not belong to any dataclass. These are standard args
     we manually inserted and now remove to allow the rest of the arguments to
     initialize dataclass"""

--- a/hexrd/cli/preprocess.py
+++ b/hexrd/cli/preprocess.py
@@ -1,15 +1,93 @@
-"""Entry point for hexrd command line interface"""
+import dataclasses
+from hexrd.preprocess.profiles import HexrdScript_Arguments
+from hexrd.preprocess.preprocessors import preprocess
+from dataclasses import fields
+
+import argparse
+
 _description = 'Preprocess detector images'
+_help =  "Preprocess data from detector and attach metadata"
+
 
 def configure_parser(sub_parsers):
-    parser = sub_parsers.add_parser('preprocess', description=_description, help=_description)
+    parser = sub_parsers.add_parser('preprocess', description=_description, help=_help)
 
     subparsers = parser.add_subparsers(
         dest="profile", required=True, help="Select detector profile"
     )
 
+    for fmt in HexrdScript_Arguments.known_formats():
+        klass = HexrdScript_Arguments.create_args(fmt)
+        add_profile_subparser(subparsers, fmt, klass)
+
     parser.set_defaults(func=execute)
 
 
 def execute(args, parser):
-    pass
+    kwargs, extra = _remove_non_dataclass_args(vars(args))
+
+    if extra["generate_default_config"]:
+        s = HexrdScript_Arguments.create_default_config(extra["profile"])
+        print(s)
+    else:
+        if extra["config"] is not None:
+            args_object = HexrdScript_Arguments.load_from_config(extra["config"].read())
+        else:
+            args_object = HexrdScript_Arguments.create_args(
+            extra["profile"], **kwargs
+            )
+        preprocess(args_object)
+
+
+def add_profile_subparser(subparsers, name, klass):
+    """Create a subparser with the options related to detector `name` using
+    `klass` to retrieve default values"""
+
+    subparser = subparsers.add_parser(
+        name,
+        help=f"{name} help",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    help_messages = getattr(klass, "help_messages")
+    short_switches = getattr(klass, "short_switches")
+
+    for field in fields(klass):
+        switches = [f"--{field.name}"]
+        if field.name in short_switches:
+            switch = short_switches[field.name]
+            switches.insert(0, f"-{switch}")
+        default_value = None
+        if field.default_factory != dataclasses.MISSING:
+            default_value = field.default_factory()
+        else:
+            default_value = field.default
+
+        subparser.add_argument(
+            *switches,
+            type=field.type,
+            default=default_value,
+            help=help_messages[field.name],
+        )
+
+    subparser.add_argument(
+        "--generate-default-config",
+        action="store_true",
+        help="Generate config file with default values",
+    )
+    subparser.add_argument(
+        "--config",
+        type=argparse.FileType("r"),
+        required=False,
+        help="Read arguments from .pp config file",
+    )
+
+def _remove_non_dataclass_args(args_dict):
+    """Remove args that do not belong to any dataclass. These are standard args we manually inserted and now remove to allows the rest initialize dataclass"""
+    d = {}
+    for key in ["profile", "config", "generate_default_config"]:
+        v = args_dict.get(key, None)
+        d[key] = v
+        if v is not None:
+            del args_dict[key]
+    return args_dict, d

--- a/hexrd/preprocess/argument_classes_factory.py
+++ b/hexrd/preprocess/argument_classes_factory.py
@@ -1,0 +1,25 @@
+class ArgumentClassesFactory:
+    """A factory to collect all Argument classes"""
+
+    _creators = {}
+
+    @classmethod
+    def register(cls, klass):
+        cls._creators[klass.profile_name] = klass
+
+    @classmethod
+    def get_registered(cls):
+        return cls._creators.keys()
+
+    @classmethod
+    def get_args(cls, profile_name):
+        creator = cls._creators.get(profile_name)
+        if not creator:
+            raise ValueError(format)
+        return creator
+
+
+def autoregister(cls):
+    """decorator that registers cls with ArgumentClassesFactory"""
+    ArgumentClassesFactory().register(cls)
+    return cls

--- a/hexrd/preprocess/argument_classes_factory.py
+++ b/hexrd/preprocess/argument_classes_factory.py
@@ -1,25 +1,39 @@
+import hexrd.preprocess.profiles as profiles
+from typing import Type
+
+
 class ArgumentClassesFactory:
     """A factory to collect all Argument classes"""
 
-    _creators = {}
+    _creators: dict[str, Type["profiles.HexrdPPScript_Arguments"]] = {}
 
     @classmethod
-    def register(cls, klass):
+    def register(cls, klass: Type["profiles.HexrdPPScript_Arguments"]) -> None:
         cls._creators[klass.profile_name] = klass
 
     @classmethod
-    def get_registered(cls):
-        return cls._creators.keys()
+    def get_registered(cls) -> list[str]:
+        return list(cls._creators.keys())
 
     @classmethod
-    def get_args(cls, profile_name):
+    def get_registered_types(
+        cls,
+    ) -> tuple[Type["profiles.HexrdPPScript_Arguments"], ...]:
+        return tuple(cls._creators.values())
+
+    @classmethod
+    def get_args(
+        cls, profile_name: str
+    ) -> Type["profiles.HexrdPPScript_Arguments"]:
         creator = cls._creators.get(profile_name)
         if not creator:
             raise ValueError(format)
         return creator
 
 
-def autoregister(cls):
+def autoregister(
+    cls: Type["profiles.HexrdPPScript_Arguments"],
+) -> Type["profiles.HexrdPPScript_Arguments"]:
     """decorator that registers cls with ArgumentClassesFactory"""
     ArgumentClassesFactory().register(cls)
     return cls

--- a/hexrd/preprocess/preprocessors.py
+++ b/hexrd/preprocess/preprocessors.py
@@ -16,13 +16,7 @@ class PP_Base(object):
         self.omwedges = omw
         self.panel_opts = panel_opts
         self.frame_start = frame_start
-        self.raw = imageseries.open(self.fname, format=self.RAWFMT)
-        self.use_frame_list = self.nframes != len(self.raw)
         self.style = style
-        print(
-            f"On Init:\n\t{self.fname}, {self.nframes} frames,"
-            f"{self.omwedges.nframes} omw, {len(self.raw)} total"
-        )
 
     @property
     def oplist(self):
@@ -83,6 +77,12 @@ class PP_Eiger(PP_Base):
             frame_start=frame_start,
             style=style,
         )
+        self.raw = imageseries.open(self.fname, format=self.RAWFMT)
+        self.use_frame_list = self.nframes != len(self.raw)
+        print(
+            f"On Init:\n\t{self.fname}, {self.nframes} frames,"
+            f"{self.omwedges.nframes} omw, {len(self.raw)} total"
+        )
 
 
 class PP_Dexela(PP_Base):
@@ -114,6 +114,7 @@ class PP_Dexela(PP_Base):
         )
 
         self._panel_id = panel_id
+        # TODO is this logic applicable also for Eiger ?
         if raw_format.lower() == "hdf5":
             self.raw = imageseries.open(
                 self.fname, self.RAWFMT, path=self.RAWPATH
@@ -125,6 +126,10 @@ class PP_Dexela(PP_Base):
         self.use_frame_list = self.nframes != len(
             self.raw
         )  # Framelist fix, DCP 6/18/18
+        print(
+            f"On Init:\n\t{self.fname}, {self.nframes} frames,"
+            f"{self.omwedges.nframes} omw, {len(self.raw)} total"
+        )
 
     def _attach_metadata(self, metadata):
         super()._attach_metadata(metadata)
@@ -173,15 +178,7 @@ def preprocess(args):
         )
         pp.save_processed(args.output, args.threshold)
     elif type(args) == Dexelas_Arguments:
-        pp = PP_Dexela(
-            fname=args.file_name,
-            omw=omw,
-            panel_opts=args.panel_opts,
-            frame_start=args.start_frame,
-            style=args.style,
-        )
-
-        for file_name in pp.file_name:
+        for file_name in args.file_names:
             for key in args.panel_keys:
                 if key.lower() in file_name:
                     pp = PP_Dexela(

--- a/hexrd/preprocess/preprocessors.py
+++ b/hexrd/preprocess/preprocessors.py
@@ -1,0 +1,205 @@
+from hexrd.preprocess.profiles import Eiger_Arguments, Dexelas_Arguments
+from hexrd import imageseries
+from hexrd.imageseries.process import ProcessedImageSeries
+import os
+import time
+
+
+class PP_Base(object):
+    PROCFMT = None
+    RAWFMT = None
+
+    def __init__(
+        self, fname, omw, panel_opts, frame_start=0, style="npz", **kwargs
+    ):
+        self.fname = fname
+        self.omwedges = omw
+        self.panel_opts = panel_opts
+        self.frame_start = frame_start
+        self.raw = imageseries.open(self.fname, format=self.RAWFMT)
+        self.use_frame_list = self.nframes != len(self.raw)
+        self.style = style
+        print(
+            f"On Init:\n\t{self.fname}, {self.nframes} frames,"
+            f"{self.omwedges.nframes} omw, {len(self.raw)} total"
+        )
+
+    @property
+    def oplist(self):
+        return self.panel_opts
+
+    @property
+    def framelist(self):
+        return range(self.frame_start, self.nframes + self.frame_start)
+
+    @property
+    def nframes(self):
+        return self.omwedges.nframes
+
+    @property
+    def omegas(self):
+        return self.omwedges.omegas
+
+    def processed(self):
+        kw = {}
+        if self.use_frame_list:
+            kw = dict(frame_list=self.framelist)
+        return ProcessedImageSeries(self.raw, self.oplist, **kw)
+
+    def _attach_metadata(self, metadata):
+        metadata["omega"] = self.omegas
+
+    def save_processed(self, name, threshold, output_dir=None):
+        if output_dir is None:
+            output_dir = os.getcwd()
+        else:
+            os.mkdir(output_dir)
+
+        # add omegas
+        pims = self.processed()
+        self._attach_metadata(pims.metadata)
+        cache = f"{name}-cachefile." + f"{self.style}"
+        imageseries.write(
+            pims,
+            "dummy",
+            self.PROCFMT,
+            style=self.style,
+            threshold=threshold,
+            cache_file=cache,
+        )
+
+
+class PP_Eiger(PP_Base):
+    """PP_Eiger"""
+
+    PROCFMT = "frame-cache"
+    RAWFMT = "eiger-stream-v1"
+
+    def __init__(self, fname, omw, panel_opts, frame_start=0, style="npz"):
+        super().__init__(
+            fname=fname,
+            omw=omw,
+            panel_opts=panel_opts,
+            frame_start=frame_start,
+            style=style,
+        )
+
+
+class PP_Dexela(PP_Base):
+    """PP_Dexela"""
+
+    PROCFMT = "frame-cache"
+    RAWFMT = "hdf5"
+
+    RAWPATH = "/imageseries"
+    DARKPCTILE = 50
+
+    def __init__(
+        self,
+        fname,
+        omw,
+        panel_opts,
+        panel_id,
+        frame_start=0,
+        style="npz",
+        raw_format="hdf5",
+        dark=None,
+    ):
+        super().__init__(
+            fname=fname,
+            omw=omw,
+            panel_opts=panel_opts,
+            frame_start=frame_start,
+            style=style,
+        )
+
+        self._panel_id = panel_id
+        if raw_format.lower() == "hdf5":
+            self.raw = imageseries.open(
+                self.fname, self.RAWFMT, path=self.RAWPATH
+            )
+        else:
+            self.raw = imageseries.open(self.fname, raw_format.lower())
+        self._dark = dark
+
+        self.use_frame_list = self.nframes != len(
+            self.raw
+        )  # Framelist fix, DCP 6/18/18
+
+    def _attach_metadata(self, metadata):
+        super()._attach_metadata(metadata)
+        metadata["panel_id"] = self.panel_id
+
+    @property
+    def panel_id(self):
+        return self._panel_id
+
+    @property
+    def dark(self, nframes=100):
+        """build and return dark image"""
+        if self._dark is None:
+            usenframes = min(nframes, self.nframes)
+            print(
+                "building dark images using %s frames (may take a while)..."
+                % usenframes
+            )
+            start = time.time()
+            #            self._dark = imageseries.stats.percentile(
+            #                    self.raw, self.DARKPCTILE, nframes=usenframes
+            #            )
+            self._dark = imageseries.stats.median(
+                self.raw, nframes=usenframes
+            )  # changed to median by DCP 11/18/17
+            elapsed = time.time() - start
+            print(
+                "done building background (dark) image: "
+                + "elapsed time is %f seconds" % elapsed
+            )
+
+        return self._dark
+
+
+def preprocess(args):
+    omw = imageseries.omega.OmegaWedges(args.num_frames)
+    omw.addwedge(args.ome_start, args.ome_end, args.num_frames)
+
+    if type(args) == Eiger_Arguments:
+        pp = PP_Eiger(
+            fname=args.file_name,
+            omw=omw,
+            panel_opts=args.panel_opts,
+            frame_start=args.start_frame,
+            style=args.style,
+        )
+        pp.save_processed(args.output, args.threshold)
+    elif type(args) == Dexelas_Arguments:
+        pp = PP_Dexela(
+            fname=args.file_name,
+            omw=omw,
+            panel_opts=args.panel_opts,
+            frame_start=args.start_frame,
+            style=args.style,
+        )
+
+        for file_name in pp.file_name:
+            for key in args.panel_keys:
+                if key.lower() in file_name:
+                    pp = PP_Dexela(
+                        fname=args.file_name,
+                        omw=omw,
+                        panel_opts=args.panel_opts[key],
+                        panel_id=key,
+                        frame_start=args.start_frame,
+                        style=args.style,
+                    )
+
+                    output_name = (
+                        args.samp_name
+                        + "_"
+                        + str(args.scan_number)
+                        + "_"
+                        + file_name.split("/")[-1].split(".")[0]
+                    )
+                    pp.save_processed(output_name, args.threshold)
+    else:
+        raise AttributeError(f"Unknown argument type: {type(args)}")

--- a/hexrd/preprocess/profiles.py
+++ b/hexrd/preprocess/profiles.py
@@ -142,7 +142,6 @@ class Eiger_Arguments(Chess_Arguments):
 
     short_switches = {
         **Chess_Arguments.short_switches,
-        "absolute_path": "ap",
     }
 
     def validate_arguments(self) -> None:

--- a/hexrd/preprocess/profiles.py
+++ b/hexrd/preprocess/profiles.py
@@ -124,23 +124,10 @@ class Eiger_Arguments(HexrdPPScript_Arguments):
 
     @property
     def file_name(self) -> str:
-        if self.absolute_path:
-            file_name = os.path.abspath(self.absolute_path)
-        else:
-            file_name = glob.glob(
-                os.path.join(
-                    self.base_dir,
-                    self.expt_name,
-                    self.samp_name,
-                    str(self.scan_number),
-                    "ff",
-                    "*.h5",
-                )
-            )
-            if len(file_name) == 0:
-                raise RuntimeError(f"No files matching found!")
+        return self.absolute_path
 
-        return file_name
+
+
 
 
 @dataclass
@@ -163,3 +150,16 @@ class Dexelas_Arguments(Eiger_Arguments):
     num_frames: int = 1441
     start_frame: int = 4  # usually 4 for normal CHESS stuff
     threshold: int = 50
+    @property
+    def file_names(self) -> list[str]:
+        names = glob.glob(
+            os.path.join(
+                self.data_dir,
+                self.expt_name,
+                self.samp_name,
+                str(self.scan_number),
+                'ff',
+                '*.h5',
+            )
+        )
+        return names

--- a/hexrd/preprocess/profiles.py
+++ b/hexrd/preprocess/profiles.py
@@ -138,10 +138,11 @@ class Eiger_Arguments(HexrdPPScript_Arguments):
                     "*.h5",
                 )
             )
-        if not os.path.exists(file_name):
-            raise RuntimeError(f"File {file_name} does not exist!")
+            if len(file_name) == 0:
+                raise RuntimeError(f"No files matching found!")
 
         return file_name
+
 
 @dataclass
 @autoregister
@@ -149,14 +150,14 @@ class Dexelas_Arguments(Eiger_Arguments):
     yaml_tag = "!Dexelas_Arguments"
     profile_name = "dexelas"
     # !!!: hard coded options for each dexela for April 2017
-    panel_opts: dict[str, any] = field(
+    panel_opts: dict[str, list[list[Union[str, int]]]] = field(
         default_factory=lambda: {
             "FF1": [
-                ("add-row", 1944),
-                ("add-column", 1296),
-                ("flip", "v"),
+                ["add-row", 1944],
+                ["add-column", 1296],
+                ["flip", "v"],
             ],
-            "FF2": [("add-row", 1944), ("add-column", 1296), ("flip", "h")],
+            "FF2": [["add-row", 1944], ["add-column", 1296], ["flip", "h"]],
         }
     )
 

--- a/hexrd/preprocess/profiles.py
+++ b/hexrd/preprocess/profiles.py
@@ -1,0 +1,58 @@
+import yaml
+from hexrd.preprocess.argument_classes_factory import ArgumentClassesFactory
+from hexrd.preprocess.yaml_internals import HexrdScriptArgumentsDumper, HexrdScriptArgumentsSafeLoader
+
+
+# Classes holding script arguments and their defaults based on the detector.
+# Each subclass can overwrite defaults or add more options
+
+
+# To add a new Argument class :
+# 1. Derive from HexrdScript_Arguments or one of its children.
+# 2. Add @autoregister decorator to the new class
+# 3. Make sure the class has a unique "yaml_tag" and "profile_name".
+# yaml_tag will be used in the configuration file and profile_name is
+# how we refer to the argument class in the cli.
+
+class HexrdScript_Arguments(yaml.YAMLObject):
+    # yaml tag to help deserialiser pick the right type write It is used in the
+    # YAML file to indicate the class that should be created when reading a
+    # file.  Override this when deriving new classes.
+    yaml_tag = "!HexrdScript_Arguments"
+    # "profile_name" is the name to use in the command line
+    # when referring to these class.
+    # Override this when deriving new classes.
+    profile_name = "none"
+
+    # Allow this and derived class to be read using yaml.safe_load
+    yaml_loader = yaml.SafeLoader
+
+    @classmethod
+    def known_formats(_):
+        """Get all know argument formats registered so far"""
+        return list(ArgumentClassesFactory().get_registered())
+
+    def dump_config(self) -> str:
+        """Create a yaml string representation of the values hold in this dataclass"""
+        return yaml.dump(self, Dumper=HexrdScriptArgumentsDumper)
+
+    @classmethod
+    def create_default_config(_, name) -> str:
+        """Create argument class of type name using kwargs to set the
+        dataclass values"""
+        return ArgumentClassesFactory().get_args(name)().dump_config()
+
+    @classmethod
+    def create_args(_, name, **kwargs):
+        """Create argument class of type name using kwargs to set the
+        dataclass values"""
+        return ArgumentClassesFactory().get_args(name)(**kwargs)
+
+    @classmethod
+    def load_from_config(cls, buffer: str):
+        """Create an HexrdScript_Arguments instance from yaml string"""
+        try:
+            args = yaml.load(buffer, Loader=HexrdScriptArgumentsSafeLoader)
+        except:
+            raise RuntimeError("Could not read config from buffer")
+        return args

--- a/hexrd/preprocess/profiles.py
+++ b/hexrd/preprocess/profiles.py
@@ -8,7 +8,6 @@ from hexrd.preprocess.argument_classes_factory import (
 )
 from hexrd.preprocess.yaml_internals import (
     HexrdPPScriptArgumentsDumper,
-    HexrdPPScriptArgumentsSafeLoader,
 )
 from typing import Union
 
@@ -64,7 +63,7 @@ class HexrdPPScript_Arguments(yaml.YAMLObject):
     def load_from_config(cls, buffer: str):
         """Create an HexrdPPScript_Arguments instance from yaml string"""
         try:
-            args = yaml.load(buffer, Loader=HexrdPPScriptArgumentsSafeLoader)
+            args = yaml.safe_load(buffer)
         except Exception as e:
             raise RuntimeError(f"Could not read config from buffer: {e}")
         return args

--- a/hexrd/preprocess/profiles.py
+++ b/hexrd/preprocess/profiles.py
@@ -1,6 +1,16 @@
+from dataclasses import dataclass, field
+import glob
+import os
 import yaml
-from hexrd.preprocess.argument_classes_factory import ArgumentClassesFactory
-from hexrd.preprocess.yaml_internals import HexrdScriptArgumentsDumper, HexrdScriptArgumentsSafeLoader
+from hexrd.preprocess.argument_classes_factory import (
+    ArgumentClassesFactory,
+    autoregister,
+)
+from hexrd.preprocess.yaml_internals import (
+    HexrdPPScriptArgumentsDumper,
+    HexrdPPScriptArgumentsSafeLoader,
+)
+from typing import Union
 
 
 # Classes holding script arguments and their defaults based on the detector.
@@ -8,17 +18,18 @@ from hexrd.preprocess.yaml_internals import HexrdScriptArgumentsDumper, HexrdScr
 
 
 # To add a new Argument class :
-# 1. Derive from HexrdScript_Arguments or one of its children.
+# 1. Derive from HexrdPPScript_Arguments or one of its children.
 # 2. Add @autoregister decorator to the new class
 # 3. Make sure the class has a unique "yaml_tag" and "profile_name".
 # yaml_tag will be used in the configuration file and profile_name is
 # how we refer to the argument class in the cli.
 
-class HexrdScript_Arguments(yaml.YAMLObject):
+
+class HexrdPPScript_Arguments(yaml.YAMLObject):
     # yaml tag to help deserialiser pick the right type write It is used in the
     # YAML file to indicate the class that should be created when reading a
     # file.  Override this when deriving new classes.
-    yaml_tag = "!HexrdScript_Arguments"
+    yaml_tag = "!HexrdPPScript_Arguments"
     # "profile_name" is the name to use in the command line
     # when referring to these class.
     # Override this when deriving new classes.
@@ -33,8 +44,9 @@ class HexrdScript_Arguments(yaml.YAMLObject):
         return list(ArgumentClassesFactory().get_registered())
 
     def dump_config(self) -> str:
-        """Create a yaml string representation of the values hold in this dataclass"""
-        return yaml.dump(self, Dumper=HexrdScriptArgumentsDumper)
+        """Create a yaml string representation of the values hold in this
+        dataclass"""
+        return yaml.dump(self, Dumper=HexrdPPScriptArgumentsDumper)
 
     @classmethod
     def create_default_config(_, name) -> str:
@@ -50,9 +62,104 @@ class HexrdScript_Arguments(yaml.YAMLObject):
 
     @classmethod
     def load_from_config(cls, buffer: str):
-        """Create an HexrdScript_Arguments instance from yaml string"""
+        """Create an HexrdPPScript_Arguments instance from yaml string"""
         try:
-            args = yaml.load(buffer, Loader=HexrdScriptArgumentsSafeLoader)
-        except:
-            raise RuntimeError("Could not read config from buffer")
+            args = yaml.load(buffer, Loader=HexrdPPScriptArgumentsSafeLoader)
+        except Exception as e:
+            raise RuntimeError(f"Could not read config from buffer: {e}")
         return args
+
+
+@dataclass
+@autoregister
+class Eiger_Arguments(HexrdPPScript_Arguments):
+    yaml_tag = "!Eiger_Arguments"
+    profile_name = "eiger"
+    # fields
+    base_dir: str = None
+    expt_name: str = None
+    samp_name: str = None
+    scan_number: int = None
+    num_frames: int = 1440
+    start_frame: int = 0
+    threshold: int = 5
+    ome_start: float = 0.0
+    ome_end: float = 360.0
+    absolute_path: str = None
+    panel_opts: dict[str, any] = field(default_factory=dict)
+    style: str = "npz"
+    output: str = "test"
+
+    # class helpers
+    # we gather all argument messages here to allow for automated help
+    # generation but also easier derivation of new dataclass arguments
+    # through inheritance
+    help_messages = {
+        "base_dir": "raw data path on chess daq",
+        "expt_name": "experiment name",
+        "samp_name": "sample name",
+        "scan_number": "ff scan number",
+        "num_frames": "number of frames to read",
+        "start_frame": "index of first data frame",
+        "threshold": "threshold for frame caches",
+        "ome_start": "start omega",
+        "ome_end": "end omega",
+        "absolute_path": "absolute path to image file",
+        "panel_opts": "detector-specific options",
+        "style": "format for saving framecache",
+        "output": "output filename",
+    }
+
+    short_switches = {
+        "num_frames": "n",
+        "start_frame": "s",
+        "threshold": "t",
+        "ome_start": "o",
+        "ome_end": "e",
+        "absolute_path": "ap",
+    }
+
+    @property
+    def ostep(self) -> float:
+        return (self.ome_end - self.ome_start) / float(self.num_frames)
+
+    @property
+    def file_name(self) -> str:
+        if self.absolute_path:
+            file_name = os.path.abspath(self.absolute_path)
+        else:
+            file_name = glob.glob(
+                os.path.join(
+                    self.base_dir,
+                    self.expt_name,
+                    self.samp_name,
+                    str(self.scan_number),
+                    "ff",
+                    "*.h5",
+                )
+            )
+        if not os.path.exists(file_name):
+            raise RuntimeError(f"File {file_name} does not exist!")
+
+        return file_name
+
+@dataclass
+@autoregister
+class Dexelas_Arguments(Eiger_Arguments):
+    yaml_tag = "!Dexelas_Arguments"
+    profile_name = "dexelas"
+    # !!!: hard coded options for each dexela for April 2017
+    panel_opts: dict[str, any] = field(
+        default_factory=lambda: {
+            "FF1": [
+                ("add-row", 1944),
+                ("add-column", 1296),
+                ("flip", "v"),
+            ],
+            "FF2": [("add-row", 1944), ("add-column", 1296), ("flip", "h")],
+        }
+    )
+
+    num_frames: int = 1441
+    start_frame: int = 4  # usually 4 for normal CHESS stuff
+    threshold: int = 50

--- a/hexrd/preprocess/yaml_internals.py
+++ b/hexrd/preprocess/yaml_internals.py
@@ -28,4 +28,5 @@ class HexrdPPScriptArgumentsDumper(yaml.Dumper):
     # first instance.
     def _ignore(*args):
         return True
+
     ignore_aliases = _ignore

--- a/hexrd/preprocess/yaml_internals.py
+++ b/hexrd/preprocess/yaml_internals.py
@@ -4,8 +4,9 @@ import yaml
 # ArgumentsClasses and can handle python tuples.
 
 
-# custom loader that can deserialize python tuples tagged as such while using safeloader
-class HexrdScriptArgumentsSafeLoader(yaml.SafeLoader):
+# custom loader that can deserialize python tuples tagged as such while using
+# safeloader
+class HexrdPPScriptArgumentsSafeLoader(yaml.SafeLoader):
     def __init__(self, args, **kwargs):
         super().__init__(args, **kwargs)
 
@@ -13,16 +14,18 @@ class HexrdScriptArgumentsSafeLoader(yaml.SafeLoader):
             return tuple(self.construct_sequence(node))
 
         tag = "tag:yaml.org,2002:python/tuple"
-        if tag not in HexrdScriptArgumentsSafeLoader.yaml_constructors:
-            HexrdScriptArgumentsSafeLoader.add_constructor(
+        if tag not in HexrdPPScriptArgumentsSafeLoader.yaml_constructors:
+            HexrdPPScriptArgumentsSafeLoader.add_constructor(
                 "tag:yaml.org,2002:python/tuple",
                 construct_python_tuple,
             )
 
 
-class HexrdScriptArgumentsDumper(yaml.Dumper):
+class HexrdPPScriptArgumentsDumper(yaml.Dumper):
     # skip aliases, this makes sure that no references are used when using
     # immutable objects. i.e. referring to the same tuple twice it will just
-    # serialize the tuple twice instead of once and using references to the first
-    # instance.
-    ignore_aliases = lambda *args: True
+    # serialize the tuple twice instead of once and using references to the
+    # first instance.
+    def _ignore(*args):
+        return True
+    ignore_aliases = _ignore

--- a/hexrd/preprocess/yaml_internals.py
+++ b/hexrd/preprocess/yaml_internals.py
@@ -1,11 +1,13 @@
+from typing import Any
 import yaml
+
 
 class HexrdPPScriptArgumentsDumper(yaml.Dumper):
     # skip aliases, this makes sure that no references are used when using
     # immutable objects. i.e. referring to the same tuple twice it will just
     # serialize the tuple twice instead of once and using references to the
     # first instance.
-    def _ignore(*args):
+    def _ignore(self, data: Any) -> bool:
         return True
 
     ignore_aliases = _ignore

--- a/hexrd/preprocess/yaml_internals.py
+++ b/hexrd/preprocess/yaml_internals.py
@@ -1,0 +1,28 @@
+import yaml
+
+# Create custom yaml loader and  dumper that know about all types in
+# ArgumentsClasses and can handle python tuples.
+
+
+# custom loader that can deserialize python tuples tagged as such while using safeloader
+class HexrdScriptArgumentsSafeLoader(yaml.SafeLoader):
+    def __init__(self, args, **kwargs):
+        super().__init__(args, **kwargs)
+
+        def construct_python_tuple(self, node):
+            return tuple(self.construct_sequence(node))
+
+        tag = "tag:yaml.org,2002:python/tuple"
+        if tag not in HexrdScriptArgumentsSafeLoader.yaml_constructors:
+            HexrdScriptArgumentsSafeLoader.add_constructor(
+                "tag:yaml.org,2002:python/tuple",
+                construct_python_tuple,
+            )
+
+
+class HexrdScriptArgumentsDumper(yaml.Dumper):
+    # skip aliases, this makes sure that no references are used when using
+    # immutable objects. i.e. referring to the same tuple twice it will just
+    # serialize the tuple twice instead of once and using references to the first
+    # instance.
+    ignore_aliases = lambda *args: True

--- a/hexrd/preprocess/yaml_internals.py
+++ b/hexrd/preprocess/yaml_internals.py
@@ -1,26 +1,5 @@
 import yaml
 
-# Create custom yaml loader and  dumper that know about all types in
-# ArgumentsClasses and can handle python tuples.
-
-
-# custom loader that can deserialize python tuples tagged as such while using
-# safeloader
-class HexrdPPScriptArgumentsSafeLoader(yaml.SafeLoader):
-    def __init__(self, args, **kwargs):
-        super().__init__(args, **kwargs)
-
-        def construct_python_tuple(self, node):
-            return tuple(self.construct_sequence(node))
-
-        tag = "tag:yaml.org,2002:python/tuple"
-        if tag not in HexrdPPScriptArgumentsSafeLoader.yaml_constructors:
-            HexrdPPScriptArgumentsSafeLoader.add_constructor(
-                "tag:yaml.org,2002:python/tuple",
-                construct_python_tuple,
-            )
-
-
 class HexrdPPScriptArgumentsDumper(yaml.Dumper):
     # skip aliases, this makes sure that no references are used when using
     # immutable objects. i.e. referring to the same tuple twice it will just

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -34,7 +34,7 @@ def test_save_load_dexelas():
     eargs = Dexelas_Arguments()
     eargs.base_dir = "/data"
     eargs.num_frames = 1
-    eargs.panel_opts["FF1"] = {("add-row", 1000)}
+    eargs.panel_opts["FF1"] = [["add-row", 1000]]
     buffer = eargs.dump_config()
     args = HexrdPPScript_Arguments.load_from_config(buffer)
     assert eargs == args

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,40 @@
+from hexrd.preprocess.profiles import (
+    Eiger_Arguments,
+    Dexelas_Arguments,
+    HexrdPPScript_Arguments,
+)
+
+
+# test load/safe with defaults
+def test_save_load_defaults_eiger():
+    eargs = Eiger_Arguments()
+    buffer = eargs.dump_config()
+    args = HexrdPPScript_Arguments.load_from_config(buffer)
+    assert eargs == args
+
+
+def test_save_load_defaults_dexelas():
+    eargs = Dexelas_Arguments()
+    buffer = eargs.dump_config()
+    args = HexrdPPScript_Arguments.load_from_config(buffer)
+    assert eargs == args
+
+
+# test load/safe with modified parameters
+def test_save_load_eiger():
+    eargs = Eiger_Arguments()
+    eargs.base_dir = "/data"
+    eargs.num_frames = 1
+    buffer = eargs.dump_config()
+    args = HexrdPPScript_Arguments.load_from_config(buffer)
+    assert eargs == args
+
+
+def test_save_load_dexelas():
+    eargs = Dexelas_Arguments()
+    eargs.base_dir = "/data"
+    eargs.num_frames = 1
+    eargs.panel_opts["FF1"] = {("add-row", 1000)}
+    buffer = eargs.dump_config()
+    args = HexrdPPScript_Arguments.load_from_config(buffer)
+    assert eargs == args

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -3,6 +3,21 @@ from hexrd.preprocess.profiles import (
     Dexelas_Arguments,
     HexrdPPScript_Arguments,
 )
+import pytest
+from pathlib import Path
+
+
+# FIXME: this is not the appropriate file to test the preprocess scrips since
+# it is missing metadata. Until we add a file we just test that
+# validate_arguments() works as expected
+@pytest.fixture
+def eiger_examples_path(example_repo_path: Path) -> Path:
+    return Path(example_repo_path) / 'eiger'
+
+
+@pytest.fixture
+def ceria_examples_path(eiger_examples_path: Path) -> Path:
+    return eiger_examples_path / 'first_ceria' / 'ff_000_data_000001.h5'
 
 
 # test load/safe with defaults
@@ -21,13 +36,17 @@ def test_save_load_defaults_dexelas():
 
 
 # test load/safe with modified parameters
-def test_save_load_eiger():
+def test_save_load_eiger(ceria_examples_path):
     eargs = Eiger_Arguments()
-    eargs.base_dir = "/data"
-    eargs.num_frames = 1
     buffer = eargs.dump_config()
     args = HexrdPPScript_Arguments.load_from_config(buffer)
     assert eargs == args
+    with pytest.raises(
+        RuntimeError
+    ):  # required argument 'absolute_path' is missing
+        args.validate_arguments()
+    args.absolute_path = str(ceria_examples_path)
+    args.validate_arguments()
 
 
 def test_save_load_dexelas():
@@ -38,3 +57,5 @@ def test_save_load_dexelas():
     buffer = eargs.dump_config()
     args = HexrdPPScript_Arguments.load_from_config(buffer)
     assert eargs == args
+    with pytest.raises(RuntimeError):  # many required arguments are missing
+        args.validate_arguments()


### PR DESCRIPTION
This MR integrates the preprocessor scripts into the main `hexrd` executable via anew subcommand.
Usage:
```
hexrd preprocess <profile>
```
for now we have two profiles `{eiger,dexelas}`.  Each profile comes with its own flags. 

Adding a new profile boils down to creating a new class derived from `PP_Base` that holds the logic of the preprocessor see `hexrd/preprocess/preprocessors.py` and creating a new profile that holds the cli flags which be done by deriving from `HexrdPPScript_Arguments`  see  `hexrd/preprocess/profiles.py`. The new profile will then become available as an option in `hexrd preprocess`. 