### PR TITLE
Implement several speedups for polar view generation

### DIFF
--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -1143,7 +1143,7 @@ class Detector:
         TODO: revisit normalization in here?
         """
         fill_value = np.nan if pad_with_nans else 0
-        int_xy = np.full(len(xy), fill_value)
+        int_xy = np.full(len(xy), fill_value, dtype=float)
 
         # clip away points too close to or off the detector edges
         xy_clip, on_panel = self.clip_to_panel(xy, buffer_edges=True)
@@ -2125,7 +2125,7 @@ def _interpolate_bilinear(
     # multi-threading friendly) when we run this code in numba.
     result = np.zeros(i_floor_img.shape[0], dtype=img.dtype)
     on_panel_idx = np.arange(i_floor_img.shape[0])
-    return _interpolate_bilinear_in_place(
+    _interpolate_bilinear_in_place(
         img,
         cc,
         fc,
@@ -2138,6 +2138,7 @@ def _interpolate_bilinear(
         on_panel_idx,
         result,
     )
+    return result
 
 
 @numba.njit(nogil=True, cache=True)

--- a/hexrd/instrument/detector.py
+++ b/hexrd/instrument/detector.py
@@ -1131,7 +1131,7 @@ class Detector:
             Array of cartesian coordinates in the image plane at which
             to evaluate intensity.
         img : array_like
-            2-dimensional image array.
+            2-dimensional image array. The shape must match (rows, cols).
         pad_with_nans : bool, optional
             Toggle for assigning NaN to points that fall off the detector.
             The default is True.
@@ -1155,16 +1155,6 @@ class Detector:
         -----
         TODO: revisit normalization in here?
         """
-
-        is_2d = img.ndim == 2
-        right_shape = img.shape[0] == self.rows and img.shape[1] == self.cols
-        assert (
-            is_2d and right_shape
-        ), "input image must be 2-d with shape (%d, %d)" % (
-            self.rows,
-            self.cols,
-        )
-
         fill_value = np.nan if pad_with_nans else 0
         if output_buffer is None:
             int_xy = np.full(len(xy), fill_value)

--- a/hexrd/projections/polar.py
+++ b/hexrd/projections/polar.py
@@ -314,9 +314,16 @@ class PolarView:
 
             _, on_panel = panel.clip_to_panel(xypts, buffer_edges=True)
 
+            xy_clip = xypts[on_panel]
+
+            bilinear_interp_dict = panel._generate_bilinear_interp_dict(
+                xy_clip,
+            )
+
             mapping[detector_id] = {
                 'xypts': xypts,
                 'on_panel': on_panel,
+                'bilinear_interp_dict': bilinear_interp_dict,
             }
 
         return mapping
@@ -351,16 +358,22 @@ class PolarView:
 
             xypts = coordinate_map[detector_id]['xypts']
             on_panel = coordinate_map[detector_id]['on_panel']
+            interp_dict = coordinate_map[detector_id]['bilinear_interp_dict']
 
             if do_interpolation:
                 this_img = panel.interpolate_bilinear(
-                    xypts, img,
+                    xypts,
+                    img,
                     pad_with_nans=pad_with_nans,
-                    on_panel=on_panel).reshape(self.shape)
+                    on_panel=on_panel,
+                    interp_dict=interp_dict,
+                ).reshape(self.shape)
             else:
                 this_img = panel.interpolate_nearest(
-                    xypts, img,
-                    pad_with_nans=pad_with_nans).reshape(self.shape)
+                    xypts,
+                    img,
+                    pad_with_nans=pad_with_nans,
+                ).reshape(self.shape)
 
             # It is faster to keep track of the global nans like this
             # rather than the previous way we were doing it...

--- a/hexrd/projections/polar.py
+++ b/hexrd/projections/polar.py
@@ -380,14 +380,15 @@ class PolarView:
         pad_with_nans: bool = False,
         do_interpolation=True,
     ) -> np.ma.MaskedArray:
-        panel_buffer_fill_value = np.nan
         summed_img = None
         output_buffer = None
         for detector_id, panel in self.detectors.items():
             img = image_dict[detector_id]
-            xypts = coordinate_map[detector_id]['xypts']
-            on_panel = coordinate_map[detector_id]['on_panel']
-            interp_dict = coordinate_map[detector_id]['bilinear_interp_dict']
+            panel_map = coordinate_map[detector_id]
+
+            xypts = panel_map['xypts']
+            on_panel = panel_map['on_panel']
+            interp_dict = panel_map['bilinear_interp_dict']
 
             if output_buffer is None:
                 output_buffer = np.empty(len(xypts))

--- a/hexrd/projections/polar.py
+++ b/hexrd/projections/polar.py
@@ -339,6 +339,7 @@ class PolarView:
         panel_buffer_fill_value = np.nan
         summed_img = None
         nan_mask = None
+        output_buffer = None
         for detector_id, panel in self.detectors.items():
             img = image_dict[detector_id]
             if apply_panel_buffer_to_image and panel.panel_buffer is not None:
@@ -360,6 +361,9 @@ class PolarView:
             on_panel = coordinate_map[detector_id]['on_panel']
             interp_dict = coordinate_map[detector_id]['bilinear_interp_dict']
 
+            if output_buffer is None:
+                output_buffer = np.empty(len(xypts))
+
             if do_interpolation:
                 this_img = panel.interpolate_bilinear(
                     xypts,
@@ -367,6 +371,7 @@ class PolarView:
                     pad_with_nans=pad_with_nans,
                     on_panel=on_panel,
                     interp_dict=interp_dict,
+                    output_buffer=output_buffer,
                 ).reshape(self.shape)
             else:
                 this_img = panel.interpolate_nearest(
@@ -386,7 +391,8 @@ class PolarView:
             this_img[img_nans] = 0
 
             if summed_img is None:
-                summed_img = this_img
+                # We use an output buffer so ensure the image is copied
+                summed_img = this_img.copy()
             else:
                 summed_img += this_img
 

--- a/hexrd/projections/polar.py
+++ b/hexrd/projections/polar.py
@@ -328,7 +328,7 @@ class PolarView:
             do_interpolation=True) -> np.ma.MaskedArray:
 
         panel_buffer_fill_value = np.nan
-        img_dict = dict.fromkeys(self.detectors)
+        summed_img = None
         nan_mask = None
         for detector_id, panel in self.detectors.items():
             # Make a copy since we may modify
@@ -367,9 +367,12 @@ class PolarView:
                 nan_mask = np.logical_and(img_nans, nan_mask)
 
             this_img[img_nans] = 0
-            img_dict[detector_id] = this_img
 
-        summed_img = np.sum(list(img_dict.values()), axis=0)
+            if summed_img is None:
+                summed_img = this_img
+            else:
+                summed_img += this_img
+
         return np.ma.masked_array(
             data=summed_img, mask=nan_mask, fill_value=0.
         )


### PR DESCRIPTION
Most of these speedups are applicable for generating a whole bunch of polar view in a row with the same image (i. e., `cache_coordinate_map=True` when instantiating the `PolarView` class), but a few of them also improve performance of creating the `PolarView` in general.

Overall, we achieved at least a 10x speedup (in serial) for generating a bunch of images in a row, and even more of a speedup for some examples. A list of the improvements are as follows:

1. Using a "moving sum" for summing the detector images. This is particularly valuable for when you have many detectors (i. e., 32 subpanel Eiger). It eliminated the requirement of stacking all the images together before performing the sum, and we can instead discard images immediately after they are included in the sum.
2. Precompute bilinear interpolation parameters, including the weights and indices of detector pixels used for each polar pixel. As long as the instrument doesn't change, these interpolation parameters don't change either, and thus we don't need to generate them every time. They are now included in the cache map.
3. Run bilinear interpolation in numba. This is faster in the single-threaded case, and it also improves parallelism via threading since numba releases the GIL.
4. ~~Instantiate and provide a re-usable output buffer for the interpolation. We re-use the output buffer for every detector, so that we don't have to repeatedly instantiate a chunk of memory for the output for every detector, as we were doing before.~~ - superseded by number 6.
5. Generate nan mask ahead of time. When we reuse the same instrument for many images in a row, we can now reuse the same nan mask, since it should not change. Skipping the step where we regenerate the nan mask provided a considerable performance improvement.
6. Avoid creating the full-size intermediate image immediately before the moving sum. Instead, we can just add valid values to the moving sum directly. This provided yet another big speedup.
7. Completely eliminate all intermediary arrays, so that the weighted interpolation is always computed and set directly into the output array.

I tested these changes a fair amount, and the output looks completely identical to what it was before.