### PR TITLE
Ensure areas are positive in auto powder picking

### DIFF
--- a/hexrd/gridutil.py
+++ b/hexrd/gridutil.py
@@ -147,6 +147,10 @@ def cellCentroids(crd, con):
 
 @numba.njit(nogil=True, cache=True)
 def compute_areas(xy_eval_vtx, conn):
+    # NOTE: this function may return negative areas if the vertices
+    # are passed in the opposite order to the function. This happens
+    # if the beam vector is in the opposite direction (positive Z
+    # instead of the usual negative Z)
     areas = np.empty(len(conn))
     for i in range(len(conn)):
         vtx0x, vtx0y = xy_eval_vtx[conn[i, 0]]

--- a/hexrd/instrument/hedm_instrument.py
+++ b/hexrd/instrument/hedm_instrument.py
@@ -2686,6 +2686,12 @@ def _extract_ring_line_positions(iter_args, instr_cfg, panel, eta_tol, npdiv,
         # strip relevant objects out of current patch
         vtx_angs, vtx_xys, conn, areas, xys_eval, ijs = patch
 
+        # These areas can be negative if the beam vector is in
+        # the opposite direction than it normally is in (positive
+        # Z instead of the usual negative Z). Take the absolute
+        # value of the areas to ensure they are positive.
+        areas = np.abs(areas)
+
         # need to reshape eval pts for interpolation
         xy_eval = np.vstack([
             xys_eval[0].flatten(),


### PR DESCRIPTION
The areas can be negative if the beam vector is in the opposite direction from which HEXRD would normally expect it (HEXRD normally expects a negative Z beam vector).

The powder picking code was assuming the areas are positive. Take the absolute value to ensure that is the case. This fixes automatic point picking for positive beam vectors.