### PR TITLE
Generalize physics package layers and distortion

### DIFF
--- a/hexrd/constants.py
+++ b/hexrd/constants.py
@@ -782,6 +782,7 @@ DENSITY_COMPOUNDS = {
     'LiF': 2.64,
     'quartz': 2.65,
     'diamond': 3.5,
+    'C22H10N2O5': 1.42,  # kapton
 }
 
 '''

--- a/hexrd/instrument/constants.py
+++ b/hexrd/instrument/constants.py
@@ -38,6 +38,18 @@ class PHYSICS_PACKAGE_DEFAULTS:
         'window_material': 'LiF',
         'window_density': DENSITY_COMPOUNDS['LiF'],
         'window_thickness': 150, # in microns
+        'ablator_material': 'C22H10N2O5',
+        'ablator_density': DENSITY_COMPOUNDS['C22H10N2O5'],
+        # No ablator by default, so thickness is 0
+        'ablator_thickness': 0,  # in microns
+        'heatshield_material': 'Au',
+        'heatshield_density': DENSITY['Au'],
+        # No heatshield by default, so thickness is 0
+        'heatshield_thickness': 0,  # in microns
+        'pusher_material': 'Be',
+        'pusher_density': DENSITY['Be'],
+        # No pusher by default, so thickness is 0
+        'pusher_thickness': 0,  # in microns
     }
     # # Template for HEDM type physics package
     # HEDM = {

--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -1145,8 +1145,8 @@ class HEDMInstrument(object):
             to the returned data. collapse_eta must also be True for this
             to have any effect. The default is False.
         tth_distortion : special class, optional
-            for special case of pinhole camera distortions.  See
-            hexrd.xrdutil.phutil.SampleLayerDistortion (only type supported)
+            for special case of pinhole camera distortions.
+            See classes in hexrd.xrdutil.phutil
         fitting_kwargs : dict, optional
             kwargs passed to hexrd.fitting.utils.fit_ring if do_fitting is True
 


### PR DESCRIPTION
This simplifies and generalizes the layers in a physics package, so that more can be easily added and used.

It adds three new default layers to the HED physics package: ablator, heatshield, and pusher.

It also generalizes the "sample layer distortion" to be just "layer distortion". All of the sample layer distortion calculations can actually be applied to any layer. The only difference is that the layer standoff (distance to pinhole) will be different.

We can use this to apply appropriate two theta distortions for layers such as the ablator, heatshield, pusher, or even window.