### PR TITLE
Add option for closing file in HDF5 imageseries

### DIFF
--- a/hexrd/imageseries/load/hdf5.py
+++ b/hexrd/imageseries/load/hdf5.py
@@ -22,6 +22,9 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
     dataname : str, optional
         The name of the HDF dataset containing the 2-d or 3d image data.
         The default values is 'images'.
+    close_when_finished: bool, optional
+        Whether to close the h5py file handle when this imageseries is
+        deleted. The default is `True`.
     """
 
     format = 'hdf5'
@@ -34,6 +37,7 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
             self.__h5name = fname
             self.__h5file = h5py.File(self.__h5name, 'r')
 
+        self._close_when_finished = kwargs.get('close_when_finished', True)
         self.__path = kwargs['path']
         self.__dataname = kwargs.pop('dataname', 'images')
         self.__images = '/'.join([self.__path, self.__dataname])
@@ -43,7 +47,10 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
     def close(self):
         self.__image_dataset = None
         self.__data_group = None
-        self.__h5file.close()
+
+        if self._close_when_finished and self.__h5file is not None:
+            self.__h5file.close()
+
         self.__h5file = None
 
     def __del__(self):


### PR DESCRIPTION
Previously, the HDF5 file would always be closed automatically. However, this presents a problem if there are multiple imageseries using the same file handle, and one of them is deleted, because the file will be closed and the other imageseries will become invalid.

This is particularly important for state files in the GUI, where there are many images saved within a single HDF5 state file, and if a user removes one detector, the file would be closed automatically and the other image series would become invalid.

This PR adds the ability to prevent automatic closing of the file when the imageseries is finished. `close_when_finished` is an optional keyword argument that defaults to `True` if missing. It fixes the issue with HDF5 state files.