### PR TITLE
Remove libmamba installations

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -23,8 +23,7 @@ conda install --override-channels -c conda-forge python=3.11 -y
 conda create --override-channels -c conda-forge -y -n hexrd python=3.11
 conda activate hexrd
 
-# Install the libmamba solver (it is much faster)
-conda install -n base -c conda-forge conda-libmamba-solver
+# Use the libmamba solver (it is much faster)
 conda config --set solver libmamba
 conda config --set conda_build.pkg_format 1 # force tar.bz2 files
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,7 +46,6 @@ jobs:
     - name: Install build requirements
       run: |
           # Change default solver to be libmamba, so that it runs much faster
-          conda install -n base --override-channels -c conda-forge conda-libmamba-solver
           conda config --set solver libmamba
 
           conda activate hexrd
@@ -66,7 +65,6 @@ jobs:
           # For some reason, we need to set this in the environment as well.
           # It seems conda build sometimes needs the solver in the environment
           # and sometimes in the base environment. I don't know why.
-          conda install --override-channels -c conda-forge conda-libmamba-solver
           conda config --env --set solver libmamba
           conda config --set conda_build.pkg_format 1 # force tar.bz2 files
           conda list


### PR DESCRIPTION
libmamba comes with conda now already. Installing libmamba is forcing conda to move back to an older version. Just remove the installs.
