### PR TITLE
ci: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -105,7 +105,7 @@ jobs:
       run: echo "HEXRD_GIT_DESCRIBE=$(git describe --tag)" >> $GITHUB_ENV
 
     - name: Upload the package to github
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HEXRD-${{ matrix.config.name }}-${{ env.HEXRD_GIT_DESCRIBE }}.tar.bz2
         path: output/**/*.tar.bz2


### PR DESCRIPTION
Fixes current CI error
```
Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

For more see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions