### PR TITLE
Structureless residual

### DIFF
--- a/hexrd/fitting/calibration/structureless.py
+++ b/hexrd/fitting/calibration/structureless.py
@@ -99,16 +99,16 @@ class StructurelessCalibrator:
                     if rng[det_name] is None or rng[det_name].size == 0:
                         continue
 
-                    tth_rng = params[f'{prefix}{ii}'].value
-                    tth_updated = np.degrees(rng[det_name][:, 0])
+                    # To make these residuals consistent with the powder
+                    # calibrator residuals, convert them to radians
+                    tth_rng = np.radians(params[f'{prefix}{ii}'].value)
+                    tth_updated = rng[det_name][:, 0]
                     delta_tth = tth_updated - tth_rng
                     if corr_rng[det_name] is not None:
-                        delta_tth -= np.degrees(corr_rng[det_name])
+                        delta_tth -= corr_rng[det_name]
                     residual.append(delta_tth)
 
-        residual = np.hstack(residual)
-
-        return residual/residual.size
+        return np.hstack(residual)
 
     def set_minimizer(self):
         self.fitter = lmfit.Minimizer(self.calc_residual,

--- a/hexrd/fitting/calibration/structureless.py
+++ b/hexrd/fitting/calibration/structureless.py
@@ -106,7 +106,8 @@ class StructurelessCalibrator:
                         delta_tth -= np.degrees(corr_rng[det_name])
                     residual.append(delta_tth)
 
-        return np.hstack(residual)
+        residual = np.hstack(residual)
+        return residual/residual.size
 
     def set_minimizer(self):
         self.fitter = lmfit.Minimizer(self.calc_residual,

--- a/hexrd/fitting/calibration/structureless.py
+++ b/hexrd/fitting/calibration/structureless.py
@@ -87,6 +87,7 @@ class StructurelessCalibrator:
         meas_angles = self.meas_angles
         tth_correction = self.tth_correction
 
+<<<<<<< HEAD
         residual = []
         prefixes = tth_parameter_prefixes(self.instr)
         for xray_source in self.data:
@@ -107,6 +108,8 @@ class StructurelessCalibrator:
                     residual.append(delta_tth)
 
         residual = np.hstack(residual)
+=======
+>>>>>>> 377b124 (use size instead of len)
         return residual/residual.size
 
     def set_minimizer(self):

--- a/hexrd/fitting/calibration/structureless.py
+++ b/hexrd/fitting/calibration/structureless.py
@@ -87,7 +87,6 @@ class StructurelessCalibrator:
         meas_angles = self.meas_angles
         tth_correction = self.tth_correction
 
-<<<<<<< HEAD
         residual = []
         prefixes = tth_parameter_prefixes(self.instr)
         for xray_source in self.data:
@@ -108,8 +107,7 @@ class StructurelessCalibrator:
                     residual.append(delta_tth)
 
         residual = np.hstack(residual)
-=======
->>>>>>> 377b124 (use size instead of len)
+
         return residual/residual.size
 
     def set_minimizer(self):


### PR DESCRIPTION
Make the residual for structureless consistent with the composite calibration. An average of the error is returned instead of the total cumulative error.