### PR TITLE
Package hexrd using windows-latest

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
           }
         - {
             name: "Windows",
-            os: windows-2019
+            os: windows-latest
           }
     defaults:
       run:


### PR DESCRIPTION
windows-2019 will be fully unsupported on June 30. Let's migrate to windows-latest.