### PR TITLE
 Improve rectangle operation performance

### DIFF
--- a/hexrd/imageseries/load/__init__.py
+++ b/hexrd/imageseries/load/__init__.py
@@ -1,8 +1,11 @@
 import abc
 import pkgutil
+import numpy as np
 
 from ..imageseriesabc import ImageSeriesABC
 from .registry import Registry
+
+RegionType = tuple[tuple[int, int], tuple[int, int]]
 
 # Metaclass for adapter registry
 
@@ -15,6 +18,13 @@ class _RegisterAdapterClass(abc.ABCMeta):
 class ImageSeriesAdapter(ImageSeriesABC, metaclass=_RegisterAdapterClass):
 
     format = None
+
+    def get_region(self, frame_idx: int, region: RegionType) -> np.ndarray:
+        r = region
+        return self[frame_idx][r[0][0]:r[0][1], r[1][0]:r[1][1]]
+
+    def __getitem__(self, _):
+        pass
 
 # import all adapter modules
 

--- a/hexrd/imageseries/load/framecache.py
+++ b/hexrd/imageseries/load/framecache.py
@@ -8,7 +8,7 @@ from scipy.sparse import csr_matrix
 import yaml
 import h5py
 
-from . import ImageSeriesAdapter
+from . import ImageSeriesAdapter, RegionType
 from ..imageseriesiter import ImageSeriesIterator
 from .metadata import yamlmeta
 from hexrd.utils.hdf5 import unwrap_h5_to_dict
@@ -175,6 +175,12 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
                                shape=self._shape,
                                dtype=self._dtype)
             self._framelist.append(frame)
+
+    def get_region(self, frame_idx: int, region: RegionType) -> np.ndarray:
+        self._load_framelist_if_needed()
+        csr_frame = self._framelist[frame_idx]
+        r = region
+        return csr_frame[r[0][0]:r[0][1], r[1][0]:r[1][1]].toarray()
 
     @property
     def metadata(self):

--- a/hexrd/imageseries/load/hdf5.py
+++ b/hexrd/imageseries/load/hdf5.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 
-from . import ImageSeriesAdapter
+from . import ImageSeriesAdapter,RegionType
 from ..imageseriesiter import ImageSeriesIterator
 
 
@@ -66,6 +66,10 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
             return np.asarray(self.__image_dataset)
         else:
             return self.__image_dataset[key]
+
+    def get_region(self, frame_idx: int, region: RegionType) -> np.ndarray:
+        r = region
+        return self.__image_dataset[frame_idx][r[0][0]:r[0][1], r[1][0]:r[1][1]]
 
     def __iter__(self):
         return ImageSeriesIterator(self)

--- a/hexrd/utils/hdf5.py
+++ b/hexrd/utils/hdf5.py
@@ -44,6 +44,9 @@ def unwrap_dict_to_h5(grp, d, asattr=False):
                         continue
                     else:
                         # probably a string badness
+
+                        if isinstance(item, np.ndarray) and np.issubdtype(item.dtype, 'U'):
+                            item = str(item) # hdf5 files do not support unicode arrays
                         grp.create_dataset(key, data=item)
 
 


### PR DESCRIPTION
# Overview

Provide optimized implementation for when applying the rectangle operator in an imageseries as its first operation. 

ImageSeriesAdapter class has a new method
```
def get_region(self, frame_idx: int, region: RegionType) -> np.ndarray:
    r = region
    return self[frame_idx][r[0][0]:r[0][1], r[1][0]:r[1][1]]
```
Derived classes can offer optimized implementations. 
only ```FrameCacheImageSeriesAdapter```  and ``HDF5ImageSeriesAdapter`` take advantage of this for now.


# Affected Workflows

workflows utilizing `ProcessedImageSeries` should see a  speedup if they use the rectangle operation as their first operation.
Results running locally on a 1441 frame dataset
| format            | before (s) | after(s) | % improvement |
|-------------------|------------|----------|---------------|
| framecache (npz)  | 1020       | 59       | 94%           |
| framecache (fch5) | 935        | 40.3     | 95%           | 
| raw hdf5                | 6020       | 6070     | -0.8 %        | 

# Documentation Changes
no documentation changes
