### PR TITLE
Calcstar speedup

### DIFF
--- a/hexrd/core/material/unitcell.py
+++ b/hexrd/core/material/unitcell.py
@@ -3,6 +3,7 @@ import numpy as np
 from numba import njit
 from hexrd.core import constants
 from hexrd.core.material import spacegroup, symbols, symmetry
+
 # TODO: Resolve extra-core-dependency
 from hexrd.hedm.ipfcolor import sphere_sector, colorspace
 from hexrd.core.valunits import valWUnit
@@ -32,33 +33,32 @@ def _calclength(u, mat):
 
 @njit(cache=True, nogil=True)
 def _calcstar(v, sym, mat):
-
     vsym = np.empty((sym.shape[0], v.shape[0]))
     nsym = sym.shape[0]
 
     n = 0
-    vsym[n,:] = v
+    vsym[n, :] = v
     n = n + 1
 
     # the first element is always the identity
     # so we can safely skip that
-    for s in sym[1:,:,:]:
-
+    for s in sym[1:, :, :]:
         vp = np.dot(np.ascontiguousarray(s), v)
 
         # check if this is new
         isnew = True
-        for vec in vsym[0:n,:]:
-            dist = np.sum((vp - vec)**2)
+        for vec in vsym[0:n, :]:
+            dist = np.sum((vp - vec) ** 2)
             if dist < 1e-4:
                 isnew = False
                 break
 
         if isnew:
-            vsym[n,:] = vp
+            vsym[n, :] = vp
             n = n + 1
 
-    return vsym[0:n,:]
+    return vsym[0:n, :]
+
 
 class unitcell:
     '''
@@ -83,7 +83,6 @@ class unitcell:
         beamenergy,
         sgsetting=0,
     ):
-
         self._tstart = time.time()
         self.pref = 0.4178214
 
@@ -141,7 +140,6 @@ class unitcell:
         self.wavelength *= 1e9
 
     def calcBetaij(self):
-
         self.betaij = np.zeros([3, 3, self.atom_ntype])
         for i in range(self.U.shape[0]):
             U = self.U[i, :]
@@ -152,7 +150,6 @@ class unitcell:
             self.betaij[:, :, i] *= 2.0 * np.pi**2 * self._aij
 
     def calcmatrices(self):
-
         a = self.a
         b = self.b
         c = self.c
@@ -275,7 +272,6 @@ class unitcell:
     ''' calculate dot product of two vectors in any space 'd' 'r' or 'c' '''
 
     def CalcDot(self, u, v, space):
-
         if space == 'd':
             dot = np.dot(u, np.dot(self.dmt, v))
         elif space == 'r':
@@ -288,7 +284,6 @@ class unitcell:
         return dot
 
     def CalcLength(self, u, space):
-
         if space == 'd':
             mat = self.dmt
             # vlen = np.sqrt(np.dot(u, np.dot(self.dmt, u)))
@@ -313,7 +308,6 @@ class unitcell:
     ''' calculate angle between two vectors in any space'''
 
     def CalcAngle(self, u, v, space):
-
         ulen = self.CalcLength(u, space)
         vlen = self.CalcLength(v, space)
 
@@ -410,7 +404,6 @@ class unitcell:
         return pxq
 
     def GenerateRecipPGSym(self):
-
         self.SYM_PG_r = self.SYM_PG_d[0, :, :]
         self.SYM_PG_r = np.broadcast_to(self.SYM_PG_r, [1, 3, 3])
 
@@ -482,7 +475,6 @@ class unitcell:
             self.SYM_PG_supergroup_laue = sym_supergroup_laue
 
         else:
-
             self.SYM_PG_supergroup = []
             self.SYM_PG_supergroup_laue = []
 
@@ -515,7 +507,6 @@ class unitcell:
         SS 12/10/2020
         '''
         if self.latticeType == 'monoclinic':
-
             om = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, -1.0, 0.0]])
 
             for i, s in enumerate(self.SYM_PG_c):
@@ -625,7 +616,6 @@ class unitcell:
         asym_pos = []
 
         for i in range(self.atom_ntype):
-
             v = self.atom_pos[i, 0:3]
             apos, n = self.CalcOrbit(v)
 
@@ -793,7 +783,6 @@ class unitcell:
             self.il = self.il + 1
 
     def InitializeInterpTable(self):
-
         f_anomalous_data = []
         self.pe_cs = {}
         data = (
@@ -803,7 +792,6 @@ class unitcell:
         )
         with h5py.File(data, 'r') as fid:
             for i in range(0, self.atom_ntype):
-
                 Z = self.atom_type[i]
                 elem = constants.ptableinverse[Z]
 
@@ -935,7 +923,6 @@ class unitcell:
         return 1e-12 * self.density * Na / M
 
     def calc_absorption_cross_sec(self):
-
         abs_cs_total = 0.0
         for i in range(self.atom_ntype):
             Z = self.atom_type[i]
@@ -992,7 +979,6 @@ class unitcell:
 
         for i, g in enumerate(hkllist):
             if mask[i]:
-
                 geqv = self.CalcStar(g, 'r', applyLaue=laue).astype(int)
 
                 for r in geqv[1:,]:
@@ -1078,10 +1064,8 @@ class unitcell:
         hkl_dsp = []
 
         for g in hkl_allowed:
-
             # ignore [0 0 0] as it is the direct beam
             if np.sum(np.abs(g)) != 0:
-
                 dspace = 1.0 / self.CalcLength(g, 'r')
 
                 if dspace >= dmin:
@@ -1134,7 +1118,6 @@ class unitcell:
         # initialize all zeros and fill the supplied values
         C = np.zeros([6, 6])
         for i, x in enumerate(_StiffnessDict[self._laueGroup][0]):
-
             C[x] = inp_Cvals[i]
 
         # enforce the equality constraints
@@ -1185,7 +1168,6 @@ class unitcell:
 
         mask = []
         for x in dir3:
-
             x2 = np.atleast_2d(x).T
             d1 = np.linalg.det(np.hstack((A, B, x2)))
             d2 = np.linalg.det(np.hstack((A, x2, C)))
@@ -1302,9 +1284,7 @@ class unitcell:
             sym = self.SYM_PG_supergroup_laue
 
         for sop in sym:
-
             if dir3_copy.size != 0:
-
                 dir3_sym = np.dot(sop, dir3_copy.T).T
 
                 mask = np.zeros(dir3_sym.shape[0]).astype(bool)
@@ -1792,7 +1772,6 @@ class unitcell:
         # vol per atom in A^3
         return 1e3 * self.vol / self.num_atom
 
-
     @property
     def chemical_formula(self):
         chemical_formula = ''
@@ -1806,7 +1785,7 @@ class unitcell:
             elem = constants.ptableinverse[Z]
             numat = self.numat[i]
             occ = self.atom_pos[i, 3]
-            abundance = str(numat*occ)
+            abundance = str(numat * occ)
             if abundance.endswith('.0'):
                 # We can remove the trailing decimal and zero.
                 # This looks nicer if you print the formula,

--- a/tests/unitcell/test_vec_math.py
+++ b/tests/unitcell/test_vec_math.py
@@ -85,8 +85,7 @@ def test_trans_space(cell: unitcell.unitcell):
 
 
 def test_calc_star(cell: unitcell.unitcell):
-
-    v = ([1., 2., 3.])
+    v = [1.0, 2.0, 3.0]
     vsym = cell.CalcStar(v, 'd', False)
     assert vsym.shape[0] == 48
 
@@ -99,7 +98,7 @@ def test_calc_star(cell: unitcell.unitcell):
     vsym = cell.CalcStar(v, 'r', True)
     assert vsym.shape[0] == 48
 
-    v = ([1., 1., 3.])
+    v = [1.0, 1.0, 3.0]
     vsym = cell.CalcStar(v, 'd', False)
     assert vsym.shape[0] == 24
 
@@ -112,7 +111,7 @@ def test_calc_star(cell: unitcell.unitcell):
     vsym = cell.CalcStar(v, 'r', True)
     assert vsym.shape[0] == 24
 
-    v = ([1., 1., 0.])
+    v = [1.0, 1.0, 0.0]
     vsym = cell.CalcStar(v, 'd', False)
     assert vsym.shape[0] == 12
 
@@ -125,7 +124,7 @@ def test_calc_star(cell: unitcell.unitcell):
     vsym = cell.CalcStar(v, 'r', True)
     assert vsym.shape[0] == 12
 
-    v = ([1., 1., 1.])
+    v = [1.0, 1.0, 1.0]
     vsym = cell.CalcStar(v, 'd', False)
     assert vsym.shape[0] == 8
 
@@ -138,7 +137,7 @@ def test_calc_star(cell: unitcell.unitcell):
     vsym = cell.CalcStar(v, 'r', True)
     assert vsym.shape[0] == 8
 
-    v = ([1., 0., 0.])
+    v = [1.0, 0.0, 0.0]
     vsym = cell.CalcStar(v, 'd', False)
     assert vsym.shape[0] == 6
 


### PR DESCRIPTION
calcstar now uses cartesian distance instead of the metric tensor. Increases speed by ~2.5x. 
Results are the same for cubic symmetries.