### PR TITLE
Compton scattering

### DIFF
--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -321,6 +321,7 @@ cPermit = 8.8541878163E-12  # permittivity of free space
 cPlanck = 6.62607015E-34  # same as h above but name is more descriptive
 cRestmass = 9.1093837090E-31  # rest mass of electron
 cClassicalelectronRad = 2.8179403e-6  # classical electron radius in nm
+cRestmasskeV = 510.99895069 # rest mass of electron in keV
 
 '''
 adding another parametrization of the

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -734,7 +734,7 @@ class Detector:
         T = self.calc_compton_physics_package_transmission(
             energy, rMat_s, physics_package)
 
-        return Inc*T
+        return Inc*T, T
 
     def polarization_factor(self, f_hor, f_vert, unpolarized=False):
         """

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -605,7 +605,9 @@ class Detector:
     # METHODS
     # =========================================================================
 
-    def pixel_Q(self, energy, origin=ct.zeros_3):
+    def pixel_Q(self,
+                energy,
+                origin=ct.zeros_3):
         '''get the equivalent momentum transfer
         for the angles. energy is keV. Q is in 
         units of A^-1
@@ -613,6 +615,20 @@ class Detector:
         lam = ct.keVToAngstrom(energy)
         tth, _ = self.pixel_angles()
         return 4.*np.pi*np.sin(tth*0.5)/lam
+
+    def pixel_compton_energy_loss(self,
+                                  energy,
+                                  origin=ct.zeros_3):
+        '''inelastic compton scattering leads
+        to energy loss of the incident photons.
+        compute the final energy of the photons
+        for each pixel.
+        incident photon energy in keV
+        '''
+        tth, _ = self.pixel_angles()
+        ang_fact = (1 = np.cos(tth))
+        beta = energy/ct.cRestmasskeV
+        return energy/(1 + beta*ang_fact)
 
     def polarization_factor(self, f_hor, f_vert, unpolarized=False):
         """

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -605,6 +605,15 @@ class Detector:
     # METHODS
     # =========================================================================
 
+    def pixel_Q(self, energy, origin=ct.zeros_3):
+        '''get the equivalent momentum transfer
+        for the angles. energy is keV. Q is in 
+        units of A^-1
+        '''
+        lam = ct.keVToAngstrom(energy)
+        tth, _ = self.pixel_angles()
+        return 4.*np.pi*np.sin(tth*0.5)/lam
+
     def polarization_factor(self, f_hor, f_vert, unpolarized=False):
         """
         Calculated the polarization factor for every pixel.

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -701,8 +701,6 @@ class Detector:
     def compute_compton_scattering_intensity(
         self,
         energy: np.floating,
-        density: np.floating,
-        formula: str,
         rMat_s: np.array,
         physics_package: AbstractPhysicsPackage,
         origin: np.array=ct.zeros_3) -> np.array:
@@ -717,27 +715,33 @@ class Detector:
         -----------
         energy: float
             energy of incident photon
-        density: float
-            density of material in g/cc
-        formula: str
-            chemical formula of the material
+        rMat_s: np.ndarray
+            rotation matrix of sample orientation
+        physics_package: AbstractPhysicsPackage
+            physics package information
         Returns
         -------
         compton_intensity: np.ndarray
             transmission corrected compton scattering
             intensity
         '''
-        Q = self.pixel_Q(energy)
-        Inc = calculate_incoherent_scattering(
-            formula, Q.flatten()).reshape(self.shape)
 
-        T = self.calc_compton_physics_package_transmission(
+        Q = self.pixel_Q(energy)
+        Inc_s = calculate_incoherent_scattering(
+            physics_package.sample_material,
+            Q.flatten()).reshape(self.shape)
+
+        Inc_w = calculate_incoherent_scattering(
+            physics_package.window_material,
+            Q.flatten()).reshape(self.shape)
+
+        T_s = self.calc_compton_physics_package_transmission(
             energy, rMat_s, physics_package)
 
         T_w = self.calc_compton_window_transmission(
             energy, rMat_s, physics_package)
 
-        return Inc*T, T, T_w
+        return Inc_s*T_s+Inc_w*T_w, T_s, T_w
 
     def polarization_factor(self, f_hor, f_vert, unpolarized=False):
         """

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -608,17 +608,16 @@ class Detector:
     # METHODS
     # =========================================================================
 
-    def pixel_Q(self,
-                energy: np.floating,
-                origin=ct.zeros_3):
+    def pixel_Q(self, energy: np.floating,
+                origin: np.ndarray = ct.zeros_3) -> np.ndarray:
         '''get the equivalent momentum transfer
-        for the angles. 
+        for the angles.
 
         Parameters
         ----------
         energy: float
             incident photon energy in keV
-        origin: np.ndarray 
+        origin: np.ndarray
             origin of diffraction volume
 
         Returns
@@ -631,19 +630,21 @@ class Detector:
         tth, _ = self.pixel_angles(origin=origin)
         return 4.*np.pi*np.sin(tth*0.5)/lam
 
-    def pixel_compton_energy_loss(self,
-                                  energy: np.floating,
-                                  origin=ct.zeros_3):
+    def pixel_compton_energy_loss(
+        self,
+        energy: np.floating,
+        origin: np.ndarray = ct.zeros_3,
+    ) -> np.ndarray:
         '''inelastic compton scattering leads
         to energy loss of the incident photons.
         compute the final energy of the photons
         for each pixel.
-        
+
         Parameters
         ----------
         energy: float
             incident photon energy in keV
-        origin: np.ndarray 
+        origin: np.ndarray
             origin of diffraction volume
 
         Returns
@@ -652,19 +653,19 @@ class Detector:
             pixel wise energy of inelastically
             scatterd photons in keV
         '''
-        if isinstance(energy, list):
-            energy = np.array(energy)
-
+        energy = np.asarray(energy)
         tth, _ = self.pixel_angles()
         ang_fact = (1 - np.cos(tth))
         beta = energy/ct.cRestmasskeV
         return energy/(1 + beta*ang_fact)
 
-    def pixel_compton_attenuation_length(self,
-                                         energy,
-                                         density,
-                                         formula,
-                                         origin=ct.zeros_3):
+    def pixel_compton_attenuation_length(
+        self,
+        energy: np.floating,
+        density: np.floating,
+        formula: str,
+        origin: np.ndarray = ct.zeros_3,
+    ) -> np.ndarray:
         '''each pixel intercepts inelastically
         scattered photons of different energy.
         the attenuation length and the transmission
@@ -692,18 +693,19 @@ class Detector:
         pixel_energy = self.pixel_compton_energy_loss(energy)
 
         pixel_attenuation_length = calculate_linear_absorption_length(
-                                        density, 
-                                        formula,
-                                        pixel_energy.flatten())
-        return pixel_attenuation_length.reshape(
-                                        self.shape)
+            density,
+            formula,
+            pixel_energy.flatten(),
+        )
+        return pixel_attenuation_length.reshape(self.shape)
 
     def compute_compton_scattering_intensity(
         self,
         energy: np.floating,
         rMat_s: np.array,
         physics_package: AbstractPhysicsPackage,
-        origin: np.array=ct.zeros_3) -> np.array:
+        origin: np.array = ct.zeros_3,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
 
         ''' compute the theoretical compton scattering
         signal on the detector. this value is corrected
@@ -726,22 +728,22 @@ class Detector:
             intensity
         '''
 
-        Q = self.pixel_Q(energy)
-        Inc_s = calculate_incoherent_scattering(
+        q = self.pixel_Q(energy)
+        inc_s = calculate_incoherent_scattering(
             physics_package.sample_material,
-            Q.flatten()).reshape(self.shape)
+            q.flatten()).reshape(self.shape)
 
-        Inc_w = calculate_incoherent_scattering(
+        inc_w = calculate_incoherent_scattering(
             physics_package.window_material,
-            Q.flatten()).reshape(self.shape)
+            q.flatten()).reshape(self.shape)
 
-        T_s = self.calc_compton_physics_package_transmission(
+        t_s = self.calc_compton_physics_package_transmission(
             energy, rMat_s, physics_package)
 
-        T_w = self.calc_compton_window_transmission(
+        t_w = self.calc_compton_window_transmission(
             energy, rMat_s, physics_package)
 
-        return Inc_s*T_s+Inc_w*T_w, T_s, T_w
+        return inc_s * t_s + inc_w * t_w, t_s, t_w
 
     def polarization_factor(self, f_hor, f_vert, unpolarized=False):
         """
@@ -1863,10 +1865,14 @@ class Detector:
         almost parallel to the sample surface or backscattered, we
         can mask out these values by setting secb to nan
         '''
-        mask = np.logical_or(cosb < 0, 
-                             np.isclose(
-                            cosb, 0.,
-                            atol=5E-2))
+        mask = np.logical_or(
+            cosb < 0,
+            np.isclose(
+                cosb,
+                0.,
+                atol=5E-2,
+            )
+        )
         cosb[mask] = np.nan
         secb = 1./cosb.reshape(self.shape)
 
@@ -1879,10 +1885,12 @@ class Detector:
         return transmission_physics_package
 
     def calc_compton_physics_package_transmission(
-        self, energy: np.floating,
+        self,
+        energy: np.floating,
         rMat_s: np.array,
-        physics_package: AbstractPhysicsPackage) -> np.float64:
-        '''calculate the attenuation of inelastically 
+        physics_package: AbstractPhysicsPackage,
+    ) -> np.ndarray:
+        '''calculate the attenuation of inelastically
         scattered photons. since these photons lose energy,
         the attenuation length is angle dependent ergo a separate
         routine than elastically scattered absorption.
@@ -1902,10 +1910,14 @@ class Detector:
         almost parallel to the sample surface or backscattered, we
         can mask out these values by setting secb to nan
         '''
-        mask = np.logical_or(cosb < 0, 
-                             np.isclose(
-                            cosb, 0.,
-                            atol=5E-2))
+        mask = np.logical_or(
+            cosb < 0,
+            np.isclose(
+                cosb,
+                0.,
+                atol=5E-2,
+            )
+        )
         cosb[mask] = np.nan
         secb = 1./cosb.reshape(self.shape)
 
@@ -1918,13 +1930,15 @@ class Detector:
         return T_sample * T_window
 
     def calc_compton_window_transmission(
-        self, energy: np.floating,
-        rMat_s: np.array,
-        physics_package: AbstractPhysicsPackage) -> np.float64:
-        '''calculate the attenuation of inelastically 
-        scattered photons just fropm the window. 
-        since these photons lose energy, the attenuation length 
-        is angle dependent ergo a separate routine than 
+        self,
+        energy: np.floating,
+        rMat_s: np.ndarray,
+        physics_package: AbstractPhysicsPackage,
+    ) -> np.ndarray:
+        '''calculate the attenuation of inelastically
+        scattered photons just fropm the window.
+        since these photons lose energy, the attenuation length
+        is angle dependent ergo a separate routine than
         elastically scattered absorption.
         '''
         bvec = self.bvec
@@ -1942,21 +1956,24 @@ class Detector:
         almost parallel to the sample surface or backscattered, we
         can mask out these values by setting secb to nan
         '''
-        mask = np.logical_or(cosb < 0, 
-                             np.isclose(
-                            cosb, 0.,
-                            atol=5E-2))
+        mask = np.logical_or(
+            cosb < 0,
+            np.isclose(
+                cosb,
+                0.,
+                atol=5E-2,
+            )
+        )
         cosb[mask] = np.nan
         secb = 1./cosb.reshape(self.shape)
 
         T_window = self.calc_compton_transmission(
             seca, secb, energy,
             physics_package, 'window')
-        T_sample = self.calc_compton_transmission_sample( 
+        T_sample = self.calc_compton_transmission_sample(
             seca, energy, physics_package)
 
         return T_sample * T_window
-
 
     def calc_transmission_sample(self, seca: np.array,
                                  secb: np.array, energy: np.floating,
@@ -1974,62 +1991,73 @@ class Detector:
 
     def calc_transmission_window(self, secb: np.array, energy: np.floating,
                                  physics_package: AbstractPhysicsPackage) -> np.array:
-        thickness_w = physics_package.window_thickness # in microns
-        if np.logical_or(
-            physics_package.window_material is None,
-            np.isclose(thickness_w, 0)):
-                return np.ones(self.shape)
+        material_w = physics_package.window_material
+        thickness_w = physics_package.window_thickness  # in microns
+        if material_w is None or np.isclose(thickness_w, 0):
+            return np.ones(self.shape)
 
         # in microns^-1
         mu_w = 1./physics_package.window_absorption_length(energy)
         return np.exp(-thickness_w*mu_w*secb)
 
-    def calc_compton_transmission(self, seca: np.array,
-            secb: np.array, energy: np.floating,
-            physics_package: AbstractPhysicsPackage,
-            pp_layer: str) -> np.array:
+    def calc_compton_transmission(
+        self,
+        seca: np.ndarray,
+        secb: np.ndarray,
+        energy: np.floating,
+        physics_package: AbstractPhysicsPackage,
+        pp_layer: str,
+    ) -> np.ndarray:
 
         if pp_layer == 'sample':
             formula = physics_package.sample_material
             density = physics_package.sample_density
             thickness = physics_package.sample_thickness
             mu = 1./physics_package.sample_absorption_length(energy)
-            mu_prime = 1./self.pixel_compton_attenuation_length(
-            energy, density, formula)
+            mu_prime = 1. / self.pixel_compton_attenuation_length(
+                energy, density, formula,
+            )
         elif pp_layer == 'window':
             formula = physics_package.window_material
             if formula is None:
                 return np.ones(self.shape)
+
             density = physics_package.window_density
             thickness = physics_package.window_thickness
             mu = 1./physics_package.sample_absorption_length(energy)
             mu_prime = 1./self.pixel_compton_attenuation_length(
                 energy, density, formula)
-        if thickness > 0:
-            x1 = mu*thickness*seca
-            x2 = mu_prime*thickness*secb
-            num = (np.exp(-x1) - np.exp(-x2))
-            return -num/(x1 - x2)
-        else:
+
+        if thickness <= 0:
             return np.ones(self.shape)
 
-    def calc_compton_transmission_sample(self, 
-            seca: np.array, energy: np.floating,
-            physics_package: AbstractPhysicsPackage) -> np.array:
+        x1 = mu*thickness*seca
+        x2 = mu_prime*thickness*secb
+        num = (np.exp(-x1) - np.exp(-x2))
+        return -num/(x1 - x2)
 
+    def calc_compton_transmission_sample(
+        self,
+        seca: np.ndarray,
+        energy: np.floating,
+        physics_package: AbstractPhysicsPackage,
+    ) -> np.ndarray:
         thickness_s = physics_package.sample_thickness  # in microns
 
         mu_s = 1./physics_package.sample_absorption_length(
             energy)
         return np.exp(-mu_s*thickness_s*seca)
 
-    def calc_compton_transmission_window(self, 
-            secb: np.array, energy: np.floating,
-            physics_package: AbstractPhysicsPackage) -> np.array:
-
+    def calc_compton_transmission_window(
+        self,
+        secb: np.ndarray,
+        energy: np.floating,
+        physics_package: AbstractPhysicsPackage,
+    ) -> np.ndarray:
         formula = physics_package.window_material
         if formula is None:
             return np.ones(self.shape)
+
         density = physics_package.window_density        # in g/cc
         thickness_w = physics_package.window_thickness  # in microns
 

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -607,7 +607,7 @@ class Detector:
     # =========================================================================
 
     def pixel_Q(self,
-                energy,
+                energy: np.floating,
                 origin=ct.zeros_3):
         '''get the equivalent momentum transfer
         for the angles. 
@@ -630,7 +630,7 @@ class Detector:
         return 4.*np.pi*np.sin(tth*0.5)/lam
 
     def pixel_compton_energy_loss(self,
-                                  energy,
+                                  energy: np.floating,
                                   origin=ct.zeros_3):
         '''inelastic compton scattering leads
         to energy loss of the incident photons.
@@ -650,6 +650,9 @@ class Detector:
             pixel wise energy of inelastically
             scatterd photons in keV
         '''
+        if isinstance(energy, list):
+            energy = np.array(energy)
+
         tth, _ = self.pixel_angles()
         ang_fact = (1 - np.cos(tth))
         beta = energy/ct.cRestmasskeV
@@ -690,9 +693,8 @@ class Detector:
                                         density, 
                                         formula,
                                         pixel_energy.flatten())
-        pixel_attenuation_length = pixel_attenuation_length.reshape(
+        return pixel_attenuation_length.reshape(
                                         self.shape)
-
 
     def polarization_factor(self, f_hor, f_vert, unpolarized=False):
         """
@@ -1800,7 +1802,7 @@ class Detector:
         need to consider HED and HEDM samples separately
         """
         bvec = self.bvec
-        sample_normal = np.dot(rMat_s, [0., 0., -1.])
+        sample_normal = np.dot(rMat_s, [0., 0., np.sign(bvec[2])])
         seca = 1./np.dot(bvec, sample_normal)
 
         tth, eta = self.pixel_angles()
@@ -1823,10 +1825,49 @@ class Detector:
 
         T_sample = self.calc_transmission_sample(
             seca, secb, energy, physics_package)
-        T_window = self.calc_transmission_window(secb, energy, physics_package)
+        T_window = self.calc_transmission_window(
+            secb, energy, physics_package)
 
         transmission_physics_package = T_sample * T_window
         return transmission_physics_package
+
+    def calc_compton_physics_package_transmission(
+        self, energy: np.floating,
+        rMat_s: np.array,
+        physics_package: AbstractPhysicsPackage) -> np.float64:
+        '''calculate the attenuation of inelastically 
+        scattered photons. since these photons lose energy,
+        the attenuation length is angle dependent ergo a separate
+        routine than elastically scattered absorption.
+        '''
+        bvec = self.bvec
+        sample_normal = np.dot(rMat_s, [0., 0., np.sign(bvec[2])])
+        seca = 1./np.dot(bvec, sample_normal)
+
+        tth, eta = self.pixel_angles()
+        angs = np.vstack((tth.flatten(), eta.flatten(),
+                          np.zeros(tth.flatten().shape))).T
+
+        dvecs = angles_to_dvec(angs, beam_vec=bvec)
+
+        cosb = np.dot(dvecs, sample_normal)
+        '''angles for which secb <= 0 or close are diffracted beams
+        almost parallel to the sample surface or backscattered, we
+        can mask out these values by setting secb to nan
+        '''
+        mask = np.logical_or(cosb < 0, 
+                             np.isclose(
+                            cosb, 0.,
+                            atol=5E-2))
+        cosb[mask] = np.nan
+        secb = 1./cosb.reshape(self.shape)
+
+        T_sample = self.calc_compton_transmission_sample(
+            seca, secb, energy, physics_package)
+        T_window = self.calc_compton_transmission_window(
+            secb, energy, physics_package)
+
+        return T_sample * T_window
 
     def calc_transmission_sample(self, seca: np.array,
                                  secb: np.array, energy: np.floating,
@@ -1851,6 +1892,35 @@ class Detector:
         # in microns^-1
         mu_w = 1./physics_package.window_absorption_length(energy)
         return np.exp(-thickness_w*mu_w*secb)
+
+    def calc_compton_transmission_sample(self, seca: np.array,
+            secb: np.array, energy: np.floating,
+            physics_package: AbstractPhysicsPackage) -> np.array:
+
+        formula = physics_package.sample_material
+        density = physics_package.sample_density
+        thickness_s = physics_package.sample_thickness
+
+        mu_s = 1./physics_package.sample_absorption_length(energy)
+        mu_s_prime = 1./self.pixel_compton_attenuation_length(
+            energy, density, formula)
+
+        x1 = mu_s*thickness_s*seca
+        x2 = mu_s_prime*thickness_s*secb
+        num = (np.exp(-x1) - np.exp(-x2))
+        return -num/(x1 - x2)
+
+    def calc_compton_transmission_window(self, 
+            secb: np.array, energy: np.floating,
+            physics_package: AbstractPhysicsPackage) -> np.array:
+
+        formula = physics_package.window_material
+        density = physics_package.window_density        # in g/cc
+        thickness_w = physics_package.window_thickness  # in microns
+
+        mu_w_prime = 1./self.pixel_compton_attenuation_length(
+            energy, density, formula)
+        return np.exp(-mu_w_prime*thickness_w*secb)
 
     def calc_effective_pinhole_area(self, physics_package: AbstractPhysicsPackage) -> np.array:
         """get the effective pinhole area correction

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -628,7 +628,7 @@ class Detector:
 
         '''
         lam = ct.keVToAngstrom(energy)
-        tth, _ = self.pixel_angles()
+        tth, _ = self.pixel_angles(origin=origin)
         return 4.*np.pi*np.sin(tth*0.5)/lam
 
     def pixel_compton_energy_loss(self,

--- a/hexrd/material/utils.py
+++ b/hexrd/material/utils.py
@@ -235,6 +235,11 @@ def calculate_incoherent_scattering_factor(element, Q):
 
 def calculate_f_squared_mean(composition, Q):
 
+    if composition is None:
+        return np.zeros_like(Q)
+    elif isinstance(composition, dict):
+        if 'None' in composition.keys():
+            return np.zeros_like(Q)
     formula = interpret_formula(composition)
     norm_elemental_abundances = normalize_composition(
         formula)
@@ -246,6 +251,11 @@ def calculate_f_squared_mean(composition, Q):
 
 def calculate_f_mean_squared(composition, Q):
 
+    if composition is None:
+        return np.zeros_like(Q)
+    elif isinstance(composition, dict):
+        if 'None' in composition.keys():
+            return np.zeros_like(Q)
     formula = interpret_formula(composition)
     norm_elemental_abundances = normalize_composition(
         formula)
@@ -257,6 +267,11 @@ def calculate_f_mean_squared(composition, Q):
 
 def calculate_incoherent_scattering(composition, Q):
 
+    if composition is None:
+        return np.zeros_like(Q)
+    elif isinstance(composition, dict):
+        if 'None' in composition.keys():
+            return np.zeros_like(Q)
     formula = interpret_formula(composition)
     norm_elemental_abundances = normalize_composition(
         formula)

--- a/hexrd/material/utils.py
+++ b/hexrd/material/utils.py
@@ -206,6 +206,11 @@ def convert_density_to_atoms_per_cubic_angstrom(composition, density):
     """
 
     # get_smallest abundance
+    if composition is None:
+        return 0.
+    elif isinstance(composition, dict):
+        if 'None' in composition.keys():
+            return 0.
     norm_elemental_abundances = normalize_composition(composition)
     mean_z = 0.0
     for element, concentration in norm_elemental_abundances.items():


### PR DESCRIPTION
Add functionality to compute Compton scattering intensity on an instrument panel. This is useful for intensity corrections during liquid total scattering analysis. There were two main calculation needed for this:
1. absorption of the inelastically scattered photons by the sample and window. since the inelastically scattered photons lose energy, the attenuation length is angle dependent.
2. computation of incoherent scattering intensity for each detector pixel. this is done by interpolating the table in `resources/Anomalous.h5`.
3. helper function in `material.utils

There is some special handling needed when the window is `None` or the thickness is `0`, both of which are valid ways to omit the window from the calculation. 