### PR TITLE
Ensure fork multiprocessing is used on Linux

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,7 +50,9 @@ jobs:
           conda config --set solver libmamba
 
           conda activate hexrd
-          conda install --override-channels -c conda-forge anaconda-client conda-build conda
+          # Newer versions of anaconda-client expect setuptools to be present, so we need to
+          # install it also.
+          conda install --override-channels -c conda-forge anaconda-client conda-build conda setuptools
 
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.

--- a/hexrd/core/imageutil.py
+++ b/hexrd/core/imageutil.py
@@ -8,6 +8,7 @@ from scipy import signal, ndimage
 from skimage.feature import blob_dog, blob_log
 from skimage.exposure import rescale_intensity
 
+from hexrd.core import constants
 from hexrd.core import convolution
 from hexrd.core.constants import fwhm_to_sigma
 
@@ -88,7 +89,9 @@ def snip1d(y, w=4, numiter=2, threshold=None, max_workers=os.cpu_count()):
 
     if max_workers > 1:
         # Parallelize over tasks
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        with ProcessPoolExecutor(
+            mp_context=constants.mp_context, max_workers=max_workers
+        ) as executor:
             for k, result in executor.map(f, tasks):
                 bkg[k, :] = result
     else:

--- a/hexrd/core/instrument/hedm_instrument.py
+++ b/hexrd/core/instrument/hedm_instrument.py
@@ -1676,6 +1676,11 @@ class HEDMInstrument(object):
                 ijs = panel.cartToPixel(patch_xys[ang_index])
                 ii, jj = polygon(ijs[:, 0], ijs[:, 1])
 
+                # Clip pixel indices to valid detector dimensions
+                nrows, ncols = panel.shape
+                np.clip(ii, 0, nrows - 1, out=ii)
+                np.clip(jj, 0, ncols - 1, out=jj)
+
                 patch_data_raw = np.stack(
                     [omega_image_series[i_frame, ii, jj] for i_frame in frame_indices],
                     axis=0,
@@ -1863,6 +1868,7 @@ class HEDMInstrument(object):
                 output_dir.mkdir(parents=True, exist_ok=True)
                 writer_text = PatchDataWriter(output_dir / str(filename))
 
+            nrows, ncols = panel.shape
             for patch_id, (vtx_angs, _, _, areas, xy_eval, ijs) in enumerate(patches):
                 prows, pcols = areas.shape
                 hkl_id, hkl = hkl_ids[patch_id], hkls_p[patch_id, :]
@@ -1880,6 +1886,12 @@ class HEDMInstrument(object):
                 if -1 in frame_indices:
                     logger.warning(f"window for {hkl} falls outside omega range")
                     continue
+
+                # Clip pixel indices to valid detector dimensions
+                ijs = (
+                    np.clip(ijs[0], 0, nrows - 1),
+                    np.clip(ijs[1], 0, ncols - 1),
+                )
 
                 omega_edges = omega_image_series.omega[frame_indices[0]][0]
                 patch_data_raw = np.stack(

--- a/hexrd/hedm/findorientations.py
+++ b/hexrd/hedm/findorientations.py
@@ -148,7 +148,7 @@ def generate_orientation_fibers(cfg, eta_ome):
         # multiple process version
         # ???: Need a chunksize in map?
         chunksize = max(1, len(input_p) // (10 * ncpus))
-        pool = mp.Pool(ncpus, discretefiber_init, (params,))
+        pool = const.mp_context.Pool(ncpus, discretefiber_init, (params,))
         qfib = pool.map(discretefiber_reduced, input_p, chunksize=chunksize)
 
         pool.close()
@@ -780,7 +780,7 @@ def find_orientations(
                 )
 
         # execute direct search
-        pool = mp.Pool(ncpus, indexer.test_orientation_FF_init, (params,))
+        pool = const.mp_context.Pool(ncpus, indexer.test_orientation_FF_init, (params,))
         completeness = pool.map(indexer.test_orientation_FF_reduced, qfib.T)
         pool.close()
         pool.join()

--- a/hexrd/hedm/fitgrains.py
+++ b/hexrd/hedm/fitgrains.py
@@ -14,6 +14,7 @@ import warnings
 
 from collections import defaultdict
 
+from hexrd.core import constants
 from hexrd.core import instrument
 from hexrd.core import rotations
 from .fitting import fitGrain, objFuncFitGrain, gFlag_ref
@@ -457,7 +458,7 @@ def fit_grains(
         nproc = min(ncpus, len(grains_table))
         chunksize = max(1, len(grains_table) // ncpus)
 
-        if multiprocessing.get_start_method() == 'fork':
+        if constants.mp_context.get_start_method() == 'fork':
             # For frame cache, we need to load in all of the data up-front
             # so it can use fork multiprocessing to share with the other
             # processes. Otherwise, every process will load in the data on
@@ -470,7 +471,7 @@ def fit_grains(
             "\tstarting fit on %d processes with chunksize %d", nproc, chunksize
         )
         start = timeit.default_timer()
-        pool = multiprocessing.Pool(nproc, fit_grain_FF_init, (params,))
+        pool = constants.mp_context.Pool(nproc, fit_grain_FF_init, (params,))
 
         async_result = pool.map_async(
             fit_grain_FF_reduced,

--- a/hexrd/hedm/indexer.py
+++ b/hexrd/hedm/indexer.py
@@ -341,7 +341,7 @@ def paintGrid(
     retval = None
     if multiProcMode:
         # multiple process version
-        pool = multiprocessing.Pool(nCPUs, paintgrid_init, (params,))
+        pool = constants.mp_context.Pool(nCPUs, paintgrid_init, (params,))
         retval = pool.map(paintGridThis, quats.T, chunksize=chunksize)
         pool.close()
     else:


### PR DESCRIPTION
# Overview

Starting in Python3.14, `forkserver` is the new default multiprocessing method for Linux. This is thread-safe, which can be important for certain applications. But it is slower, and it loses the copy-on-write mechanics we have set up, which are essential for running fit-grains on large datasets.

Make sure all cases of multiprocessing in hexrd on Linux use the `fork` multiprocessing method, as has been done for all versions of Python prior to 3.14.

This also fixes a rare edge case where, if a spot occurs right on the edge of a detector, the patch indices might include an index that is off the detector. This would raise exceptions.

Instead, we clip the indices to the valid detector dimensions.

Fixes: #914

# Affected Workflows

HEDM

# Documentation Changes

None