### PR TITLE
Call _gaussian3d_no_bg with the correct arguments

### DIFF
--- a/hexrd/core/fitting/peakfunctions.py
+++ b/hexrd/core/fitting/peakfunctions.py
@@ -962,7 +962,7 @@ def gaussian3d(p, x, y, z):
     bg1y = p[9]
     bg1z = p[10]
 
-    f = _gaussian3d_no_bg(p[:5], x, y) + (bg0 + bg1x * x + bg1y * y + bg1z * z)
+    f = _gaussian3d_no_bg(p[:5], x, y, z) + (bg0 + bg1x * x + bg1y * y + bg1z * z)
     return f
 
 


### PR DESCRIPTION
The gaussian3d function in peakfunctions.py was previously written incorrectly, calling an internal function with 3 arguments instead of 4. This fix adds the z parameter to the function call to _gaussian3d_no_bg.

Resolves #855 