### PR TITLE
Fix some bugs with the detector class

### DIFF
--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -210,11 +210,25 @@ class CylindricalDetector(Detector):
             'cols': self.cols,
         }
 
-    def pixel_tth_gradient(self, origin=ct.zeros_3):
-        return _pixel_tth_gradient(origin=origin, **self._pixel_angle_kwargs)
+    def pixel_tth_gradient(self, origin=ct.zeros_3, bvec: np.ndarray | None = None):
+        if bvec is None:
+            bvec = self.bvec
 
-    def pixel_eta_gradient(self, origin=ct.zeros_3):
-        return _pixel_eta_gradient(origin=origin, **self._pixel_angle_kwargs)
+        return _pixel_tth_gradient(
+            origin=origin,
+            bvec=bvec,
+            **self._pixel_angle_kwargs,
+        )
+
+    def pixel_eta_gradient(self, origin=ct.zeros_3, bvec: np.ndarray | None = None):
+        if bvec is None:
+            bvec = self.bvec
+
+        return _pixel_eta_gradient(
+            origin=origin,
+            bvec=bvec,
+            **self._pixel_angle_kwargs,
+        )
 
     @property
     def caxis(self):

--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -117,7 +117,9 @@ class CylindricalDetector(Detector):
                                                tVec_c=tvec_c,
                                                normalize=False)
 
-    def pixel_angles(self, origin=ct.zeros_3):
+    def pixel_angles(self, origin=ct.zeros_3, bvec: np.ndarray | None = None):
+        if bvec is None:
+            bvec = self.bvec
         return _pixel_angles(origin=origin, **self._pixel_angle_kwargs)
 
     def local_normal(self):

--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -120,7 +120,11 @@ class CylindricalDetector(Detector):
     def pixel_angles(self, origin=ct.zeros_3, bvec: np.ndarray | None = None):
         if bvec is None:
             bvec = self.bvec
-        return _pixel_angles(origin=origin, **self._pixel_angle_kwargs)
+        return _pixel_angles(
+            origin=origin,
+            bvec=bvec,
+            **self._pixel_angle_kwargs,
+        )
 
     def local_normal(self):
         """get the local normal of each pixel in the
@@ -201,7 +205,6 @@ class CylindricalDetector(Detector):
             'paxis': self.paxis,
             'tvec_d': self.tvec,
             'radius': self.radius,
-            'bvec': self.bvec,
             'evec': self.evec,
             'rows': self.rows,
             'cols': self.cols,

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -2023,10 +2023,14 @@ class Detector:
         mask = np.isclose(jb2, 0.)
 
         f1 = np.zeros_like(jb)
-        f1[~mask] = np.arctan(np.sqrt(1/jb2[~mask] - 1))
+        f3 = 1/jb2[~mask] - 1
+        f3[f3<0.] = np.nan
+        f1[~mask] = np.arctan(np.sqrt(f3))
         f1[mask] = np.pi/2
 
-        f2 = jb*np.sqrt(1 - jb2)
+        f3 = 1 - jb2
+        f3[f3<0.] = np.nan
+        f2 = jb*np.sqrt(f3)
 
         return 0.5*(f1 - f2)
 


### PR DESCRIPTION
Two bug fixes in this PR:

1. fix missing bvec argument from cylindrical detectors, same as the planar detectors.
2. fix runtime warning for pinhole effective area correction due to `sqrt` of a negative number.

