### PR TITLE
Solid angle speedup

### DIFF
--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -231,6 +231,12 @@ class CylindricalDetector(Detector):
         )
 
     @property
+    def pixel_normal(self):
+        if not hasattr(self, '_pixel_normal'):
+            self._pixel_normal = self.local_normal()
+        return self._pixel_normal
+
+    @property
     def caxis(self):
         # returns the cylinder axis
         return np.dot(self.rmat, ct.lab_y)

--- a/hexrd/instrument/cylindrical_detector.py
+++ b/hexrd/instrument/cylindrical_detector.py
@@ -7,7 +7,7 @@ from hexrd import xrdutil
 from hexrd.utils.decorators import memoize
 
 from .detector import (
-    Detector, _solid_angle_of_triangle, _row_edge_vec, _col_edge_vec
+    Detector, _row_edge_vec, _col_edge_vec
 )
 
 from functools import partial
@@ -290,34 +290,6 @@ class CylindricalDetector(Detector):
         return sz / self.radius / 2.0
 
     @property
-    def pixel_solid_angles(self):
-        kwargs = {
-            'rows': self.rows,
-            'cols': self.cols,
-            'pixel_size_row': self.pixel_size_row,
-            'pixel_size_col': self.pixel_size_col,
-            'caxis': self.caxis,
-            'paxis': self.paxis,
-            'radius': self.radius,
-            'tvec': self.tvec,
-            'max_workers': self.max_workers,
-        }
-        return _pixel_solid_angles(**kwargs)
-
-    @staticmethod
-    def update_memoization_sizes(all_panels):
-        Detector.update_memoization_sizes(all_panels)
-
-        num_matches = sum(isinstance(x, CylindricalDetector) for x in all_panels)
-        funcs = [
-            _pixel_angles,
-            _pixel_tth_gradient,
-            _pixel_eta_gradient,
-            _pixel_solid_angles,
-        ]
-        Detector.increase_memoization_sizes(funcs, num_matches)
-
-    @property
     def extra_config_kwargs(self):
         return {
             'radius': self.radius,
@@ -389,68 +361,3 @@ def _fix_branch_cut_in_gradients(pgarray):
         np.abs(np.stack([pgarray - np.pi, pgarray, pgarray + np.pi])),
         axis=0
     )
-
-
-def _generate_pixel_solid_angles(start_stop, rows, cols, pixel_size_row,
-                                 pixel_size_col, caxis, paxis, radius, tvec):
-    start, stop = start_stop
-    row_edge_vec = _row_edge_vec(rows, pixel_size_row)
-    col_edge_vec = _col_edge_vec(cols, pixel_size_col)
-
-    # pixel vertex coords
-    pvy, pvx = np.meshgrid(row_edge_vec, col_edge_vec, indexing='ij')
-    xy_data = np.vstack((pvx.flatten(), pvy.flatten())).T
-
-    # transform to lab frame using the _warp_to_cylinder
-    # function
-    pcrd_array_full = xrdutil.utils._warp_to_cylinder(xy_data,
-                                                      tvec,
-                                                      radius,
-                                                      caxis,
-                                                      paxis,
-                                                      normalize=False)
-
-    conn = cellConnectivity(rows, cols)
-
-    ret = np.empty(len(range(start, stop)), dtype=float)
-
-    for i, ipix in enumerate(range(start, stop)):
-        pix_conn = conn[ipix]
-        vtx_list = pcrd_array_full[pix_conn, :]
-        ret[i] = (_solid_angle_of_triangle(vtx_list[[0, 1, 2], :]) +
-                  _solid_angle_of_triangle(vtx_list[[2, 3, 0], :]))
-
-    return ret
-
-
-@memoize
-def _pixel_solid_angles(rows, cols, pixel_size_row, pixel_size_col,
-                        caxis, paxis, radius, tvec, max_workers):
-    # connectivity array for pixels
-    conn = cellConnectivity(rows, cols)
-
-    # result
-    solid_angs = np.empty(len(conn), dtype=float)
-
-    # Distribute tasks to each process
-    tasks = distribute_tasks(len(conn), max_workers)
-    kwargs = {
-        'rows': rows,
-        'cols': cols,
-        'pixel_size_row': pixel_size_row,
-        'pixel_size_col': pixel_size_col,
-        'caxis': caxis,
-        'paxis': paxis,
-        'radius': radius,
-        'tvec': tvec,
-    }
-    func = partial(_generate_pixel_solid_angles, **kwargs)
-    with ProcessPoolExecutor(mp_context=ct.mp_context,
-                             max_workers=max_workers) as executor:
-        results = executor.map(func, tasks)
-
-    # Concatenate all the results together
-    solid_angs[:] = np.concatenate(list(results))
-    solid_angs = solid_angs.reshape(rows, cols)
-
-    return solid_angs

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -537,6 +537,22 @@ class Detector:
         )
         return pix_i, pix_j
 
+    @property
+    def pixel_solid_angles(self):
+        y, x = self.pixel_coords
+        xy = np.vstack((x.flatten(),y.flatten())).T
+        dvecs = self.cart_to_dvecs(xy)
+        mod_r = np.linalg.norm(dvecs,axis=1)
+        args = (
+            self.pixel_area,
+            mod_r,
+            dvecs,
+            self.pixel_normal,
+            self.shape
+            )
+        return _pixel_solid_angles(*args)
+
+
     # =========================================================================
     # METHODS
     # =========================================================================
@@ -2063,6 +2079,18 @@ class Detector:
 # UTILITY METHODS
 # =============================================================================
 
+@memoize
+def _pixel_solid_angles(pixel_area,
+                        mod_r,
+                        dvecs,
+                        pixel_normal,
+                        det_shape):
+
+    return np.reshape(
+            (pixel_area/mod_r**3)*
+            np.abs(np.sum(
+            pixel_normal*dvecs,axis=1)),
+            det_shape)
 
 def _fix_indices(idx, lo, hi):
     nidx = np.array(idx)
@@ -2079,21 +2107,3 @@ def _row_edge_vec(rows, pixel_size_row):
 
 def _col_edge_vec(cols, pixel_size_col):
     return pixel_size_col * (np.arange(cols + 1) - 0.5 * cols)
-
-
-# FIXME find a better place for this, and maybe include loop over pixels
-@numba.njit(nogil=True, cache=True)
-def _solid_angle_of_triangle(vtx_list):
-    norms = np.sqrt(np.sum(vtx_list * vtx_list, axis=1))
-    norms_prod = norms[0] * norms[1] * norms[2]
-    scalar_triple_product = np.dot(
-        vtx_list[0], np.cross(vtx_list[2], vtx_list[1])
-    )
-    denominator = (
-        norms_prod
-        + norms[0] * np.dot(vtx_list[1], vtx_list[2])
-        + norms[1] * np.dot(vtx_list[2], vtx_list[0])
-        + norms[2] * np.dot(vtx_list[0], vtx_list[1])
-    )
-
-    return 2.0 * np.arctan2(scalar_triple_product, denominator)

--- a/hexrd/instrument/planar_detector.py
+++ b/hexrd/instrument/planar_detector.py
@@ -166,6 +166,14 @@ class PlanarDetector(Detector):
         return output
 
     @property
+    def pixel_normal(self):
+        if not hasattr(self, '_pixel_normal'):
+            self._pixel_normal = np.repeat(np.atleast_2d(
+                self.normal),
+                np.prod(self.shape),axis=0)
+        return self._pixel_normal
+
+    @property
     def pixel_solid_angles(self):
         kwargs = {
             'rows': self.rows,

--- a/hexrd/instrument/planar_detector.py
+++ b/hexrd/instrument/planar_detector.py
@@ -11,7 +11,7 @@ from hexrd.transforms.xfcapi import (
 from hexrd.utils.decorators import memoize
 
 from .detector import (
-    Detector, _solid_angle_of_triangle, _row_edge_vec, _col_edge_vec
+    Detector, _row_edge_vec, _col_edge_vec
 )
 
 from functools import partial
@@ -173,32 +173,6 @@ class PlanarDetector(Detector):
                 np.prod(self.shape),axis=0)
         return self._pixel_normal
 
-    @property
-    def pixel_solid_angles(self):
-        kwargs = {
-            'rows': self.rows,
-            'cols': self.cols,
-            'pixel_size_row': self.pixel_size_row,
-            'pixel_size_col': self.pixel_size_col,
-            'rmat': self.rmat,
-            'tvec': self.tvec,
-            'max_workers': self.max_workers,
-        }
-        return _pixel_solid_angles(**kwargs)
-
-    @staticmethod
-    def update_memoization_sizes(all_panels):
-        Detector.update_memoization_sizes(all_panels)
-
-        num_matches = sum(isinstance(x, PlanarDetector) for x in all_panels)
-        funcs = [
-            _pixel_angles,
-            _pixel_tth_gradient,
-            _pixel_eta_gradient,
-            _pixel_solid_angles,
-        ]
-        Detector.increase_memoization_sizes(funcs, num_matches)
-
 
 @memoize
 def _pixel_angles(origin, pixel_coords, distortion, rmat, tvec, bvec, evec,
@@ -256,63 +230,3 @@ def _fix_branch_cut_in_gradients(pgarray):
         np.abs(np.stack([pgarray - np.pi, pgarray, pgarray + np.pi])),
         axis=0
     )
-
-
-def _generate_pixel_solid_angles(start_stop, rows, cols, pixel_size_row,
-                                 pixel_size_col, rmat, tvec):
-    start, stop = start_stop
-    row_edge_vec = _row_edge_vec(rows, pixel_size_row)
-    col_edge_vec = _col_edge_vec(cols, pixel_size_col)
-
-    nvtx = len(row_edge_vec) * len(col_edge_vec)
-    # pixel vertex coords
-    pvy, pvx = np.meshgrid(row_edge_vec, col_edge_vec, indexing='ij')
-
-    # add Z_d coord and transform to lab frame
-    pcrd_array_full = np.dot(
-        np.vstack([pvx.flatten(), pvy.flatten(), np.zeros(nvtx)]).T,
-        rmat.T
-    ) + tvec
-
-    conn = cellConnectivity(rows, cols)
-
-    ret = np.empty(len(range(start, stop)), dtype=float)
-
-    for i, ipix in enumerate(range(start, stop)):
-        pix_conn = conn[ipix]
-        vtx_list = pcrd_array_full[pix_conn, :]
-        ret[i] = (_solid_angle_of_triangle(vtx_list[[0, 1, 2], :]) +
-                  _solid_angle_of_triangle(vtx_list[[2, 3, 0], :]))
-
-    return ret
-
-
-@memoize
-def _pixel_solid_angles(rows, cols, pixel_size_row, pixel_size_col,
-                        rmat, tvec, max_workers):
-    # connectivity array for pixels
-    conn = cellConnectivity(rows, cols)
-
-    # result
-    solid_angs = np.empty(len(conn), dtype=float)
-
-    # Distribute tasks to each process
-    tasks = distribute_tasks(len(conn), max_workers)
-    kwargs = {
-        'rows': rows,
-        'cols': cols,
-        'pixel_size_row': pixel_size_row,
-        'pixel_size_col': pixel_size_col,
-        'rmat': rmat,
-        'tvec': tvec,
-    }
-    func = partial(_generate_pixel_solid_angles, **kwargs)
-    with ProcessPoolExecutor(mp_context=ct.mp_context,
-                             max_workers=max_workers) as executor:
-        results = executor.map(func, tasks)
-
-    # Concatenate all the results together
-    solid_angs[:] = np.concatenate(list(results))
-    solid_angs = solid_angs.reshape(rows, cols)
-
-    return solid_angs

--- a/tests/test_pixel_solid_angles.py
+++ b/tests/test_pixel_solid_angles.py
@@ -1,0 +1,41 @@
+import importlib.resources
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+import pytest
+
+import hexrd.resources
+from hexrd.instrument.hedm_instrument import HEDMInstrument
+
+
+@pytest.fixture
+def tardis_instrument() -> HEDMInstrument:
+    path = importlib.resources.files(hexrd.resources).joinpath(
+        'tardis_reference_config.yml'
+    )
+    with open(path, 'r') as rf:
+        conf = yaml.safe_load(rf)
+
+    return HEDMInstrument(conf)
+
+
+@pytest.fixture
+def expected_pixel_solid_angles_results(
+    test_data_dir: Path,
+) -> dict[str, np.ndarray]:
+    path = test_data_dir / 'expected_pixel_solid_angles_results.npz'
+    return {k: v for k, v in np.load(path).items()}
+
+
+def test_pixel_solid_angles(
+    tardis_instrument: HEDMInstrument,
+    expected_pixel_solid_angles_results: np.ndarray,
+):
+    instr = tardis_instrument
+    ref = expected_pixel_solid_angles_results
+
+    assert sorted(instr.detectors.keys()) == sorted(ref.keys())
+    for det_key, panel in instr.detectors.items():
+        assert np.allclose(panel.pixel_solid_angles, ref[det_key])


### PR DESCRIPTION
Simplify the solid angle calculation using the first principle definition. For a surface of area, $\Delta$ at a location, $\mathbf{r}$ from the diffracting volume, the solid angle, $\mathrm{d}\Omega$ is given by:

$\mathrm{d}\Omega = \left(\frac{\Delta}{\vert \mathbf{r}\vert^{3}}\right)\mathbf{r}\cdot\hat{\mathbf{n}}$. 

$\hat{\mathbf{n}}$ is the local normal of the surface. Using this definition instead of summing over the areas of the triangle improves the speed by 2 orders of magnitude.
