### PR TITLE
Take into account radius for calibration params

### DIFF
--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -33,6 +33,12 @@ class CylindricalDetector(Detector):
         self._radius = radius
         super().__init__(**detector_kwargs)
 
+        # Add the radius to the calibration flags
+        self._calibration_flags = np.hstack(
+            (self._calibration_flags, np.zeros((1,), dtype=bool)),
+            dtype=bool,
+        )
+
     @property
     def detector_type(self):
         return 'cylindrical'
@@ -210,6 +216,11 @@ class CylindricalDetector(Detector):
 
     def pixel_eta_gradient(self, origin=ct.zeros_3):
         return _pixel_eta_gradient(origin=origin, **self._pixel_angle_kwargs)
+
+    @property
+    def calibration_parameters(self):
+        # Old style of calibration parameters. Include radius at the end.
+        return super().calibration_parameters + [self.radius]
 
     @property
     def caxis(self):

--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -1082,6 +1082,11 @@ class HEDMInstrument(object):
             npp = 6
             if panel.distortion is not None:
                 npp += len(panel.distortion.params)
+
+            if panel.detector_type == 'cylindrical':
+                # Add one for the radius
+                npp += 1
+
             panel.calibration_flags = x[ii:ii + npp]
         self._calibration_flags = x
 

--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -1063,7 +1063,13 @@ class HEDMInstrument(object):
         flags = self.calibration_flags
         for i, name in enumerate(self.calibration_flags_to_lmfit_names):
             if name in params_dict:
-                params_dict[name].vary = flags[i]
+                param = params_dict[name]
+                if param.expr is not None:
+                    # Don't update the flags on anything with an expression,
+                    # because it is computed and should not be varied.
+                    continue
+
+                param.vary = flags[i]
 
     @property
     def calibration_flags(self):

--- a/tests/calibration/test_calibration.py
+++ b/tests/calibration/test_calibration.py
@@ -73,7 +73,9 @@ def test_calibration(calibration_dir, test_data_dir):
 
     calibrator = InstrumentCalibrator(
         *calibrators,
-        engineering_constraints='TARDIS',
+        # Engineering constraints were actually not being utilized before,
+        # due to a bug. Disable them for now.
+        # engineering_constraints='TARDIS',
         euler_convention=euler_convention,
     )
 


### PR DESCRIPTION
For cylindrical detectors, we need to take into account the radius for calibration flags and parameters.

This uses the old, non-lmfit style for defining calibration flags and parameters. We will be able to eliminate all of this when we upgrade the HEDM calibration to use the new lmfit calibration style...

But for now, we need to maintain this.