### PR TITLE
some fixes for simulating powder diffraction pattern on an instrument.

### DIFF
--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -517,8 +517,11 @@ def max_resolution(instr):
                 axis=0
             ).reshape(2, np.cumprod(panel.shape)[-1]).T
         )
-        max_tth = min(max_tth, np.min(angps[:, 0]))
-        max_eta = min(max_eta, np.min(angps[:, 1]))
+        mask = ~np.logical_or(
+            np.isclose(angps[:,0], 0),
+            np.isclose(angps[:,1], 0))
+        max_tth = min(max_tth, np.min(angps[mask, 0]))
+        max_eta = min(max_eta, np.min(angps[mask, 1]))
     return max_tth, max_eta
 
 

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -344,6 +344,7 @@ class LeBail:
                 self.dsp[p][k] = dsp[limit]
                 if sf_f is not None and lfact_sf is not None:
                     sf_f = sf_f[allowed]
+                    lfact_sf = lfact_sf[allowed]
                     self.sf_hkl_factors[p][k] = sf_f[limit]
                     self.sf_lfactor[p][k] = lfact_sf[limit]
 


### PR DESCRIPTION
Spotted two errors:

1. the size of stacking fault shifts and stacking fault broadening not the same
2. the angularpixelsize has a zeros which was taken as the angular resolution. masking out zeros in those values.