### PR TITLE
Fix CIF atom-site loop output

### DIFF
--- a/hexrd/core/material/material.py
+++ b/hexrd/core/material/material.py
@@ -42,6 +42,7 @@ from hexrd.core.constants import ptable, ptableinverse, chargestate
 from hexrd.core.utils.logger import redirect_stdout_to_logger
 
 from os import path
+import logging
 from pathlib import Path
 from CifFile import ReadCif, CifFile, CifBlock
 import h5py
@@ -57,6 +58,7 @@ from hexrd.core.fitting.peakfunctions import _unit_gaussian
 
 __all__ = ['Material', 'loadMaterialList']
 
+logger = logging.getLogger(__name__)
 
 #
 # ================================================== Module Data
@@ -1155,7 +1157,7 @@ class Material(object):
         cb = self.to_cif_block()
         cf[self.name] = cb
 
-        with redirect_stdout_to_logger():
+        with redirect_stdout_to_logger(logger, level=logging.DEBUG):
             # WriteOut prints unwanted output to stdout; redirect to logger
             cif_text = cf.WriteOut()
 

--- a/hexrd/core/utils/logger.py
+++ b/hexrd/core/utils/logger.py
@@ -1,10 +1,13 @@
-import logging
 from contextlib import contextmanager, redirect_stdout
+from typing import Iterator
+import logging
 import io
 
 
 @contextmanager
-def redirect_stdout_to_logger(level=logging.DEBUG):
+def redirect_stdout_to_logger(
+    logger: logging.Logger, level: int = logging.DEBUG
+) -> Iterator[None]:
     """
     Context manager to redirect stdout to a logger.
 
@@ -12,13 +15,12 @@ def redirect_stdout_to_logger(level=logging.DEBUG):
     ----------
     level : int, optional
         Logging level (default: logging.DEBUG)
-    
+
     Examples
     --------
     >>> with redirect_stdout_to_logger(logging.DEBUG):
     ...     some_function_that_prints()
     """
-    logger = logging.getLogger(__name__)
     captured = io.StringIO()
 
     with redirect_stdout(captured):


### PR DESCRIPTION
# Overview

This PR fixes CIF export formatting so atom-site coordinates are written as valid CIF `loop_` records instead of PyCifRW-style bracketed arrays.

# Affected Workflows

- `Material.write_cif()` now produces atom-site output in `loop_` form, which should improve compatibility with CIF validators
