### PR TITLE
Liquid model wppf

### DIFF
--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -120,9 +120,9 @@ class LeBail:
 
         self.phases = phases
 
-        self.params = params
-
         self.amorphous_model = amorphous_model
+
+        self.params = params
 
         self.initialize_Icalc()
 
@@ -1342,7 +1342,8 @@ class LeBail:
                 self.phases,
                 self.peakshape,
                 self.bkgmethod,
-                init_val=self.cheb_init_coef
+                init_val=self.cheb_init_coef,
+                amorphous_model=self.amorphous_model
             )
             self._params = params
 
@@ -1487,6 +1488,9 @@ class LeBail:
             if updated_lp:
                 self.calctth()
 
+
+        if self.amorphous_model is not None:
+            if self.amorphous_model.model_type
 
 def _nm(x):
     return valWUnit("lp", "length", x, "nm")
@@ -2385,7 +2389,8 @@ class Rietveld:
                 self.phases,
                 self.peakshape,
                 self.bkgmethod,
-                init_val=self.cheb_init_coef
+                init_val=self.cheb_init_coef,
+                amorphous_model=self.amorphous_model
             )
             self._params = params
 

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1488,9 +1488,57 @@ class LeBail:
             if updated_lp:
                 self.calctth()
 
-
         if self.amorphous_model is not None:
-            if self.amorphous_model.model_type
+            scale = {}
+            shift = {}
+            center = {}
+            fwhm = {}
+            for key in self.amorphous_model.scale:
+                nn = f'{key}_amorphous_scale'
+                if nn in params:
+                    scale[key] = params[nn].value
+                else:
+                    scale[key] = self.amorphous_model.scale[key]
+
+                if self.amorphous_model.model_type == "experimental":
+                    nn = f'{key}_amorphous_shift'
+                    if nn in params:
+                        shift[key] = params[nn].value
+                    else:
+                        shift[key] = self.amorphous_model.shift[key]
+
+                elif self.amorphous_model.model_type == "split_gaussian":
+                    nn = f'{key}_amorphous_center'
+                    if nn in params:
+                        center[key] = params[nn].value
+                    else:
+                        center[key] = self.amorphous_model.center[key]
+
+                    nnl = f'{key}_amorphous_fwhm_l'
+                    if nnl in params:
+                        fwhm_l = params[nnl].value
+                    else:
+                        fwhm_l = self.amorphous_model.fwhm[key][0]
+
+                    nnr = f'{key}_amorphous_fwhm_r'
+                    if nnr in params:
+                        fwhm_r = params[nnr].value
+                    else:
+                        fwhm_r = self.amorphous_model.fwhm[key][1]
+
+                    fwhm[key] = np.array([fwhm_l,
+                                          fwhm_r
+                                          ])
+
+            self.amorphous_model.scale = scale
+
+            if self.amorphous_model.model_type == "experimental":
+                self.amorphous_model.shift = shift
+
+            elif self.amorphous_model.model_type == "split_gaussian":
+                self.amorphous_model.center = center
+                self.amorphous_model.fwhm = fwhm
+
 
 def _nm(x):
     return valWUnit("lp", "length", x, "nm")
@@ -2267,6 +2315,57 @@ class Rietveld:
                     self.calcsf()
 
             self.phases.phase_fraction = pf/np.sum(pf)
+
+        if self.amorphous_model is not None:
+            scale = {}
+            shift = {}
+            center = {}
+            fwhm = {}
+            for key in self.amorphous_model.scale:
+                nn = f'{key}_amorphous_scale'
+                if nn in params:
+                    scale[key] = params[nn].value
+                else:
+                    scale[key] = self.amorphous_model.scale[key]
+
+                if self.amorphous_model.model_type == "experimental":
+                    nn = f'{key}_amorphous_shift'
+                    if nn in params:
+                        shift[key] = params[nn].value
+                    else:
+                        shift[key] = self.amorphous_model.shift[key]
+
+                elif self.amorphous_model.model_type == "split_gaussian":
+                    nn = f'{key}_amorphous_center'
+                    if nn in params:
+                        center[key] = params[nn].value
+                    else:
+                        center[key] = self.amorphous_model.center[key]
+
+                    nnl = f'{key}_amorphous_fwhm_l'
+                    if nnl in params:
+                        fwhm_l = params[nnl].value
+                    else:
+                        fwhm_l = self.amorphous_model.fwhm[key][0]
+
+                    nnr = f'{key}_amorphous_fwhm_r'
+                    if nnr in params:
+                        fwhm_r = params[nnr].value
+                    else:
+                        fwhm_r = self.amorphous_model.fwhm[key][1]
+
+                    fwhm[key] = np.array([fwhm_l,
+                                          fwhm_r
+                                          ])
+
+            self.amorphous_model.scale = scale
+
+            if self.amorphous_model.model_type == "experimental":
+                self.amorphous_model.shift = shift
+
+            elif self.amorphous_model.model_type == "split_gaussian":
+                self.amorphous_model.center = center
+                self.amorphous_model.fwhm = fwhm
 
     def _update_shkl(self, params):
         """

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -513,7 +513,7 @@ class LeBail:
                 y += self.computespectrum_fcn(*args)
 
         if self.amorphous_model is not None:
-            y += self.amorphous_model.amorphous_lienout
+            y += self.amorphous_model.amorphous_lineout
 
         self._spectrum_sim = Spectrum(x=x, y=y)
 
@@ -2042,7 +2042,7 @@ class Rietveld:
                 y += self.computespectrum_fcn(*args)
 
         if self.amorphous_model is not None:
-            y += self.amorphous_model.amorphous_lienout
+            y += self.amorphous_model.amorphous_lineout
 
         self._spectrum_sim = Spectrum(x=x, y=y)
 

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1539,6 +1539,19 @@ class LeBail:
                 self.amorphous_model.center = center
                 self.amorphous_model.fwhm = fwhm
 
+    @property
+    def DOC(self):
+        if self.amorphous_model is None:
+            return 1.
+        else:
+            tth, intensity   = self.spectrum_sim.data
+            _, background    = self.background.data
+            crystalline_intensity = intensity-background
+            amorphous_area = \
+                self.amorphous_model.integrated_area
+            return 1. - amorphous_area/np.trapz(
+                        crystalline_intensity, tth)
+
 
 def _nm(x):
     return valWUnit("lp", "length", x, "nm")
@@ -3078,6 +3091,20 @@ class Rietveld:
     @eta_fwhm.setter
     def eta_fwhm(self, val):
         self._eta_fwhm = val
+
+    @property
+    def DOC(self):
+        if self.amorphous_model is None:
+            return 1.
+        else:
+            tth, intensity   = self.spectrum_sim.data
+            _, background    = self.background.data
+            crystalline_intensity = intensity-background
+            amorphous_area = \
+                self.amorphous_model.integrated_area
+            return 1. - amorphous_area/np.trapz(
+                        crystalline_intensity, tth)
+
 
 
 def calc_num_variables(params):

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1577,13 +1577,13 @@ class LeBail:
         if self.amorphous_model is None:
             return 1.
         else:
-            tth, intensity   = self.spectrum_sim.data
+            tth, intensity   = self.spectrum_expt.data
             _, background    = self.background.data
-            crystalline_intensity = intensity-background
+            total_intensity = intensity-background
             amorphous_area = \
                 self.amorphous_model.integrated_area
             return 1. - amorphous_area/np.trapz(
-                        crystalline_intensity, tth)
+                        total_intensity, tth)
 
 
 def _nm(x):
@@ -3162,15 +3162,13 @@ class Rietveld:
         if self.amorphous_model is None:
             return 1.
         else:
-            tth, intensity   = self.spectrum_sim.data
+            tth, intensity   = self.spectrum_expt.data
             _, background    = self.background.data
-            crystalline_intensity = intensity-background
+            total_intensity = intensity-background
             amorphous_area = \
                 self.amorphous_model.integrated_area
             return 1. - amorphous_area/np.trapz(
-                        crystalline_intensity, tth)
-
-
+                        total_intensity, tth)
 
 def calc_num_variables(params):
     P = 0

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -103,6 +103,7 @@ class LeBail:
         bkgmethod={"spline": None},
         intensity_init=None,
         peakshape="pvfcj",
+        amorphous_model=None,
     ):
 
         self.peakshape = peakshape
@@ -120,6 +121,8 @@ class LeBail:
         self.phases = phases
 
         self.params = params
+
+        self.amorphous_model = amorphous_model
 
         self.initialize_Icalc()
 
@@ -508,6 +511,9 @@ class LeBail:
                     )
 
                 y += self.computespectrum_fcn(*args)
+
+        if self.amorphous_model is not None:
+            y += self.amorphous_model.amorphous_lienout
 
         self._spectrum_sim = Spectrum(x=x, y=y)
 
@@ -1676,6 +1682,7 @@ class Rietveld:
         shape_factor=1.0,
         particle_size=1.0,
         phi=0.0,
+        amorphous_model=None,
     ):
 
         self.bkgmethod = bkgmethod
@@ -1684,6 +1691,7 @@ class Rietveld:
         self.phi = phi
         self.peakshape = peakshape
         self.spectrum_expt = expt_spectrum
+        self.amorphous_model = amorphous_model
 
         self._tstart = time.time()
 
@@ -2032,6 +2040,9 @@ class Rietveld:
                     )
 
                 y += self.computespectrum_fcn(*args)
+
+        if self.amorphous_model is not None:
+            y += self.amorphous_model.amorphous_lienout
 
         self._spectrum_sim = Spectrum(x=x, y=y)
 

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1507,13 +1507,15 @@ class LeBail:
                     else:
                         shift[key] = self.amorphous_model.shift[key]
 
-                elif self.amorphous_model.model_type == "split_gaussian":
+                elif self.amorphous_model.model_type in ["split_gaussian",
+                                                     "split_pv"]:
                     nn = f'{key}_amorphous_center'
                     if nn in params:
                         center[key] = params[nn].value
                     else:
                         center[key] = self.amorphous_model.center[key]
 
+                if self.amorphous_model.model_type == "split_gaussian":
                     nnl = f'{key}_amorphous_fwhm_l'
                     if nnl in params:
                         fwhm_l = params[nnl].value
@@ -1529,13 +1531,44 @@ class LeBail:
                     fwhm[key] = np.array([fwhm_l,
                                           fwhm_r
                                           ])
+                elif self.amorphous_model.model_type == "split_pv":
+                    nnl = f'{key}_amorphous_fwhm_g_l'
+                    if nnl in params:
+                        fwhm_g_l = params[nnl].value
+                    else:
+                        fwhm_g_l = self.amorphous_model.fwhm[key][0]
+
+                    nnl = f'{key}_amorphous_fwhm_l_l'
+                    if nnl in params:
+                        fwhm_l_l = params[nnl].value
+                    else:
+                        fwhm_l_l = self.amorphous_model.fwhm[key][1]
+
+                    nnr = f'{key}_amorphous_fwhm_g_r'
+                    if nnr in params:
+                        fwhm_g_r = params[nnr].value
+                    else:
+                        fwhm_g_r = self.amorphous_model.fwhm[key][2]
+
+                    nnr = f'{key}_amorphous_fwhm_l_r'
+                    if nnr in params:
+                        fwhm_l_r = params[nnr].value
+                    else:
+                        fwhm_l_r = self.amorphous_model.fwhm[key][3]
+
+                    fwhm[key] = np.array([fwhm_g_l,
+                                          fwhm_l_l,
+                                          fwhm_g_r,
+                                          fwhm_l_r
+                                          ])
 
             self.amorphous_model.scale = scale
 
             if self.amorphous_model.model_type == "experimental":
                 self.amorphous_model.shift = shift
 
-            elif self.amorphous_model.model_type == "split_gaussian":
+            elif self.amorphous_model.model_type in ["split_gaussian",
+                                                     "split_pv"]:
                 self.amorphous_model.center = center
                 self.amorphous_model.fwhm = fwhm
 
@@ -2348,13 +2381,15 @@ class Rietveld:
                     else:
                         shift[key] = self.amorphous_model.shift[key]
 
-                elif self.amorphous_model.model_type == "split_gaussian":
+                elif self.amorphous_model.model_type in ["split_gaussian",
+                                                     "split_pv"]:
                     nn = f'{key}_amorphous_center'
                     if nn in params:
                         center[key] = params[nn].value
                     else:
                         center[key] = self.amorphous_model.center[key]
 
+                if self.amorphous_model.model_type == "split_gaussian":
                     nnl = f'{key}_amorphous_fwhm_l'
                     if nnl in params:
                         fwhm_l = params[nnl].value
@@ -2369,6 +2404,36 @@ class Rietveld:
 
                     fwhm[key] = np.array([fwhm_l,
                                           fwhm_r
+                                          ])
+                elif self.amorphous_model.model_type == "split_pv":
+                    nnl = f'{key}_amorphous_fwhm_g_l'
+                    if nnl in params:
+                        fwhm_g_l = params[nnl].value
+                    else:
+                        fwhm_g_l = self.amorphous_model.fwhm[key][0]
+
+                    nnl = f'{key}_amorphous_fwhm_l_l'
+                    if nnl in params:
+                        fwhm_l_l = params[nnl].value
+                    else:
+                        fwhm_l_l = self.amorphous_model.fwhm[key][1]
+
+                    nnr = f'{key}_amorphous_fwhm_g_r'
+                    if nnr in params:
+                        fwhm_g_r = params[nnr].value
+                    else:
+                        fwhm_g_r = self.amorphous_model.fwhm[key][2]
+
+                    nnr = f'{key}_amorphous_fwhm_l_r'
+                    if nnr in params:
+                        fwhm_l_r = params[nnr].value
+                    else:
+                        fwhm_l_r = self.amorphous_model.fwhm[key][3]
+
+                    fwhm[key] = np.array([fwhm_g_l,
+                                          fwhm_l_l,
+                                          fwhm_g_r,
+                                          fwhm_l_r
                                           ])
 
             self.amorphous_model.scale = scale

--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1507,7 +1507,7 @@ class LeBail:
                     else:
                         shift[key] = self.amorphous_model.shift[key]
 
-                elif self.amorphous_model.model_type in ["split_gaussian",
+                if self.amorphous_model.model_type in ["split_gaussian",
                                                      "split_pv"]:
                     nn = f'{key}_amorphous_center'
                     if nn in params:
@@ -2381,7 +2381,7 @@ class Rietveld:
                     else:
                         shift[key] = self.amorphous_model.shift[key]
 
-                elif self.amorphous_model.model_type in ["split_gaussian",
+                if self.amorphous_model.model_type in ["split_gaussian",
                                                      "split_pv"]:
                     nn = f'{key}_amorphous_center'
                     if nn in params:
@@ -2441,7 +2441,9 @@ class Rietveld:
             if self.amorphous_model.model_type == "experimental":
                 self.amorphous_model.shift = shift
 
-            elif self.amorphous_model.model_type == "split_gaussian":
+
+            elif self.amorphous_model.model_type in ["split_gaussian",
+                                                     "split_pv"]:
                 self.amorphous_model.center = center
                 self.amorphous_model.fwhm = fwhm
 

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -13,17 +13,17 @@ class Amorphous:
                     saransh1@llnl.gov
     >> @DATE:       06/09/2025 SS 1.0 original
     >> @DETAILS:    amorphous class can be used to include a
-                    broad, diffuse signal in the Rietveld 
+                    broad, diffuse signal in the Rietveld
                     refinement. The primary purpose is to
                     extract an approximate solid/liquid phase
-                    fraction. This is best used for solid and 
+                    fraction. This is best used for solid and
                     liquid coming from materials with the same
                     chemistry. The technique is most similar to
                     degree of crystallinity (DOC) as documented
-                    in 
+                    in
                     Dinnebier and Kern,
                     "Quantification of amorphous phases - theory",
-                    PPXRD-13 workshop, Quantitative phase analysis 
+                    PPXRD-13 workshop, Quantitative phase analysis
                     by XRPD (2015)
 
     Attributes
@@ -34,8 +34,8 @@ class Amorphous:
         an experimentally measured lineoiut of the amorphous phase
 
     model_data: numpy.ndarray
-        if the "experimental model type is used, then model_data 
-        is a numpy array containing the 2theta-intensity of the 
+        if the "experimental model type is used, then model_data
+        is a numpy array containing the 2theta-intensity of the
         measured amorphous signal. the signal in model_data will
         be shifted and scaled to get the best fit with the observed
         data."
@@ -53,11 +53,12 @@ class Amorphous:
                  tth_list,
                  model_type='split_gaussian',
                  model_data=None,
-                 scale={'c1':1.},
-                 shift={'c1':0.},
+                 scale=None,
+                 shift=None,
                  smoothing=0,
-                 center={'c1': 30.},
-                 fwhm={'c1': np.array([5, 5])}):
+                 center=None,
+                 fwhm=None
+        ):
         '''
         Parameters
         ----------
@@ -68,13 +69,13 @@ class Amorphous:
         model_type: str
             type of model to use for amorphous peak.
             this could be a predefined model such as
-            "split_pv", or an experimentally measured 
+            "split_pv", or an experimentally measured
             pattern "experimental"
 
         model_data: numpy.ndarray, optional
             if the model is "experimental", then this
             optional array input is used as the model
-            for amporphous peak. this model will be 
+            for amporphous peak. this model will be
             shifted and scaled to minimize the difference
             between observed and calculated intensities
 
@@ -94,19 +95,32 @@ class Amorphous:
             should have same keys as scale
 
         fwhm: dict
-            dictionary of arrays of shape [2,] with 
-            [fwhm_l, fwhm_r] of the two halves for gaussian peak. 
+            dictionary of arrays of shape [2,] with
+            [fwhm_l, fwhm_r] of the two halves for gaussian peak.
             for pseudo-voight peaks, shape is [4,] with entries for
             [fwhm_g_l, fwhm_l_l, fwhm_g_r, fwhm_l_r].
             should have same keys as scale
         '''
+
+        if scale is None:
+            scale = {'c1':1.}
+
+        if shift is None:
+            shift = {'c1':0.}
+
+        if center is None:
+            center = {'c1': 30.}
+
+        if fwhm is None:
+            fwhm = {'c1': np.array([5, 5])}
+
         self.tth_list = tth_list
 
         self.model_type = model_type
         self.model_data = model_data
 
         self.scale = scale
-        
+
         self._shift = shift
         self._smoothing = smoothing
 
@@ -116,7 +130,7 @@ class Amorphous:
     @property
     def model_type(self):
         return self._model_type
-    
+
     @model_type.setter
     def model_type(self, mtype):
         if mtype.lower() in ["split_pv",
@@ -272,7 +286,7 @@ class Amorphous:
                                    self.model_data[key],
                                    self.smoothing
                                    )
-                
+
                 lo  += self.scale[key]*np.interp(
                                     self.tth_list,
                                     self.tth_list+self.shift[key],

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -245,7 +245,14 @@ class Amorphous:
         if self.model_type in ["split_gaussian",
                                "split_pv"]:
             if isinstance(val, dict):
-                self._fwhm = val
+                if self.model_type == "split_gaussian":
+                    if val.size==2:
+                        self._fwhm = val
+                elif self.model_type == "split_pv":
+                    if val.size==4:
+                        self._fwhm = val
+                else:
+                    msg = (f'incompatible fwhm size')
             else:
                 msg = f'fwhm should be passed as a dictionary'
                 raise ValueError(msg)

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -47,7 +47,10 @@ class Amorphous:
     '''
     def __init__(self,
                  model_type='split_pv',
-                 model_data=None):
+                 model_data=None,
+                 scale=None,
+                 shift=None,
+                 smoothing=None,):
         '''
         Parameters
         ----------

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -245,7 +245,7 @@ class Amorphous:
         if self.model_type in ["split_gaussian",
                                "split_pv"]:
             if isinstance(val, dict):
-                sizes = [val[k] for k in val]
+                sizes = np.array([val[k].size for k in val])
                 if self.model_type == "split_gaussian":
                     if np.all(sizes==2):
                         self._fwhm = val

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -242,7 +242,7 @@ class Amorphous:
     def fwhm(self, val):
         if self.model_type in ["split_gaussian",
                                "split_pv"]:
-            if isinstance(fwhm, dict):
+            if isinstance(val, dict):
                 self._fwhm = val
             else:
                 msg = f'fwhm should be passed as a dictionary'

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -1,6 +1,10 @@
 import numpy as np
 import warnings
 from scipy.interpolate import CubicSpline
+from scipy.ndimage import gaussian_filter
+from hexrd.wppf.peakfunctions import (
+    _split_unit_gaussian as sp_gauss)
+    #_split_unit_pv as sp_pv)
 
 class Amorphous:
     '''
@@ -46,14 +50,21 @@ class Amorphous:
         much (if any) gaussian smoothing to apply to the lineout
     '''
     def __init__(self,
-                 model_type='split_pv',
+                 tth_list,
+                 model_type='split_gaussian',
                  model_data=None,
-                 scale=None,
-                 shift=None,
-                 smoothing=None,):
+                 scale=1.,
+                 shift=0.,
+                 smoothing=0,
+                 center=30.,
+                 fwhm=np.array([5, 5])):
         '''
         Parameters
         ----------
+        tth_list: numpy.ndarray
+            list of two-theta values for which amorphous
+            intensity is computed
+
         model_type: str
             type of model to use for amorphous peak.
             this could be a predefined model such as
@@ -66,35 +77,167 @@ class Amorphous:
             for amporphous peak. this model will be 
             shifted and scaled to minimize the difference
             between observed and calculated intensities
+
+        scale: float
+            scaling factor for the experimentally measured
+            signal
+
+        shift: float
+            shift in two-theta for the experimental signal
+            to match the observations
+
+        smoothing: int
+            width of gaussian kernel smoothing function
+
+        center: float
+            center of split gaussian or pseudo-voight function
+
+        fwhm: numpy.ndarray
+            array of shape [2,] with [fwhm_l, fwhm_r] of the 
+            two halves
         '''
+        self.tth_list = tth_list
 
         self.model_type = model_type
         self.model_data = model_data
 
-        @property
-        def model_type(self):
-            return self._model_type
+        self.scale = scale
         
-        @model_type.setter
-        def model_type(self, mtype):
-            if mtype.lower() in ["split_pv",
-                                 "split_gaussian",
-                                 "experimental"]:
-                self._model_type = mtype
-            else:
-                msg = (f'{mtype} is an unknown model type')
-                raise ValueError(msg)
+        self._shift = shift
+        self._smoothing = smoothing
 
+        self._center = center
+        self._fwhm = fwhm
+
+    @property
+    def model_type(self):
+        return self._model_type
+    
+    @model_type.setter
+    def model_type(self, mtype):
+        if mtype.lower() in ["split_pv",
+                             "split_gaussian",
+                             "experimental"]:
+            self._model_type = mtype
+        else:
+            msg = (f'{mtype} is an unknown model type')
+            raise ValueError(msg)
+
+    @property
+    def tth_list(self):
+        return self._tth_list
+
+    @tth_list.setter
+    def tth_list(self, val):
+        if isinstance(val, np.ndarray):
+            self._tth_list = val
+        elif isinstance(val, (list, tuple)):
+            self._tth_list = np.array(val)
+        else:
+            msg = f'{type(val)} not supported for tth_list'
+            raise ValueError(msg)
+
+    @property
+    def model_data(self):
+        return self._model_data
+
+    @model_data.setter
+    def model_data(self, data):
         if self.model_type.lower() == "experimental":
-            if model_data is not None:
-                self.model_data = model_data
+            if data is not None:
+                self._model_data = data
             else:
                 msg = (f'experimental model is being used. '
-                       f'Please supply the data array')
+                       f'please supply the data array')
                 raise ValueError(msg)
         else:
-            if model_data is not None:
+            if data is not None:
                 msg = (f'model data supplied will be ignored'
-                       f'for model type {mtype}.')
+                       f'for model type {self.model_type}')
                 warnings.warn(msg)
 
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, val):
+        self._scale = val
+
+    @property
+    def shift(self):
+        if self.model_type == "experimental":
+            return self._shift
+        return None
+
+    @shift.setter
+    def shift(self, val):
+        if self.model_type == "experimental":
+            self._shift = val
+        else:
+            msg = (f'can not set shift for '
+                   f'model_type {self.model_type}')
+            warnings.warn(msg)
+
+    @property
+    def smoothing(self):
+        if self.model_type == "experimental":
+            return self._smoothing
+        return None
+
+    @smoothing.setter
+    def smoothing(self, val):
+        if self.model_type == "experimental":
+            self._smoothing = val
+        else:
+            msg = (f'can not set smoothing for '
+                   f'model_type {self.model_type}')
+            warnings.warn(msg)
+
+    @property
+    def center(self):
+        if self.model_type in ["split_gaussian",
+                               "split_pv"]:
+            return self._center
+
+        return None
+
+    @center.setter
+    def center(self, val):
+        if self.model_type in ["split_gaussian",
+                               "split_pv"]:
+            self._center = val
+        else:
+            msg = (f'can not set center for '
+                   f'model_type {self.model_type}')
+            warnings.warn(msg)
+
+    @property
+    def fwhm(self):
+        if self.model_type in ["split_gaussian",
+                               "split_pv"]:
+            return self._fwhm
+
+        return None
+
+    @fwhm.setter
+    def fwhm(self, val):
+        if self.model_type in ["split_gaussian",
+                               "split_pv"]:
+            self._fwhm = val
+        else:
+            msg = (f'can not set fwhm for '
+                   f'model_type {self.model_type}')
+            warnings.warn(msg)
+
+    @property
+    def amorphous_lineout(self):
+        if self.model_type == "experimental":
+            return self.scale*gaussian_filter(
+                                   self.model_data,
+                                   self.smoothing
+                                   )
+        elif self.model_type == "split_gaussian":
+            p = np.hstack((self.center,
+                           self.fwhm))
+            return self.scale*sp_gauss(p, self.tth_list)

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -1,0 +1,97 @@
+import numpy as np
+import warnings
+from scipy.interpolate import CubicSpline
+
+class Amorphous:
+    '''
+    >> @AUTHOR:     Saransh Singh,
+                    Lawrence Livermore National Lab,
+                    saransh1@llnl.gov
+    >> @DATE:       06/09/2025 SS 1.0 original
+    >> @DETAILS:    amorphous class can be used to include a
+                    broad, diffuse signal in the Rietveld 
+                    refinement. The primary purpose is to
+                    extract an approximate solid/liquid phase
+                    fraction. This is best used for solid and 
+                    liquid coming from materials with the same
+                    chemistry. The technique is most similar to
+                    degree of crystallinity (DOC) as documented
+                    in 
+                    Dinnebier and Kern,
+                    "Quantification of amorphous phases - theory",
+                    PPXRD-13 workshop, Quantitative phase analysis 
+                    by XRPD (2015)
+
+    Attributes
+    ----------
+    model_type : str
+        allowed model types are "split_pv" for split pseudo-voight
+        "split_gaussian" for split gaussian and "experimental" for
+        an experimentally measured lineoiut of the amorphous phase
+
+    model_data: numpy.ndarray
+        if the "experimental model type is used, then model_data 
+        is a numpy array containing the 2theta-intensity of the 
+        measured amorphous signal. the signal in model_data will
+        be shifted and scaled to get the best fit with the observed
+        data."
+
+    scale: if model is "experimental", then this quantifies the
+        scale factor. otherwise, not present
+
+    shift: if model is "experimental", then this quantifies the
+        shift in 2theta. otherwise, not present
+
+    smoothing: if model is "experimental", then this specifies how
+        much (if any) gaussian smoothing to apply to the lineout
+    '''
+    def __init__(self,
+                 model_type='split_pv',
+                 model_data=None):
+        '''
+        Parameters
+        ----------
+        model_type: str
+            type of model to use for amorphous peak.
+            this could be a predefined model such as
+            "split_pv", or an experimentally measured 
+            pattern "experimental"
+
+        model_data: numpy.ndarray, optional
+            if the model is "experimental", then this
+            optional array input is used as the model
+            for amporphous peak. this model will be 
+            shifted and scaled to minimize the difference
+            between observed and calculated intensities
+        '''
+
+        self.model_type = model_type
+        self.model_data = model_data
+
+        @property
+        def model_type(self):
+            return self._model_type
+        
+        @model_type.setter
+        def model_type(self, mtype):
+            if mtype.lower() in ["split_pv",
+                                 "split_gaussian",
+                                 "experimental"]:
+                self._model_type = mtype
+            else:
+                msg = (f'{mtype} is an unknown model type')
+                raise ValueError(msg)
+
+        if self.model_type.lower() == "experimental":
+            if model_data is not None:
+                self.model_data = model_data
+            else:
+                msg = (f'experimental model is being used. '
+                       f'Please supply the data array')
+                raise ValueError(msg)
+        else:
+            if model_data is not None:
+                msg = (f'model data supplied will be ignored'
+                       f'for model type {mtype}.')
+                warnings.warn(msg)
+

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -245,11 +245,12 @@ class Amorphous:
         if self.model_type in ["split_gaussian",
                                "split_pv"]:
             if isinstance(val, dict):
+                sizes = [val[k] for k in val]
                 if self.model_type == "split_gaussian":
-                    if val.size==2:
+                    if np.all(sizes==2):
                         self._fwhm = val
                 elif self.model_type == "split_pv":
-                    if val.size==4:
+                    if np.all(sizes==4):
                         self._fwhm = val
                 else:
                     msg = (f'incompatible fwhm size')

--- a/hexrd/wppf/texture.py
+++ b/hexrd/wppf/texture.py
@@ -35,7 +35,7 @@ import hexrd.resources
     precompute the values of k_l^m(y) and we already know what the reflections
     are so k_l^m(h) can also be pre-computed.
 
->> @PARAMETERS:  ymmetry symmetry of the mesh
+>> @PARAMETERS: symmetry of the mesh
 ===============================================================================
 """
 

--- a/hexrd/wppf/wppfsupport.py
+++ b/hexrd/wppf/wppfsupport.py
@@ -146,7 +146,7 @@ def _add_chebyshev_background(params,
     """
     add coefficients for chebyshev background
     polynomial. The initial values will be the
-    same as determined by WPPF.chebyshevfit 
+    same as determined by WPPF.chebyshevfit
     routine
     """
     for d in range(degree+1):
@@ -171,7 +171,7 @@ def _add_stacking_fault_parameters(params,
     """
     phase_name = mat.name
     if mat.sgnum == 225:
-        sf_alpha_name = f"{phase_name}_sf_alpha" 
+        sf_alpha_name = f"{phase_name}_sf_alpha"
         twin_beta_name = f"{phase_name}_twin_beta"
         if isinstance(params, Parameters):
             params.add(sf_alpha_name, value=0., lb=0.,
@@ -363,7 +363,7 @@ def _add_atominfo_to_params(params, mat):
                     min=0.0, max=np.inf,
                     vary=False)
 
-def _generate_default_parameters_amoprhous_model(
+def _generate_default_parameters_amorphous_model(
                                         params,
                                         amorphous_model):
     '''
@@ -372,155 +372,84 @@ def _generate_default_parameters_amoprhous_model(
     if amorphous_model is None:
         return
 
-    for key in amorphous_model.scale:
-        nn = f'{key}_amorphous_scale'
+    # Use 'min' and 'max' below, and automatically convert to
+    # 'lb' and 'ub' if needed.
+    def convert(**kwargs):
         if isinstance(params, Parameters):
-            params.add(
-                nn, 
-                value=amorphous_model.scale[key],
-                lb=0,
-                ub=np.inf,
-                vary=False)
-        elif isinstance(params, Parameters_lmfit):
-            params.add(
-                nn, 
-                value=amorphous_model.scale[key],
-                min=0,
-                max=np.inf,
-                vary=False)
+            kwargs['lb'] = kwargs.pop('min')
+            kwargs['ub'] = kwargs.pop('max')
+        return kwargs
+
+
+    for key in amorphous_model.scale:
+        params.add(f'{key}_amorphous_scale', **convert(
+            value=amorphous_model.scale[key],
+            min=0,
+            max=np.inf,
+            vary=False,
+        ))
 
         if amorphous_model.model_type == "experimental":
-            nn = f'{key}_amorphous_shift'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.shift[key],
-                    lb=-np.inf,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.shift[key],
-                    min=-np.inf,
-                    max=np.inf,
-                    vary=False)
-
-        elif amorphous_model.model_type in ["split_gaussian",
-                                            "split_pv"]:
-            nn = f'{key}_amorphous_center'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.center[key],
-                    lb=-np.inf,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.center[key],
-                    min=-np.inf,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_shift', **convert(
+                value=amorphous_model.shift[key],
+                min=-np.inf,
+                max=np.inf,
+                vary=False,
+            ))
+        else:
+            params.add(f'{key}_amorphous_center', **convert(
+                value=amorphous_model.center[key],
+                min=-np.inf,
+                max=np.inf,
+                vary=False,
+            ))
 
         if amorphous_model.model_type == "split_gaussian":
-            nn = f'{key}_amorphous_fwhm_l'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][0],
-                    lb=0,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][0],
-                    min=0,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_fwhm_l', **convert(
+                nn,
+                value=amorphous_model.fwhm[key][0],
+                min=0,
+                max=np.inf,
+                vary=False,
+            ))
 
-            nn = f'{key}_amorphous_fwhm_r'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][1],
-                    lb=0,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][1],
-                    min=0,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_fwhm_r', **convert(
+                nn,
+                value=amorphous_model.fwhm[key][1],
+                min=0,
+                max=np.inf,
+                vary=False,
+            ))
 
         elif amorphous_model.model_type == "split_pv":
-            nn = f'{key}_amorphous_fwhm_g_l'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][0],
-                    lb=0,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][0],
-                    min=0,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_fwhm_g_l', **convert(
+                value=amorphous_model.fwhm[key][0],
+                min=0,
+                max=np.inf,
+                vary=False,
+            ))
 
-            nn = f'{key}_amorphous_fwhm_l_l'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][1],
-                    lb=0,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][1],
-                    min=0,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_fwhm_l_l', **convert(
+                value=amorphous_model.fwhm[key][1],
+                min=0,
+                max=np.inf,
+                vary=False,
+            ))
 
-            nn = f'{key}_amorphous_fwhm_g_r'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][2],
-                    lb=0,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][2],
-                    min=0,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_fwhm_g_r', **convert(
+                value=amorphous_model.fwhm[key][2],
+                min=0,
+                max=np.inf,
+                vary=False,
+            ))
 
-            nn = f'{key}_amorphous_fwhm_l_r'
-            if isinstance(params, Parameters):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][3],
-                    lb=0,
-                    ub=np.inf,
-                    vary=False)
-            elif isinstance(params, Parameters_lmfit):
-                params.add(
-                    nn, 
-                    value=amorphous_model.fwhm[key][3],
-                    min=0,
-                    max=np.inf,
-                    vary=False)
+            params.add(f'{key}_amorphous_fwhm_l_r', **convert(
+                value=amorphous_model.fwhm[key][3],
+                min=0,
+                max=np.inf,
+                vary=False,
+            ))
+
 
 def _generate_default_parameters_LeBail(mat,
                                         peakshape,
@@ -610,7 +539,7 @@ def _generate_default_parameters_LeBail(mat,
             _add_Shkl_terms(params, m)
             _add_lp_to_params(params, m)
             _add_stacking_fault_parameters(params, m)
-            
+
     elif isinstance(mat, dict):
         """
         dictionary of materials class
@@ -626,8 +555,8 @@ def _generate_default_parameters_LeBail(mat,
                f"Material is accpeted.")
         raise ValueError(msg)
 
-    _generate_default_parameters_amoprhous_model(params,
-                                                amorphous_model)
+    _generate_default_parameters_amorphous_model(params,
+                                                 amorphous_model)
 
     return params
 

--- a/hexrd/wppf/wppfsupport.py
+++ b/hexrd/wppf/wppfsupport.py
@@ -406,15 +406,16 @@ def _generate_default_parameters_amoprhous_model(
                     max=np.inf,
                     vary=False)
 
-        elif amorphous_model.model_type == "split_gaussian":
+        elif amorphous_model.model_type in ["split_gaussian",
+                                            "split_pv"]:
             nn = f'{key}_amorphous_center'
             if isinstance(params, Parameters):
-                    params.add(
-                        nn, 
-                        value=amorphous_model.center[key],
-                        lb=-np.inf,
-                        ub=np.inf,
-                        vary=False)
+                params.add(
+                    nn, 
+                    value=amorphous_model.center[key],
+                    lb=-np.inf,
+                    ub=np.inf,
+                    vary=False)
             elif isinstance(params, Parameters_lmfit):
                 params.add(
                     nn, 
@@ -423,14 +424,15 @@ def _generate_default_parameters_amoprhous_model(
                     max=np.inf,
                     vary=False)
 
+        if amorphous_model.model_type == "split_gaussian":
             nn = f'{key}_amorphous_fwhm_l'
             if isinstance(params, Parameters):
-                    params.add(
-                        nn, 
-                        value=amorphous_model.fwhm[key][0],
-                        lb=0,
-                        ub=np.inf,
-                        vary=False)
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][0],
+                    lb=0,
+                    ub=np.inf,
+                    vary=False)
             elif isinstance(params, Parameters_lmfit):
                 params.add(
                     nn, 
@@ -441,16 +443,81 @@ def _generate_default_parameters_amoprhous_model(
 
             nn = f'{key}_amorphous_fwhm_r'
             if isinstance(params, Parameters):
-                    params.add(
-                        nn, 
-                        value=amorphous_model.fwhm[key][1],
-                        lb=0,
-                        ub=np.inf,
-                        vary=False)
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][1],
+                    lb=0,
+                    ub=np.inf,
+                    vary=False)
             elif isinstance(params, Parameters_lmfit):
                 params.add(
                     nn, 
                     value=amorphous_model.fwhm[key][1],
+                    min=0,
+                    max=np.inf,
+                    vary=False)
+
+        elif amorphous_model.model_type == "split_pv":
+            nn = f'{key}_amorphous_fwhm_g_l'
+            if isinstance(params, Parameters):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][0],
+                    lb=0,
+                    ub=np.inf,
+                    vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][0],
+                    min=0,
+                    max=np.inf,
+                    vary=False)
+
+            nn = f'{key}_amorphous_fwhm_l_l'
+            if isinstance(params, Parameters):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][1],
+                    lb=0,
+                    ub=np.inf,
+                    vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][1],
+                    min=0,
+                    max=np.inf,
+                    vary=False)
+
+            nn = f'{key}_amorphous_fwhm_g_r'
+            if isinstance(params, Parameters):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][2],
+                    lb=0,
+                    ub=np.inf,
+                    vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][2],
+                    min=0,
+                    max=np.inf,
+                    vary=False)
+
+            nn = f'{key}_amorphous_fwhm_l_r'
+            if isinstance(params, Parameters):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][3],
+                    lb=0,
+                    ub=np.inf,
+                    vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][3],
                     min=0,
                     max=np.inf,
                     vary=False)

--- a/hexrd/wppf/wppfsupport.py
+++ b/hexrd/wppf/wppfsupport.py
@@ -362,11 +362,105 @@ def _add_atominfo_to_params(params, mat):
                     nn, value=mat.U[i],
                     min=0.0, max=np.inf,
                     vary=False)
+
+def _generate_default_parameters_amoprhous_model(
+                                        params,
+                                        amorphous_model):
+    '''
+    add refinement parameters for amorphous models
+    '''
+    if amorphous_model is None:
+        return
+
+    for key in amorphous_model.scale:
+        nn = f'{key}_amorphous_scale'
+        if isinstance(params, Parameters):
+            params.add(
+                nn, 
+                value=amorphous_model.scale[key],
+                lb=0,
+                ub=np.inf,
+                vary=False)
+        elif isinstance(params, Parameters_lmfit):
+            params.add(
+                nn, 
+                value=amorphous_model.scale[key],
+                min=0,
+                max=np.inf,
+                vary=False)
+
+        if amorphous_model.model_type == "experimental":
+            nn = f'{key}_amorphous_shift'
+            if isinstance(params, Parameters):
+                params.add(
+                    nn, 
+                    value=amorphous_model.shift[key],
+                    lb=-np.inf,
+                    ub=np.inf,
+                    vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.shift[key],
+                    min=-np.inf,
+                    max=np.inf,
+                    vary=False)
+
+        elif amorphous_model.model_type == "split_gaussian":
+            nn = f'{key}_amorphous_center'
+            if isinstance(params, Parameters):
+                    params.add(
+                        nn, 
+                        value=amorphous_model.center[key],
+                        lb=-np.inf,
+                        ub=np.inf,
+                        vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.center[key],
+                    min=-np.inf,
+                    max=np.inf,
+                    vary=False)
+
+            nn = f'{key}_amorphous_fwhm_l'
+            if isinstance(params, Parameters):
+                    params.add(
+                        nn, 
+                        value=amorphous_model.fwhm[key][0],
+                        lb=-np.inf,
+                        ub=np.inf,
+                        vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][0],
+                    min=-np.inf,
+                    max=np.inf,
+                    vary=False)
+
+            nn = f'{key}_amorphous_fwhm_r'
+            if isinstance(params, Parameters):
+                    params.add(
+                        nn, 
+                        value=amorphous_model.fwhm[key][1],
+                        lb=-np.inf,
+                        ub=np.inf,
+                        vary=False)
+            elif isinstance(params, Parameters_lmfit):
+                params.add(
+                    nn, 
+                    value=amorphous_model.fwhm[key][1],
+                    min=-np.inf,
+                    max=np.inf,
+                    vary=False)
+
 def _generate_default_parameters_LeBail(mat,
                                         peakshape,
                                         bkgmethod,
                                         init_val=None,
-                                        ptype="wppf"):
+                                        ptype="wppf",
+                                        amorphous_model=None):
     """
     @author:  Saransh Singh, Lawrence Livermore National Lab
     @date:    03/12/2021 SS 1.0 original
@@ -465,6 +559,9 @@ def _generate_default_parameters_LeBail(mat,
                f"Material is accpeted.")
         raise ValueError(msg)
 
+    _generate_default_parameters_amoprhous_model(params,
+                                                amorphous_model)
+
     return params
 
 def _add_phase_fractions(mat, params):
@@ -560,7 +657,8 @@ def _generate_default_parameters_Rietveld(mat,
                                           peakshape,
                                           bkgmethod,
                                           init_val=None,
-                                          ptype="wppf"):
+                                          ptype="wppf",
+                                          amorphous_model=None):
     """
     @author:  Saransh Singh, Lawrence Livermore National Lab
     @date:    03/12/2021 SS 1.0 original
@@ -571,7 +669,8 @@ def _generate_default_parameters_Rietveld(mat,
                                                  peakshape,
                                                  bkgmethod,
                                                  init_val,
-                                                 ptype=ptype)
+                                                 ptype=ptype,
+                                                 amorphous_model=amorphous_model)
 
     if ptype == "wppf":
         params.add(name="scale",

--- a/hexrd/wppf/wppfsupport.py
+++ b/hexrd/wppf/wppfsupport.py
@@ -428,14 +428,14 @@ def _generate_default_parameters_amoprhous_model(
                     params.add(
                         nn, 
                         value=amorphous_model.fwhm[key][0],
-                        lb=-np.inf,
+                        lb=0,
                         ub=np.inf,
                         vary=False)
             elif isinstance(params, Parameters_lmfit):
                 params.add(
                     nn, 
                     value=amorphous_model.fwhm[key][0],
-                    min=-np.inf,
+                    min=0,
                     max=np.inf,
                     vary=False)
 
@@ -444,14 +444,14 @@ def _generate_default_parameters_amoprhous_model(
                     params.add(
                         nn, 
                         value=amorphous_model.fwhm[key][1],
-                        lb=-np.inf,
+                        lb=0,
                         ub=np.inf,
                         vary=False)
             elif isinstance(params, Parameters_lmfit):
                 params.add(
                     nn, 
                     value=amorphous_model.fwhm[key][1],
-                    min=-np.inf,
+                    min=0,
                     max=np.inf,
                     vary=False)
 

--- a/tests/test_wppf_amorphous.py
+++ b/tests/test_wppf_amorphous.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from hexrd.material import load_materials_hdf5
+from hexrd.valunits import valWUnit
+from hexrd.wppf import LeBail, Rietveld
+from hexrd.wppf.amorphous import Amorphous
+
+
+@pytest.fixture
+def amorphous_examples_path(example_repo_path: Path) -> Path:
+    return Path(example_repo_path) / 'tests/wppf/amorphous'
+
+
+@pytest.fixture
+def amorphous_expt_spectrum(amorphous_examples_path: Path) -> np.ndarray:
+    return np.loadtxt(amorphous_examples_path / 'expt_spectrum.xy')
+
+
+@pytest.fixture
+def amorphous_materials_path(amorphous_examples_path: Path) -> Path:
+    return amorphous_examples_path / 'materials.h5'
+
+
+@pytest.fixture
+def wppf_amorphous_object(amorphous_expt_spectrum: np.ndarray) -> Amorphous:
+    tth_list = amorphous_expt_spectrum[:, 0]
+
+    '''the amorphous peak can be either "split_pv"
+    or split_gaussian. you can add more than one peak
+    in the amorphous model. if you need to have more than
+    one peak, you can pass the dictionary with more entries
+    e.g. center={'c1':36, 'c2':65}
+    fwhm is the full-width at half-max for the peaks. pseudo-voight
+    peaks need 4 numbers per peak e.g.
+
+    fwhm_g_l: fwhm gaussian left
+    fwhm_l_l: fwhm lorentzian left
+    fwhm_g_r: fwhm gaussian right
+    fwhm_l_r: fwhm lorentzian right
+
+    For split_gaussian we only have 2 per peak
+
+    fwhm_l: fwhm left
+    fwhm_r: fwhm right
+
+    '''
+    return Amorphous(
+        tth_list,
+        model_type="split_pv",
+        center={'c1': 36},
+        fwhm={'c1': np.array([3, 3, 5, 5])},
+        scale={'c1': 55},
+    )
+
+
+@pytest.fixture
+def wppf_amorphous_kwargs(amorphous_expt_spectrum: np.ndarray,
+                          wppf_amorphous_object: Amorphous,
+                          amorphous_materials_path: Path) -> dict:
+    lam = _nm(0.123957521)
+    dmin = _angstrom(0.5)
+    kev = _kev(10.00215218)
+
+    materials = load_materials_hdf5(
+        amorphous_materials_path,
+        dmin=dmin,
+        kev=kev,
+    )
+    Ti_amb = materials['Ti_ambient']
+    Ti_beta = materials['Ti_beta']
+
+    return {
+        "expt_spectrum": amorphous_expt_spectrum,
+        "phases": [Ti_amb, Ti_beta],
+        "wavelength": {
+            "lle": [lam, 1.0],
+        },
+        "bkgmethod": {"chebyshev": 2},
+        "peakshape": "pvtch",
+        "amorphous_model": wppf_amorphous_object,
+    }
+
+
+def _nm(x):
+    return valWUnit("lp", "LENGTH", x, "nm")
+
+
+def _angstrom(x):
+    return valWUnit("lp", "LENGTH", x, "angstrom")
+
+
+def _kev(x):
+    return valWUnit("accvoltage", "ENERGY", x, "keV")
+
+
+def test_wppf_amorphous_rietveld(wppf_amorphous_kwargs: dict):
+    obj = Rietveld(**wppf_amorphous_kwargs)
+    obj.scale = 1E-8
+
+    obj.params['scale'].vary = True
+
+    obj.Refine()
+
+    # After refining only the scale, the goodness of fit and chi squared
+    # shouldn't be that great.
+    assert obj.Rwp > 0.1
+    assert obj.gofF > 0.5
+
+    # we can refine some parameters here
+    obj.params['c1_amorphous_scale'].vary = True
+    obj.params['c1_amorphous_center'].vary = True
+
+    obj.Refine()
+
+    obj.params['scale'].vary = False
+
+    obj.params['c1_amorphous_fwhm_g_l'].vary = True
+    obj.params['c1_amorphous_fwhm_l_l'].vary = True
+    obj.params['c1_amorphous_fwhm_g_r'].vary = True
+    obj.params['c1_amorphous_fwhm_l_r'].vary = True
+
+    obj.Refine()
+
+    obj.params['bkg_0'].vary = True
+    obj.params['bkg_1'].vary = True
+    obj.params['bkg_2'].vary = True
+
+    obj.Refine()
+
+    # Verify that the goodness of fit and chi-squared are below expected values
+    assert obj.Rwp < 0.057
+    assert obj.gofF < 0.27
+
+
+def test_wppf_amorphous_lebail(wppf_amorphous_kwargs: dict):
+    obj = LeBail(**wppf_amorphous_kwargs)
+
+    # Before any refinement, the goodness of fit and chi-squared shouldn't
+    # be that great.
+    assert obj.Rwp > 0.1
+    assert obj.gofF > 0.5
+
+    # we can refine some parameters here
+    obj.params['c1_amorphous_scale'].vary = True
+    obj.params['c1_amorphous_center'].vary = True
+
+    obj.RefineCycle()
+
+    obj.params['c1_amorphous_fwhm_g_l'].vary = True
+    obj.params['c1_amorphous_fwhm_l_l'].vary = True
+    obj.params['c1_amorphous_fwhm_g_r'].vary = True
+    obj.params['c1_amorphous_fwhm_l_r'].vary = True
+
+    obj.RefineCycle()
+
+    obj.params['bkg_0'].vary = True
+    obj.params['bkg_1'].vary = True
+    obj.params['bkg_2'].vary = True
+
+    obj.RefineCycle()
+
+    # Verify that the goodness of fit and chi-squared are below expected values
+    assert obj.Rwp < 0.06
+    assert obj.gofF < 0.3


### PR DESCRIPTION
# Overview

The WPPF module lacked a model to deal with cases where diffraction from both crystalline and amorphous diffraction are present. This PR addresses this deficiency by including 3 amorphous diffraction models:

1. An asymmetric split-gaussian peak shape
2. An asymmetric split-pseudo flight peak shape
3. a liquid profile which is experimentally measured

The first two peak shapes are implemented as `numba` accelerated function in `WPPF.peakshapes` module. The set of refinement parameters are different for the three models. Additional changes have been made to `WPPF.wppfsupport` module to deal with this. An example fit for Ti is shown below

![Screenshot 2025-06-13 at 2 05 45 PM](https://github.com/user-attachments/assets/551ccceb-d3a2-4a0d-8c8b-a4b00e5bab65)


# Affected Workflows

None