### PR TITLE
Remove deprecated `quiet` from `pull_spots()` call

### DIFF
--- a/hexrd/hedm/fitgrains.py
+++ b/hexrd/hedm/fitgrains.py
@@ -120,7 +120,6 @@ def fit_grain_FF_reduced(grain_id):
             dirname=analysis_dirname,
             filename=spots_filename,
             return_spot_list=False,
-            quiet=True,
             check_only=False,
             interp='nearest',
         )


### PR DESCRIPTION
This was producing deprecation warnings.

# Overview

Fixes deprecation warning

# Affected Workflows

Fixes HEDM workflow deprecation warning

# Documentation Changes

None