### PR TITLE
Return numpy dtype from eiger-stream-v1

### DIFF
--- a/hexrd/imageseries/load/eiger_stream_v1.py
+++ b/hexrd/imageseries/load/eiger_stream_v1.py
@@ -116,7 +116,7 @@ class EigerStreamV1ImageSeriesAdapter(ImageSeriesAdapter):
 
     @property
     def dtype(self):
-        return self._first_data_entry['dtype'][()]
+        return np.dtype(self._first_data_entry['dtype'][()])
 
     @property
     def shape(self):


### PR DESCRIPTION
All of the other imageseries adapters return a numpy dtype. Here, we were just returning a string representing a dtype. However, we should return a numpy dtype to be consistent with all of the other imageseries adapters as well.

This also fixes issues in other places in the code where it is assumed that a numpy dtype is returned from the imageseries.

Fixes: hexrd/hexrdgui#1780