### PR TITLE
Fix issues with multiple texture models

### DIFF
--- a/hexrd/powder/wppf/texture.py
+++ b/hexrd/powder/wppf/texture.py
@@ -1554,6 +1554,10 @@ class HarmonicModel:
         for name in self.parameter_names:
             harmonic_params[name] = copy.deepcopy(params[name])
 
+        if not any(param.vary for param in harmonic_params.values()):
+            # No parameters are marked as vary. Return early.
+            return None
+
         self.sph_c = {}
         self.sph_s = {}
 


### PR DESCRIPTION
This fixes a few issues with multiple texture models. Now, you can have some materials with texture modeling and some without texture modeling. You also no longer have to refine harmonic coefficients for all texture models (you can disable some).

This also sanitizes the material name so that materials may contain a `-` in them without causing errors in lmfit.