### PR TITLE
Modified pinhole area correction

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -2000,11 +2000,17 @@ class Detector:
 
     def calc_effective_pinhole_area(self, physics_package: AbstractPhysicsPackage) -> np.array:
         """get the effective pinhole area correction
+        @SS 04/01/25 a modification was made based on the 
+        CeO2 data recorded on NIF. An extra factor of sec(beta)
+        was included as compared to RSI 91, 043902 (2020).
         """
-        # always assume thin pinhole
         hod = (physics_package.pinhole_thickness /
         physics_package.pinhole_diameter)
 
+        '''we compute the beta angle using existing
+        functions by just changing beam vector
+        to be the z-axis with the right sign.
+        '''
         bvec_old = self.bvec.copy()
         bvec_new = np.array([0., 0., np.sign(bvec_old[2])])
         self.bvec = bvec_new

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -2000,21 +2000,22 @@ class Detector:
 
     def calc_effective_pinhole_area(self, physics_package: AbstractPhysicsPackage) -> np.array:
         '''get the effective pinhole area correction
-        @SS 04/01/25 a modification was made based on the 
+        @SS 04/01/25 a modification was made based on the
         CeO2 data recorded on NIF. An extra factor of sec(beta)
         was included as compared to RSI 91, 043902 (2020).
         '''
-        hod = (physics_package.pinhole_thickness /
-        physics_package.pinhole_diameter)
+        hod = (
+            physics_package.pinhole_thickness /
+            physics_package.pinhole_diameter
+        )
 
         '''we compute the beta angle using existing
         functions by just changing beam vector
         to be the z-axis with the right sign.
         '''
-        bvec_old = self.bvec.copy()
-        bvec_new = np.array([0., 0., np.sign(bvec_old[2])])
-        self.bvec = bvec_new
-        beta, eta = self.pixel_angles()
+        bvec = np.array([0., 0., np.sign(self.bvec[2])])
+        beta, eta = self.pixel_angles(bvec=bvec)
+
         tb = np.tan(beta)
         jb = hod*tb
         jb[jb > 1] = np.nan
@@ -2026,9 +2027,6 @@ class Detector:
         f1[mask] = np.pi/2
 
         f2 = jb*np.sqrt(1 - jb2)
-
-        # set beam vector back to original
-        self.bvec = bvec_old
 
         return 0.5*(f1 - f2)
 

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -1999,11 +1999,11 @@ class Detector:
         return np.exp(-mu_w_prime*thickness_w*secb)
 
     def calc_effective_pinhole_area(self, physics_package: AbstractPhysicsPackage) -> np.array:
-        """get the effective pinhole area correction
+        '''get the effective pinhole area correction
         @SS 04/01/25 a modification was made based on the 
         CeO2 data recorded on NIF. An extra factor of sec(beta)
         was included as compared to RSI 91, 043902 (2020).
-        """
+        '''
         hod = (physics_package.pinhole_thickness /
         physics_package.pinhole_diameter)
 

--- a/hexrd/instrument/planar_detector.py
+++ b/hexrd/instrument/planar_detector.py
@@ -87,9 +87,12 @@ class PlanarDetector(Detector):
         crds = np.hstack([xy_data, np.zeros((npts, 1))])
         return np.dot(crds, self.rmat.T) + self.tvec
 
-    def pixel_angles(self, origin=ct.zeros_3):
+    def pixel_angles(self, origin=ct.zeros_3, bvec: np.ndarray | None = None):
+        if bvec is None:
+            bvec = self.bvec
+
         return _pixel_angles(origin, self.pixel_coords, self.distortion,
-                             self.rmat, self.tvec, self.bvec, self.evec,
+                             self.rmat, self.tvec, bvec, self.evec,
                              self.rows, self.cols)
 
     def pixel_tth_gradient(self, origin=ct.zeros_3):


### PR DESCRIPTION
# Overview

An error was discovered in the pinhole area correction based on the CeO2 data recorded on TARDIS. An extra `sec(beta)` factor was added to the correction published in Rygg et al., Rev. Sci. Instrum. 91, 043902 (2020). This PR makes that change. 

Another small modification was made to use the existing functionality in the `transforms` module to compute the `beta` angles. This streamlines the function.

