### PR TITLE
Make memoized output numpy arrays readonly

### DIFF
--- a/hexrd/utils/decorators.py
+++ b/hexrd/utils/decorators.py
@@ -75,8 +75,15 @@ def memoize(func=None, maxsize=2):
                     # Remove the left item (least recently used)
                     cache.popitem(last=False)
 
+                output = func(*args, **kwargs)
+                if isinstance(output, np.ndarray):
+                    # Make the array readonly so that caller functions *cannot*
+                    # modify the cached output array. Otherwise, we run into
+                    # hard-to-track-down bugs.
+                    output.flags.writeable = False
+
                 # This inserts the item on the right (most recently used)
-                cache[key] = func(*args, **kwargs)
+                cache[key] = output
                 misses += 1
             else:
                 # Move the item to the right (most recently used)


### PR DESCRIPTION
When a memoized function returns a numpy array, it is possible that the caller of the function may modify the numpy array. This unfortunately also modifies the cached numpy array stored within the memoize decorator, and thus affects future callers.

As such, make returned numpy arrays read-only so that we do not run into these hard-to-track-down bugs, like the one being fixed in hexrd/hexrdgui#1910.