### PR TITLE
Correctly save a `tThWidth` of `None`

### DIFF
--- a/hexrd/core/material/material.py
+++ b/hexrd/core/material/material.py
@@ -961,7 +961,7 @@ class Material(object):
             tThWidth = np.array(gid.get('tThWidth'), dtype=np.float64).item()
             tThWidth = np.radians(tThWidth)
         else:
-            tThWidth = Material.DFLT_TTH
+            tThWidth = None
 
         self._tThWidth = tThWidth
 
@@ -991,9 +991,7 @@ class Material(object):
         AtomInfo['hkls'] = self.planeData.getHKLs()
         AtomInfo['dmin'] = self.unitcell.dmin
         AtomInfo['kev'] = self.beamEnergy.getVal("keV")
-        if self.planeData.tThWidth is None:
-            AtomInfo['tThWidth'] = np.degrees(Material.DFLT_TTH)
-        else:
+        if self.planeData.tThWidth is not None:
             AtomInfo['tThWidth'] = np.degrees(self.planeData.tThWidth)
 
         AtomInfo['pressure'] = self.pressure


### PR DESCRIPTION
# Overview

Before, if the `tThWidth` was set to `None`, which is a valid setting, saving the material and reloading it would reset it to the default value, rather than restoring the value of `None`.

This PR fixes the bug so that `None` is properly saved and restored, as it should be.

# Affected Workflows

All workflows, but it probably doesn't affect most users (only a select few would set it to `None`).

# Documentation Changes

None
