### PR TITLE
Use ConfigParser instead of deprecated SafeConfigParser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: [3.11]
         config:

--- a/hexrd/material/material.py
+++ b/hexrd/material/material.py
@@ -31,7 +31,7 @@ Module for XRD material class
 Use the Material class directly for new materials.  Known
 materials are defined by name in materialDict.
 """
-from configparser import SafeConfigParser as Parser
+from configparser import ConfigParser as Parser
 import numpy as np
 
 from hexrd.material.crystallography import PlaneData as PData


### PR DESCRIPTION
Resolves issue #769. `SafeConfigParser` is removed in Python 3.12.

See source code here: https://github.com/python/cpython/blob/v3.11.1/Lib/configparser.py#L1242-L1252

Fixes: #769