### PR TITLE
Significantly improve fit-grains performance

### DIFF
--- a/hexrd/imageseries/load/framecache.py
+++ b/hexrd/imageseries/load/framecache.py
@@ -4,10 +4,11 @@ import functools
 import os
 from threading import Lock
 
-import numpy as np
-from scipy.sparse import csr_matrix
-import yaml
 import h5py
+import numpy as np
+import yaml
+from scipy.sparse import csr_matrix
+from scipy.sparse.compressed import csr_sample_values
 
 from . import ImageSeriesAdapter, RegionType
 from ..imageseriesiter import ImageSeriesIterator
@@ -213,10 +214,16 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
             # Extract only what we need from the sparse array
             # using fancy indexing before we convert it to a
             # numpy array.
-            sparse_frame = self._framelist[key[0]][*key[1:]]
-        else:
-            sparse_frame = self._framelist[key]
-        return sparse_frame.toarray()
+            mat = self._framelist[key[0]]
+            if len(key) == 3:
+                # This is definitely used frequently and needs to
+                # be performant.
+                return _extract_sparse_values(mat, key[1], key[2])
+            elif len(key) == 2:
+                # Not sure if this will actually be used.
+                return mat[key[1]].toarray()
+
+        return self._framelist[key].toarray()
 
     def __iter__(self):
         return ImageSeriesIterator(self)
@@ -320,3 +327,28 @@ def _load_framecache_fch5(
                               range(num_frames)))
 
     return framelist
+
+
+def _extract_sparse_values(
+    mat: csr_matrix,
+    row: np.ndarray,
+    col: np.ndarray,
+) -> np.ndarray:
+    # This was first copied from here: https://github.com/scipy/scipy/blob/a465e2ce014c1b20b0e4b949e46361e5c2fb727e/scipy/sparse/_compressed.py#L556-L569
+    # And then subsequently modified to return the internal `val` array.
+
+    # It uses the `csr_sample_values()` function to extract values. This is
+    # excellent because it skips the creation of a new sparse array (and
+    # subsequent conversion to a numpy array *again*). It provides a nearly
+    # 10% performance boost for `pull_spots()`.
+    idx_dtype = mat.indices.dtype
+    M, N = mat._swap(mat.shape)
+    major, minor = mat._swap((row, col))
+    major = np.asarray(major, dtype=idx_dtype)
+    minor = np.asarray(minor, dtype=idx_dtype)
+
+    val = np.empty(major.size, dtype=mat.dtype)
+    csr_sample_values(M, N, mat.indptr, mat.indices, mat.data,
+                      major.size, major.ravel(), minor.ravel(), val)
+
+    return val.reshape(major.shape)

--- a/hexrd/imageseries/load/framecache.py
+++ b/hexrd/imageseries/load/framecache.py
@@ -210,7 +210,7 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
 
     def __getitem__(self, key):
         self._load_framelist_if_needed()
-        if isinstance(key, tuple):
+        if not isinstance(key, int):
             # Extract only what we need from the sparse array
             # using fancy indexing before we convert it to a
             # numpy array.

--- a/hexrd/imageseries/load/framecache.py
+++ b/hexrd/imageseries/load/framecache.py
@@ -209,7 +209,14 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
 
     def __getitem__(self, key):
         self._load_framelist_if_needed()
-        return self._framelist[key].toarray()
+        if isinstance(key, tuple):
+            # Extract only what we need from the sparse array
+            # using fancy indexing before we convert it to a
+            # numpy array.
+            sparse_frame = self._framelist[key[0]][*key[1:]]
+        else:
+            sparse_frame = self._framelist[key]
+        return sparse_frame.toarray()
 
     def __iter__(self):
         return ImageSeriesIterator(self)

--- a/hexrd/imageseries/load/hdf5.py
+++ b/hexrd/imageseries/load/hdf5.py
@@ -64,6 +64,11 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
             warnings.warn("HDF5ImageSeries could not close h5 file")
 
     def __getitem__(self, key):
+        if isinstance(key, tuple):
+            # FIXME: we do not yet support fancy indexing here.
+            # Fully expand the array then apply the fancy indexing.
+            return self[key[0]][*key[1:]]
+
         if self._ndim == 2:
             if key != 0:
                 raise IndexError(

--- a/hexrd/imageseries/load/hdf5.py
+++ b/hexrd/imageseries/load/hdf5.py
@@ -64,7 +64,7 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
             warnings.warn("HDF5ImageSeries could not close h5 file")
 
     def __getitem__(self, key):
-        if isinstance(key, tuple):
+        if not isinstance(key, int):
             # FIXME: we do not yet support fancy indexing here.
             # Fully expand the array then apply the fancy indexing.
             return self[key[0]][*key[1:]]

--- a/hexrd/imageseries/load/imagefiles.py
+++ b/hexrd/imageseries/load/imagefiles.py
@@ -45,7 +45,7 @@ class ImageFilesImageSeriesAdapter(ImageSeriesAdapter):
             return self._nframes
 
     def __getitem__(self, key):
-        if isinstance(key, tuple):
+        if not isinstance(key, int):
             # FIXME: we do not yet support fancy indexing here.
             # Fully expand the array then apply the fancy indexing.
             return self[key[0]][*key[1:]]

--- a/hexrd/imageseries/load/imagefiles.py
+++ b/hexrd/imageseries/load/imagefiles.py
@@ -45,6 +45,11 @@ class ImageFilesImageSeriesAdapter(ImageSeriesAdapter):
             return self._nframes
 
     def __getitem__(self, key):
+        if isinstance(key, tuple):
+            # FIXME: we do not yet support fancy indexing here.
+            # Fully expand the array then apply the fancy indexing.
+            return self[key[0]][*key[1:]]
+
         if self.singleframes:
             frame = None
             filename = self._files[key]

--- a/hexrd/imageseries/load/rawimage.py
+++ b/hexrd/imageseries/load/rawimage.py
@@ -111,7 +111,7 @@ class RawImageSeriesAdapter(ImageSeriesAdapter):
         return ImageSeriesIterator(self)
 
     def __getitem__(self, key):
-        if isinstance(key, tuple):
+        if not isinstance(key, int):
             # FIXME: we do not yet support fancy indexing here.
             # Fully expand the array then apply the fancy indexing.
             return self[key[0]][*key[1:]]

--- a/hexrd/imageseries/load/rawimage.py
+++ b/hexrd/imageseries/load/rawimage.py
@@ -111,6 +111,11 @@ class RawImageSeriesAdapter(ImageSeriesAdapter):
         return ImageSeriesIterator(self)
 
     def __getitem__(self, key):
+        if isinstance(key, tuple):
+            # FIXME: we do not yet support fancy indexing here.
+            # Fully expand the array then apply the fancy indexing.
+            return self[key[0]][*key[1:]]
+
         count = key * self._frame_bytes + self.skipbytes
 
         # Ensure reading a frame the file is thread-safe

--- a/hexrd/imageseries/process.py
+++ b/hexrd/imageseries/process.py
@@ -44,7 +44,22 @@ class ProcessedImageSeries(ImageSeries):
         self.addop(self.GAUSS_LAPLACE, self._gauss_laplace)
 
     def __getitem__(self, key):
-        return self._process_frame(self._get_index(key))
+        if isinstance(key, int):
+            idx = key
+            rest = []
+        else:
+            # Handle fancy indexing
+            idx = key[0]
+            rest = key[1:]
+
+        idx = self._get_index(idx)
+
+        if rest:
+            arg = tuple([idx, *rest])
+        else:
+            arg = idx
+
+        return self._process_frame(arg)
 
     def _get_index(self, key):
         return self._frames[key] if self._hasframelist else key

--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -1723,7 +1723,7 @@ class HEDMInstrument(object):
                         contains_signal = False
                         for i_frame in frame_indices:
                             contains_signal = contains_signal or np.any(
-                                ome_imgser[i_frame][ii, jj] > threshold
+                                ome_imgser[i_frame, ii, jj] > threshold
                             )
                         compl.append(contains_signal)
                         patch_output.append((ii, jj, frame_indices))
@@ -1792,7 +1792,7 @@ class HEDMInstrument(object):
                         contains_signal = False
                         patch_data_raw = []
                         for i_frame in frame_indices:
-                            tmp = ome_imgser[i_frame][ijs[0], ijs[1]]
+                            tmp = ome_imgser[i_frame, ijs[0], ijs[1]]
                             contains_signal = contains_signal or np.any(
                                 tmp > threshold
                             )


### PR DESCRIPTION
Profiling showed that the list comprehension in `objFuncFitGrain` was taking a significant amount of time. This is because that function is called repeatedly during the least squares fit, and repeatedly performing the list comprehension would take a substantial amount of time.

Performing the list comprehension outside of `objFuncFitGrain` was shown to provide a substantial speedup.

This is something I discovered when I was working on the spot tracking code. I'm simply cherry-picking that commit here.

This only affects the fitting part, and not the `pull_spots()` part.