### PR TITLE
Unpin pycifrw

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_reqs = [
     'numba',
     'numpy<1.27',  # noqa NOTE: bump this to support the latest version numba supports
     'psutil',
-    'pycifrw<5.0',  # Remove version pin when this issue is fixed: https://github.com/jamesrhester/pycifrw/issues/14
+    'pycifrw',
     'pyyaml',
     'scikit-image',
     'scikit-learn',


### PR DESCRIPTION
It seems that the [issue](https://github.com/jamesrhester/pycifrw/issues/14) that caused us to pin it has been fixed.