### PR TITLE
Stable vector set comparison

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+concurrency = multiprocessing
+parallel = true
+sigterm = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,14 +71,16 @@ jobs:
         HEXRD_EXAMPLE_REPO_PATH: ${{ github.workspace }}/examples
       run: |
           pytest -s tests/
-      if: ${{ matrix.config.os != 'ubuntu-latest'}}
       working-directory: hexrd
 
     - name: Run tests with codecov
       env:
         HEXRD_EXAMPLE_REPO_PATH: ${{ github.workspace }}/examples
+        NUMBA_DISABLE_JIT: 1
       run: |
-          pytest -s --cov hexrd --cov-report xml:coverage.xml tests/
+          coverage run --include "./*" -m pytest tests/
+          coverage combine
+          coverage xml
       if: ${{ matrix.config.os == 'ubuntu-latest'}}
       working-directory: hexrd
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
         HEXRD_EXAMPLE_REPO_PATH: ${{ github.workspace }}/examples
       run: |
           pytest -s tests/
+      if: ${{ matrix.config.os != 'ubuntu-latest'}}
       working-directory: hexrd
 
     - name: Run tests with codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,11 +76,11 @@ jobs:
     - name: Run tests with codecov
       env:
         HEXRD_EXAMPLE_REPO_PATH: ${{ github.workspace }}/examples
-        NUMBA_DISABLE_JIT: 1
+        NUMBA_DISABLE_JIT: 0
       run: |
-          coverage run --include "./*" -m pytest tests/
+          coverage run --source hexrd -m pytest tests/
           coverage combine
-          coverage xml
+          coverage xml -i
       if: ${{ matrix.config.os == 'ubuntu-latest'}}
       working-directory: hexrd
 

--- a/tests/calibration/test_laue_auto_pick.py
+++ b/tests/calibration/test_laue_auto_pick.py
@@ -19,14 +19,14 @@ def simulated_tardis_path(example_repo_path: Path) -> Path:
 @pytest.fixture
 def simulated_tardis_images(
     simulated_tardis_path: Path,
-) -> dict[str, np.array]:
+) -> dict[str, np.ndarray]:
     path = simulated_tardis_path / 'tardis_images.npz'
     npz = np.load(path)
     return {k: v for k, v in npz.items()}
 
 
 @pytest.fixture
-def lif_grain_params(simulated_tardis_path: Path) -> np.array:
+def lif_grain_params(simulated_tardis_path: Path) -> np.ndarray:
     path = simulated_tardis_path / 'lif_grains_ideal.out'
     grain = np.loadtxt(path, ndmin=2)[0]
     return grain[3:15]
@@ -56,8 +56,8 @@ def expected_laue_auto_pick_results(test_data_dir: Path) -> dict[str, list]:
 def test_autopick_laue_spots(
     tardis_instrument: HEDMInstrument,
     lif_material: Material,
-    lif_grain_params: np.array,
-    simulated_tardis_images: dict[str, np.array],
+    lif_grain_params: np.ndarray,
+    simulated_tardis_images: dict[str, np.ndarray],
     expected_laue_auto_pick_results: dict[str, list],
 ):
     instr = tardis_instrument

--- a/tests/calibration/test_laue_auto_pick.py
+++ b/tests/calibration/test_laue_auto_pick.py
@@ -8,6 +8,7 @@ import pytest
 from hexrd.fitting.calibration import LaueCalibrator
 from hexrd.material.material import load_materials_hdf5, Material
 from hexrd.instrument.hedm_instrument import HEDMInstrument
+from common import compare_vector_set
 
 
 @pytest.fixture
@@ -134,8 +135,7 @@ def test_autopick_laue_spots(
     # Now just verify that everything matches the previous results
     for pick_key in expected_laue_auto_pick_results:
         for det_key in expected_laue_auto_pick_results[pick_key]:
-            assert np.allclose(
-                picks[pick_key][det_key],
-                expected_laue_auto_pick_results[pick_key][det_key],
-                equal_nan=True
+            assert compare_vector_set(
+                np.array(picks[pick_key][det_key]),
+                np.array(expected_laue_auto_pick_results[pick_key][det_key]),
             )

--- a/tests/calibration/test_laue_auto_pick.py
+++ b/tests/calibration/test_laue_auto_pick.py
@@ -8,7 +8,6 @@ import pytest
 from hexrd.fitting.calibration import LaueCalibrator
 from hexrd.material.material import load_materials_hdf5, Material
 from hexrd.instrument.hedm_instrument import HEDMInstrument
-from common import compare_vector_set
 from collections import defaultdict
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -29,14 +29,32 @@ def convert_axis_angle_to_rmat(axis, angle):
     s = math.sin(angle)
     t = 1.0 - c
 
-    m[0, 0] = c + axis[0]*axis[0]*t
-    m[0, 1] = axis[0]*axis[1]*t - axis[2]*s
-    m[0, 2] = axis[0]*axis[2]*t + axis[1]*s
-    m[1, 0] = axis[0]*axis[1]*t + axis[2]*s
-    m[1, 1] = c + axis[1]*axis[1]*t
-    m[1, 2] = axis[1]*axis[2]*t - axis[0]*s
-    m[2, 0] = axis[0]*axis[2]*t - axis[1]*s
-    m[2, 1] = axis[1]*axis[2]*t + axis[0]*s
-    m[2, 2] = c + axis[2]*axis[2]*t
+    m[0, 0] = c + axis[0] * axis[0] * t
+    m[0, 1] = axis[0] * axis[1] * t - axis[2] * s
+    m[0, 2] = axis[0] * axis[2] * t + axis[1] * s
+    m[1, 0] = axis[0] * axis[1] * t + axis[2] * s
+    m[1, 1] = c + axis[1] * axis[1] * t
+    m[1, 2] = axis[1] * axis[2] * t - axis[0] * s
+    m[2, 0] = axis[0] * axis[2] * t - axis[1] * s
+    m[2, 1] = axis[1] * axis[2] * t + axis[0] * s
+    m[2, 2] = c + axis[2] * axis[2] * t
 
     return m
+
+
+def compare_vector_set(
+    vectors1: np.ndarray,
+    vectors2: np.ndarray,
+    sort_dim: int = 0,
+    rtol: float = 1.0e-5,
+    atol: float = 1.0e-8,
+) -> bool:
+    """Compares two sets of vectors for equality. Ignores the order."""
+    vectors1 = vectors1.copy()
+    vectors2 = vectors2.copy()
+    vectors1.sort(axis=sort_dim)
+    vectors2.sort(axis=sort_dim)
+
+    return np.allclose(
+        vectors1, vectors2, rtol=rtol, atol=atol, equal_nan=True
+    )

--- a/tests/common.py
+++ b/tests/common.py
@@ -45,16 +45,13 @@ def convert_axis_angle_to_rmat(axis, angle):
 def compare_vector_set(
     vectors1: np.ndarray,
     vectors2: np.ndarray,
-    sort_dim: int = 0,
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
 ) -> bool:
     """Compares two sets of vectors for equality. Ignores the order."""
-    vectors1 = vectors1.copy()
-    vectors2 = vectors2.copy()
-    vectors1.sort(axis=sort_dim)
-    vectors2.sort(axis=sort_dim)
+    i = np.lexsort(vectors1.T)
+    j = np.lexsort(vectors2.T)
 
     return np.allclose(
-        vectors1, vectors2, rtol=rtol, atol=atol, equal_nan=True
+        vectors1[i], vectors2[j], rtol=rtol, atol=atol, equal_nan=True
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -40,18 +40,3 @@ def convert_axis_angle_to_rmat(axis, angle):
     m[2, 2] = c + axis[2] * axis[2] * t
 
     return m
-
-
-def compare_vector_set(
-    vectors1: np.ndarray,
-    vectors2: np.ndarray,
-    rtol: float = 1.0e-5,
-    atol: float = 1.0e-8,
-) -> bool:
-    """Compares two sets of vectors for equality. Ignores the order."""
-    i = np.lexsort(vectors1.T)
-    j = np.lexsort(vectors2.T)
-
-    return np.allclose(
-        vectors1[i], vectors2[j], rtol=rtol, atol=atol, equal_nan=True
-    )

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest
 coloredlogs
-pytest-codecov
+coverage

--- a/tests/test_laue.py
+++ b/tests/test_laue.py
@@ -7,6 +7,7 @@ import pytest
 
 from hexrd.material.material import load_materials_hdf5, Material
 from hexrd.instrument.hedm_instrument import HEDMInstrument
+from common import compare_vector_set
 
 
 @pytest.fixture
@@ -107,5 +108,16 @@ def test_simulate_laue_spots(
 
         # Now verify that nothing changed
         ref = expected_simulated_laue_results[det_key]
-        for results, results_ref in zip(psim, ref):
-            assert np.allclose(results, results_ref, equal_nan=True)
+        (
+            result_xy_det,
+            result_hkls,
+            result_angles,
+            result_dspacing,
+            result_energy,
+        ) = ref
+
+        assert compare_vector_set(xy_det, result_xy_det, 1)
+        assert compare_vector_set(hkls, result_hkls, 2)
+        assert compare_vector_set(angles, result_angles, 1)
+        assert compare_vector_set(dspacing, result_dspacing, 1)
+        assert compare_vector_set(energy, result_energy, 1)

--- a/tests/test_laue.py
+++ b/tests/test_laue.py
@@ -113,30 +113,27 @@ def test_simulate_laue_spots(
             result_energy,
         ) = ref
 
-        # Stack all of the coupled data into the same vector before comparing.
+        # Get everything into a similar shape and sort them by hkl
+        hkls = hkls.transpose(0, 2, 1)[0]
+        result_hkls = result_hkls.transpose(0, 2, 1)[0]
 
-        stacked = np.concatenate(
-            [
-                xy_det,
-                hkls.transpose(0, 2, 1),
-                angles,
-                dspacing[..., None],
-                energy[..., None],
-            ],
-            axis=2,
-        )
+        i = np.lexsort(hkls.T)
+        j = np.lexsort(result_hkls.T)
 
-        results_stacked = np.concatenate(
-            [
-                result_xy_det,
-                result_hkls.transpose(0, 2, 1),
-                result_angles,
-                result_dspacing[..., None],
-                result_energy[..., None],
-            ],
-            axis=2,
-        )
+        hkls = hkls[i]
+        xy_det = xy_det[0][i]
+        angles = angles[0][i]
+        dspacing = dspacing[..., None][0][i]
+        energy = energy[..., None][0][i]
 
-        assert compare_vector_set(
-            stacked.transpose(1, 0, 2), results_stacked.transpose(1, 0, 2)
-        )
+        result_hkls = result_hkls[j]
+        result_xy_det = result_xy_det[0][j]
+        result_angles = result_angles[0][j]
+        result_dspacing = result_dspacing[..., None][0][j]
+        result_energy = result_energy[..., None][0][j]
+
+        assert np.allclose(hkls, result_hkls, equal_nan=True)
+        assert np.allclose(xy_det, result_xy_det, equal_nan=True)
+        assert np.allclose(angles, result_angles, equal_nan=True)
+        assert np.allclose(dspacing, result_dspacing, equal_nan=True)
+        assert np.allclose(energy, result_energy, equal_nan=True)

--- a/tests/test_laue.py
+++ b/tests/test_laue.py
@@ -113,8 +113,28 @@ def test_simulate_laue_spots(
             result_energy,
         ) = ref
 
-        assert compare_vector_set(xy_det, result_xy_det, 1)
-        assert compare_vector_set(hkls, result_hkls, 2)
-        assert compare_vector_set(angles, result_angles, 1)
-        assert compare_vector_set(dspacing, result_dspacing, 1)
-        assert compare_vector_set(energy, result_energy, 1)
+        # Stack all of the coupled data into the same vector before comparing.
+
+        stacked = np.concatenate(
+            [
+                xy_det,
+                hkls.transpose(0, 2, 1),
+                angles,
+                dspacing[..., None],
+                energy[..., None],
+            ],
+            axis=2,
+        )
+
+        results_stacked = np.concatenate(
+            [
+                result_xy_det,
+                result_hkls.transpose(0, 2, 1),
+                result_angles,
+                result_dspacing[..., None],
+                result_energy[..., None],
+            ],
+            axis=2,
+        )
+
+        assert compare_vector_set(stacked, results_stacked, 1)

--- a/tests/test_laue.py
+++ b/tests/test_laue.py
@@ -16,7 +16,7 @@ def simulated_tardis_path(example_repo_path: Path) -> Path:
 
 
 @pytest.fixture
-def lif_grain_params(simulated_tardis_path: Path) -> np.array:
+def lif_grain_params(simulated_tardis_path: Path) -> np.ndarray:
     path = simulated_tardis_path / 'lif_grains_ideal.out'
     grain = np.loadtxt(path, ndmin=2)[0]
     return grain[3:15]
@@ -46,7 +46,7 @@ def expected_simulated_laue_results(test_data_dir: Path) -> dict[str, list]:
 def test_simulate_laue_spots(
     tardis_instrument: HEDMInstrument,
     lif_material: Material,
-    lif_grain_params: np.array,
+    lif_grain_params: np.ndarray,
     expected_simulated_laue_results: dict[str, np.ndarray],
 ):
     instr = tardis_instrument
@@ -56,10 +56,7 @@ def test_simulate_laue_spots(
     plane_data.exclusions = None
 
     sim_data = instr.simulate_laue_pattern(
-        plane_data,
-        minEnergy=5,
-        maxEnergy=35,
-        grain_params=[lif_grain_params]
+        plane_data, minEnergy=5, maxEnergy=35, grain_params=[lif_grain_params]
     )
 
     # A few manual expected results

--- a/tests/test_laue.py
+++ b/tests/test_laue.py
@@ -137,4 +137,6 @@ def test_simulate_laue_spots(
             axis=2,
         )
 
-        assert compare_vector_set(stacked, results_stacked, 1)
+        assert compare_vector_set(
+            stacked.transpose(1, 0, 2), results_stacked.transpose(1, 0, 2)
+        )

--- a/tests/test_laue.py
+++ b/tests/test_laue.py
@@ -7,7 +7,6 @@ import pytest
 
 from hexrd.material.material import load_materials_hdf5, Material
 from hexrd.instrument.hedm_instrument import HEDMInstrument
-from common import compare_vector_set
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

This PR addresses a couple of small testing related issues. 

Firstly, the recently introduced in #761 compare the results of the LAUE functions as ordered lists, when, in fact, the order is not neither guaranteed nor important. Here we change that comparison to first sort both arrays and then compare them so the order is ignored. 

Secondly the pytest-cov plugin doesn't count code that is running in a separate process like when using a ProcessPoolExecutor.

To address the `multiprocessing` coverage, we can configure a `.coveragerc` file like the following, `coverage` will automatically start a new trace for each process created.

```
[run]
concurrency = multiprocessing
parallel = true
sigterm = true
```

Then we need to change the coverage report generation script like the following:
```yaml
      run: |
          coverage run --include "./*" -m pytest tests/
          coverage combine
          coverage xml
```

After including these changes

Here is a function that is exclusively called in a separate process:
![image](https://github.com/user-attachments/assets/7410e27f-b286-4e5e-958e-64a86f4717e6)


All told this brings the codecov up from the undercounted ~47% to the more correctly counted ~48%.


Note: pytest-cov also doesn't count `@numba.jit` functions. However, they represent <1% of the code in the library, and disabling jit for coverage tests (the commonly accepted answer) results in 5x runtime for the test cases. So we will continue to jit the functions and not worry about that.