### PR TITLE
Resolve scikit-image deprecation

### DIFF
--- a/hexrd/core/instrument/hedm_instrument.py
+++ b/hexrd/core/instrument/hedm_instrument.py
@@ -1961,7 +1961,7 @@ class HEDMInstrument(object):
 
                     peak_id = patch_id
                     coms = np.vstack(
-                        [x.weighted_centroid for x in regionprops(labels, patch_data)]
+                        [x.centroid_weighted for x in regionprops(labels, patch_data)]
                     )
                     closest_peak_idx = np.argmin(
                         np.sum(


### PR DESCRIPTION
Resolves #877

# Overview

This PR changes the skimage `weighted_centroid` property to `centroid_weighted`, per the conversion notes in the library.

# Affected Workflows

No workflows are impacted by this PR.

# Documentation Changes

No documentation changes are required for this PR.