### PR TITLE
ci: force tar.bz2 packages

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -32,6 +32,8 @@ ${HOME}/miniconda3/bin/conda activate hexrd
 # Install the libmamba solver (it is much faster)
 ${HOME}/miniconda3/bin/conda install -n base -c conda-forge conda-libmamba-solver
 ${HOME}/miniconda3/bin/conda config --set solver libmamba
+${HOME}/miniconda3/bin/conda config --set conda_build.pkg_format 1 # force tar.bz2 files
+
 
 # Remove anaconda telemetry (it is causing errors for us)
 ${HOME}/miniconda3/bin/conda remove -n base conda-anaconda-telemetry

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,6 +65,7 @@ jobs:
           # and sometimes in the base environment. I don't know why.
           conda install --override-channels -c conda-forge conda-libmamba-solver
           conda config --env --set solver libmamba
+          conda config --set conda_build.pkg_format 1 # force tar.bz2 files
           conda list
 
           mkdir output


### PR DESCRIPTION
conda_build >= 25.1.0 use .conda files by default
See https://docs.conda.io/projects/conda-build/en/latest/release-notes.html#enhancements


Alternatively we can adapt the rest of the step to expect `.conda` packages.