### PR TITLE
Update Linux packaging to build using AlmaLinux 8

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -1,46 +1,40 @@
 #!/usr/bin/env bash
 cd /github/workspace/
 
-# Use archive mirror for CentOS 7 until we are ready to migrate to CentOS 8
-sed -i -e 's/mirrorlist/#mirrorlist/g' \
-	-e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' \
-	/etc/yum.repos.d/CentOS-*
-
 # Install dependencies
-yum install -y wget git centos-release-scl ca-certificates
-
-# Need to install packages that depend on centos-release-scl on a different line.
-# This will use gcc==10, which is the same as what manylinux2014 uses.
-yum install -y devtoolset-10
+# Use gcc-14 for manylinux_2_28
+yum install -y wget git gcc-toolset-14
 
 # Enable this toolset
-source /opt/rh/devtoolset-10/enable
+source /opt/rh/gcc-toolset-14/enable
 
 # Download and install miniconda
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod a+x Miniconda3-latest-Linux-x86_64.sh
 ./Miniconda3-latest-Linux-x86_64.sh -b
 
+# Activate conda
+source $HOME/miniconda3/bin/activate
+
 # The base needs to have the same python version (3.11, right now)
-${HOME}/miniconda3/bin/conda install python=3.11 -y
+conda install --override-channels -c conda-forge python=3.11 -y
 
 # Set up the hexrd channel
-${HOME}/miniconda3/bin/conda create --override-channels -c conda-forge -y -n hexrd python=3.11
-${HOME}/miniconda3/bin/activate hexrd
-${HOME}/miniconda3/bin/conda activate hexrd
+conda create --override-channels -c conda-forge -y -n hexrd python=3.11
+conda activate hexrd
 
 # Install the libmamba solver (it is much faster)
-${HOME}/miniconda3/bin/conda install -n base -c conda-forge conda-libmamba-solver
-${HOME}/miniconda3/bin/conda config --set solver libmamba
-${HOME}/miniconda3/bin/conda config --set conda_build.pkg_format 1 # force tar.bz2 files
+conda install -n base -c conda-forge conda-libmamba-solver
+conda config --set solver libmamba
+conda config --set conda_build.pkg_format 1 # force tar.bz2 files
 
 
 # Remove anaconda telemetry (it is causing errors for us)
-${HOME}/miniconda3/bin/conda remove -n base conda-anaconda-telemetry
+conda remove -n base conda-anaconda-telemetry
 
 # Install conda build and create output directory
-${HOME}/miniconda3/bin/conda install --override-channels -c conda-forge conda-build -y
+conda install --override-channels -c conda-forge conda-build -y
 mkdir output
 
 # Build the package
-${HOME}/miniconda3/bin/conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
+conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -80,7 +80,10 @@ jobs:
 
     - name: Build the package (container)
       if: ${{ matrix.config.name == 'Linux' }}
-      uses: docker://centos:7
+      # AlmaLinux 8 is used for manylinux_2_28 support. This supports glibc
+      # 2.28 and later, which supports linux OS's starting in August 2018.
+      # AlmaLinux 8 will be supported with security updates until 2029.
+      uses: docker://almalinux:8
       with:
         entrypoint: /github/workspace/.github/workflows/container_build.sh
 


### PR DESCRIPTION
Centos 7 reached its end of life in 2024. manylinux2014 also reached its end of life at the same time.

AlmaLinux 8 is used for manylinux_2_28 support. This supports glibc 2.28 and later, which supports Linux OS's starting in August 2018. AlmaLinux 8 will be supported with security updates until 2029.

These updates are necessary, not only because of the end of life dates that have been reached, but also because conda must now be ran on a system supporting glibc 2.28.