### PR TITLE
Fix calculation of measured omega values

### DIFF
--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -1767,6 +1767,7 @@ class HEDMInstrument(object):
                     frame_indices = [
                         ome_imgser.omega_to_frame(ome)[0] for ome in ome_eval
                     ]
+                    ome_edges = np.array(frame_indices) * delta_ome
 
                     if -1 in frame_indices:
                         if not quiet:
@@ -1836,10 +1837,12 @@ class HEDMInstrument(object):
                                 else:
                                     closest_peak_idx = 0
                                 coms = coms[closest_peak_idx]
-                                # meas_omes = \
-                                #     ome_edges[0] + (0.5 + coms[0])*delta_ome
                                 meas_omes = \
-                                    ome_eval[0] + coms[0]*delta_ome
+                                    ome_edges[0] + (0.5 + coms[0])*delta_ome
+                                # The old way of calculating `meas_omes`
+                                # (which is likely not as accurate):
+                                # meas_omes = \
+                                #     ome_eval[0] + coms[0]*delta_ome
                                 meas_angs = np.hstack(
                                     [tth_edges[0] + (0.5 + coms[2])*delta_tth,
                                      eta_edges[0] + (0.5 + coms[1])*delta_eta,


### PR DESCRIPTION
The `ome_eval` comes from simulated rotation series angles, and may not be the best thing to use as a reference point when computing measured omega values. We've had a hard time figuring out why it is being used. The measurement of a spot's omega value should ideally not depend on the current instrument calibration.

Instead, it seems better to use the code that is commented out immediately above it, which uses omega edges from the frame data as a reference point when computing measured omega values.

We have some new spot detection code (not in this repository) that also measures omega values, and our new spot detection code is in much greater agreement with `pull_spots()` if we implement this change. That provides further evidence as well that this change produces more accurate omega values for the spots.