### PR TITLE
Skip nested metadata when writing out NPZ files

### DIFF
--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -6,6 +6,7 @@ import multiprocessing
 import os
 import threading
 import warnings
+import sys
 
 import numpy as np
 import h5py
@@ -266,6 +267,14 @@ class WriteFrameCache(Writer):
     def _process_meta(self, save_omegas=False):
         d = {}
         for k, v in list(self._meta.items()):
+            if isinstance(v, dict):
+                print(
+                    'WARNING: NPZ files do not support nested metadata. '
+                    f'The metadata key "{k}" will not be written out.',
+                    file=sys.stderr,
+                )
+                continue
+
             if isinstance(v, np.ndarray) and save_omegas:
                 # Save as a numpy array file
                 # if file does not exist (careful about directory)


### PR DESCRIPTION
NPZ files do not support nested metadata. When we write them out, they produce an NPZ file that requires `allow_pickle=True` to open, and we do not want to perform that within hexrd or the GUI for security reasons.

While saving an NPZ file, if we encounter a nested metadata item, print a warning that it will be skipped, and skip over it.