### PR TITLE
Amorphous fix

### DIFF
--- a/hexrd/wppf/WPPF.py
+++ b/hexrd/wppf/WPPF.py
@@ -1574,17 +1574,27 @@ class LeBail:
                 self.amorphous_model.fwhm = fwhm
 
     @property
+    def total_area(self):
+        tth, intensity   = self.spectrum_sim.data
+        _, background    = self.background.data
+        total_intensity = intensity-background
+        '''put some guard rails around the total intensity
+        to protect against nans in the values
+        '''
+        mask = np.isnan(total_intensity)
+        sum_area = np.trapz(total_intensity[~mask], tth[~mask])
+        return sum_area
+
+
+    @property
     def DOC(self):
         if self.amorphous_model is None:
             return 1.
         else:
-            tth, intensity   = self.spectrum_sim.data
-            _, background    = self.background.data
-            total_intensity = intensity-background
             amorphous_area = \
                 self.amorphous_model.integrated_area
-            return 1. - amorphous_area/np.trapz(
-                        total_intensity, tth)
+            total_area = self.total_area
+            return 1. - amorphous_area/total_area
 
 
 def _nm(x):

--- a/hexrd/wppf/amorphous.py
+++ b/hexrd/wppf/amorphous.py
@@ -312,8 +312,8 @@ class Amorphous:
     def amorphous_lineout(self):
         if self.model_type == "experimental":
 
+            lo = np.zeros_like(self.tth_list)
             for key in self.shift:
-                lo = np.zeros_like(self.tth_list)
                 smooth_model_data = gaussian_filter(
                                    self.model_data[key],
                                    self.smoothing


### PR DESCRIPTION
Two fixes:

1. Sometimes the simulated spectra has some `nans` in it. The `wppf.DOC` property was being calculated as `nans` for these cases. Fixing it.
2. the `amorphous_lineout` for experimental spectra with multiple phases was initialized to `zeros` inside the loop. Fixing that.