### PR TITLE
Indexer

### DIFF
--- a/hexrd/hedm/indexer.py
+++ b/hexrd/hedm/indexer.py
@@ -32,7 +32,6 @@ import logging
 import multiprocessing
 
 import numpy as np
-import numba
 
 import timeit
 


### PR DESCRIPTION
# Overview

This PR simplifies the logic in the `_filter_and_count_hits` logic. It runs faster, even without `numba.njit` used, by relying on built-in vectorized numpy functions and uses less bookkeeping than the original version. I also removed the now un-used functions:

- `_meshgrid2d`
- `_check_dilated`
- `_find_in_range`
- _angle_is_hit

# Affected Workflows

Workflows should be unaffected, as the behavior of the function is not modified.

# Documentation Changes

As the functions removed were not previously documented, no documentation changes are required.
