### PR TITLE
Handle recursion in imageseries get_region()

### DIFF
--- a/hexrd/imageseries/baseclass.py
+++ b/hexrd/imageseries/baseclass.py
@@ -1,6 +1,9 @@
 """Base class for imageseries
 """
-from .imageseriesabc import ImageSeriesABC
+import numpy as np
+
+from .imageseriesabc import ImageSeriesABC, RegionType
+
 
 class ImageSeries(ImageSeriesABC):
     """collection of images
@@ -39,3 +42,6 @@ class ImageSeries(ImageSeriesABC):
     @property
     def metadata(self):
         return self._adapter.metadata
+
+    def get_region(self, frame_idx: int, region: RegionType) -> np.ndarray:
+        return self._adapter.get_region(frame_idx, region)

--- a/hexrd/imageseries/imageseriesabc.py
+++ b/hexrd/imageseries/imageseriesabc.py
@@ -1,6 +1,9 @@
 """Abstract Base Class"""
 import collections.abc
 
+# Type for extracting regions
+RegionType = tuple[tuple[int, int], tuple[int, int]]
+
 
 class ImageSeriesABC(collections.abc.Sequence):
     pass

--- a/hexrd/imageseries/load/__init__.py
+++ b/hexrd/imageseries/load/__init__.py
@@ -2,10 +2,8 @@ import abc
 import pkgutil
 import numpy as np
 
-from ..imageseriesabc import ImageSeriesABC
+from ..imageseriesabc import ImageSeriesABC, RegionType
 from .registry import Registry
-
-RegionType = tuple[tuple[int, int], tuple[int, int]]
 
 # Metaclass for adapter registry
 

--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -96,7 +96,7 @@ class ProcessedImageSeries(ImageSeries):
         return ret
 
     def _rectangle_optimized(self, img_key, r):
-        return self._imser._adapter.get_region(img_key, r)
+        return self._imser.get_region(img_key, r)
 
     def _rectangle(self, img, r):
         # restrict to rectangle


### PR DESCRIPTION
Sometimes (as is the case for `OmegaImageSeries`), `self._adapter` is itself an imageseries, rather than an imageseries adapter.

To handle this recursion, use a forwarding function on the `ImageSeries` base class to forward the call to its adapter (which, if the adapter is itself an imageseries, will then forward the call to its own adapter).

This fixes running [this example](https://github.com/HEXRD/examples/blob/master/NIST_ruby/multiruby_dexelas/include/mruby_config_composite_roi.yml).