### PR TITLE
Preload data for CLI fit-grains

### DIFF
--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -386,6 +386,16 @@ def fit_grains(cfg,
     else:
         nproc = min(ncpus, len(grains_table))
         chunksize = max(1, len(grains_table)//ncpus)
+
+        if multiprocessing.get_start_method() == 'fork':
+            # For frame cache, we need to load in all of the data up-front
+            # so it can use fork multiprocessing to share with the other
+            # processes. Otherwise, every process will load in the data on
+            # its own. Accessing one frame in the imageseries is currently
+            # all we need to do to trigger frame caches to load in all the data.
+            for ims in imsd.values():
+                ims[0]
+
         logger.info("\tstarting fit on %d processes with chunksize %d",
                     nproc, chunksize)
         start = timeit.default_timer()

--- a/hexrd/imageseries/load/hdf5.py
+++ b/hexrd/imageseries/load/hdf5.py
@@ -67,7 +67,7 @@ class HDF5ImageSeriesAdapter(ImageSeriesAdapter):
         if not isinstance(key, int):
             # FIXME: we do not yet support fancy indexing here.
             # Fully expand the array then apply the fancy indexing.
-            return self[key[0]][*key[1:]]
+            return self[key[0]][tuple(key[1:])]
 
         if self._ndim == 2:
             if key != 0:

--- a/hexrd/imageseries/load/imagefiles.py
+++ b/hexrd/imageseries/load/imagefiles.py
@@ -48,7 +48,7 @@ class ImageFilesImageSeriesAdapter(ImageSeriesAdapter):
         if not isinstance(key, int):
             # FIXME: we do not yet support fancy indexing here.
             # Fully expand the array then apply the fancy indexing.
-            return self[key[0]][*key[1:]]
+            return self[key[0]][tuple(key[1:])]
 
         if self.singleframes:
             frame = None

--- a/hexrd/imageseries/load/rawimage.py
+++ b/hexrd/imageseries/load/rawimage.py
@@ -114,7 +114,7 @@ class RawImageSeriesAdapter(ImageSeriesAdapter):
         if not isinstance(key, int):
             # FIXME: we do not yet support fancy indexing here.
             # Fully expand the array then apply the fancy indexing.
-            return self[key[0]][*key[1:]]
+            return self[key[0]][tuple(key[1:])]
 
         count = key * self._frame_bytes + self.skipbytes
 


### PR DESCRIPTION
A while back, we started lazily loading the data when a frame-cache imageseries was opened. This was so that a user could open an imageseries and investigate things like the shape and metadata before actually performing the data load.

For the CLI running fit grains, however, the data preload can be very helpful, because all the processes in the multiprocessing can share the loaded data if `fork` multiprocessing is being used (such as is the case for Linux).

We restore that behavior in this PR.

Before this PR, a frame cache that required 70 GB of RAM to load in the sparse arrays (which is not uncommon) would end up being loaded separately on every process, which would result in 70 GB times the number of processes of RAM being taken up (easily requiring terabytes of RAM).

Now, we ensure the data is preloaded, and the fork multiprocessing enables all 70 GB to just be shared with every process.