### PR TITLE
Upgrade mac package runner

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-13
+            os: macos-15-intel
           }
         - {
             name: "Windows",


### PR DESCRIPTION
macos-13 is now retired.

We should stick with intel for now because the cross-compilation of the conda-forge packages are set up already to work with intel. We can continue supporting intel packages until the macos-15-intel runners are retired (about 1.5 years from now).