### PR TITLE
Allow skipped subpanels in fit-grains

### DIFF
--- a/hexrd/hedm/fitting/grains.py
+++ b/hexrd/hedm/fitting/grains.py
@@ -248,7 +248,7 @@ def objFuncFitGrain(
             instrument.detector_parameters[det_key]
         )
 
-        results = reflections_dict[det_key]
+        results = reflections_dict.get(det_key, [])
         if not isinstance(results, dict) and len(results) == 0:
             continue
 


### PR DESCRIPTION
This allows subpanels to be skipped in the fitting method. This happens if there is no HEDM signal on a particular subpanel.

It prevents an error like the following:

```python
File ".../hexrd/hedm/fitting/grains.py", line 251, in objFuncFitGrain
    results = reflections_dict[det_key]
              ~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'eiger_0_0'
```