### PR TITLE
Add ability to preprocess eiger-stream-v2 files

### DIFF
--- a/hexrd/hedm/preprocess/profiles.py
+++ b/hexrd/hedm/preprocess/profiles.py
@@ -128,10 +128,14 @@ class Eiger_Arguments(Chess_Arguments):
     profile_name = "eiger"
     # fields
     absolute_path: Optional[str] = None
+    eiger_stream_v2_threshold: str = 'threshold_1'
+    eiger_stream_v2_multiplier: float = 1.0
 
     help_messages = {
         **Chess_Arguments.help_messages,
         "absolute_path": "absolute path to image file",
+        "eiger_stream_v2_threshold": "Threshold to use for eiger-stream-v2 input file. Options are 'threshold_1', 'threshold_2', or 'man_diff', which is defined as `threshold_1 - multiplier * threshold_2`",
+        "eiger_stream_v2_multiplier": "Multiplier to use for threshold setting 'man_diff'. Unused otherwise.",
     }
 
     short_switches = {

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,10 +1,14 @@
+from pathlib import Path
+import tempfile
+
+import pytest
+
 from hexrd.hedm.preprocess.profiles import (
     Eiger_Arguments,
     Dexelas_Arguments,
     HexrdPPScript_Arguments,
 )
-import pytest
-from pathlib import Path
+from hexrd.hedm.preprocess.preprocessors import preprocess
 
 
 # FIXME: this is not the appropriate file to test the preprocess scrips since
@@ -18,6 +22,11 @@ def eiger_examples_path(example_repo_path: Path) -> Path:
 @pytest.fixture
 def ceria_examples_path(eiger_examples_path: Path) -> Path:
     return eiger_examples_path / 'first_ceria' / 'ff_000_data_000001.h5'
+
+
+@pytest.fixture
+def eiger_stream_v2_examples_path(eiger_examples_path: Path) -> Path:
+    return eiger_examples_path / 'eiger_stream_v2/eiger_stream_v2_test_dataset.h5'
 
 
 # test load/safe with defaults
@@ -41,12 +50,36 @@ def test_save_load_eiger(ceria_examples_path):
     buffer = eargs.dump_config()
     args = HexrdPPScript_Arguments.load_from_config(buffer)
     assert eargs == args
-    with pytest.raises(
-        RuntimeError
-    ):  # required argument 'absolute_path' is missing
+    with pytest.raises(RuntimeError):  # required argument 'absolute_path' is missing
         args.validate_arguments()
     args.absolute_path = str(ceria_examples_path)
     args.validate_arguments()
+
+
+def test_save_load_eiger_stream_v2(eiger_stream_v2_examples_path: Path):
+    eargs = Eiger_Arguments()
+    buffer = eargs.dump_config()
+    args = HexrdPPScript_Arguments.load_from_config(buffer)
+    assert eargs == args
+    with pytest.raises(RuntimeError):  # required argument 'absolute_path' is missing
+        args.validate_arguments()
+    args.absolute_path = str(eiger_stream_v2_examples_path)
+    args.eiger_stream_v2_threshold = 'man_diff'
+    args.eiger_stream_v2_multiplier = 0.75
+    args.num_frames = 1
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Write the output file in the temporary directory
+        output_file = Path(tmpdirname) / 'test'
+        args.output = output_file
+
+        args.validate_arguments()
+
+        # Write out the example file!
+        preprocess(args)
+
+        # Verify that there is an output file
+        assert len(list(Path(tmpdirname).glob(f"*.npz"))) > 0
 
 
 def test_save_load_dexelas():


### PR DESCRIPTION
Previously, we only allowed processing of eiger-stream-v1 files. This adds automatic detection so that `eiger-stream-v1` or `eiger-stream-v2` is selected automatically.

It also adds a couple of command-line options specific for `eiger-stream-v2`, namely setting the threshold option and the multiplier.

A test was also added that exercises the full preprocessing.

This will be used potentially next week at CHESS.

Example of running this:

```bash
hexrd preprocess eiger -n 1 --eiger_stream_v2_threshold 'man_diff' --eiger_stream_v2_multiplier 0.75 ./eiger_stream_v2_test_dataset.h5
```

That is on the example file [here](https://github.com/HEXRD/examples/tree/master/eiger/eiger_stream_v2).

It should output a file named `test-cachefile.npz`.