### PR TITLE
Issue 918

### DIFF
--- a/hexrd/core/imageseries/process.py
+++ b/hexrd/core/imageseries/process.py
@@ -28,6 +28,8 @@ class ProcessedImageSeries(ImageSeries):
     RECT = 'rectangle'
     ADD = 'add'
     GAUSS_LAPLACE = 'gauss_laplace'
+    ADD_ROW = 'add-row'
+    ADD_COL = 'add-column'
 
     def __init__(self, imser, oplist, **kwargs):
         self._imser = imser
@@ -44,6 +46,8 @@ class ProcessedImageSeries(ImageSeries):
         self.addop(self.RECT, self._rectangle)
         self.addop(self.ADD, self._add)
         self.addop(self.GAUSS_LAPLACE, self._gauss_laplace)
+        self.addop(self.ADD_ROW, self._add_row)
+        self.addop(self.ADD_COL, self._add_col)
 
     def __getitem__(self, key):
         if isinstance(key, int):
@@ -159,6 +163,14 @@ class ProcessedImageSeries(ImageSeries):
 
     def _gauss_laplace(self, img, sigma):
         return scipy.ndimage.gaussian_laplace(img, sigma)
+
+    def _add_row(self, img, index):
+        """Insert a zero row at the given row index."""
+        return np.insert(img, index, 0, axis=0)
+
+    def _add_col(self, img, index):
+        """Insert a zero column at the given column index."""
+        return np.insert(img, index, 0, axis=1)
 
     def _update_omega(self):
         """Update omega if there is a framelist"""

--- a/hexrd/hedm/cli/preprocess.py
+++ b/hexrd/hedm/cli/preprocess.py
@@ -136,7 +136,7 @@ def _get_supported_type(tp, default_value=None):
     # second condition is required in case the dataclass field is defined using
     # members of the typing module.
     if tp is dict or get_origin(tp) is dict:
-        return json.loads, f"'{json.dumps(default_value)}'"
+        return json.loads, json.dumps(default_value)
     elif is_optional(tp):
         return get_args(tp)[0], None
     else:

--- a/hexrd/hedm/preprocess/argument_classes_factory.py
+++ b/hexrd/hedm/preprocess/argument_classes_factory.py
@@ -1,7 +1,9 @@
-from typing import Type, TYPE_CHECKING
+from typing import Type, TypeVar, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import hexrd.hedm.preprocess.profiles as profiles
+
+_T = TypeVar("_T", bound="profiles.HexrdPPScript_Arguments")
 
 
 class ArgumentClassesFactory:
@@ -31,9 +33,7 @@ class ArgumentClassesFactory:
         return creator
 
 
-def autoregister(
-    cls: Type["profiles.HexrdPPScript_Arguments"],
-) -> Type["profiles.HexrdPPScript_Arguments"]:
+def autoregister(cls: Type[_T]) -> Type[_T]:
     """decorator that registers cls with ArgumentClassesFactory"""
     ArgumentClassesFactory().register(cls)
     return cls

--- a/hexrd/hedm/preprocess/preprocessors.py
+++ b/hexrd/hedm/preprocess/preprocessors.py
@@ -85,6 +85,7 @@ class PP_Base(object):
             threshold=threshold,
             cache_file=cache,
         )
+        logger.info(f"Frame cache saved to {os.path.join(output_dir, cache)}.")
 
 
 class PP_Eiger(PP_Base):
@@ -114,8 +115,10 @@ class PP_Eiger(PP_Base):
         self.eiger_stream_v2_threshold = eiger_stream_v2_threshold
         self.eiger_stream_v2_multiplier = eiger_stream_v2_multiplier
         logger.info(
-            f"On Init:\n\t{self.fname}, {self.nframes} frames, "
-            f"{self.omwedges.nframes} omw, {len(self.raw)} total"
+            f"\nFile found at:      {self.fname}\n"
+            f"  File contains:    {len(self.raw)} frames\n"
+            f"  Frames requested: {self.nframes}\n"
+            f"  Skipping first:   {self.frame_start} frames"
         )
 
         if self.is_eiger_stream_v2:
@@ -191,9 +194,12 @@ class PP_Dexela(PP_Base):
         self.use_frame_list = self.nframes != len(
             self.raw
         )  # Framelist fix, DCP 6/18/18
+
         logger.info(
-            f"On Init:\n\t{self.fname}, {self.nframes} frames, "
-            f"{self.omwedges.nframes} omw, {len(self.raw)} total"
+            f"\nFile found at:      {self.fname}\n"
+            f"  File contains:    {len(self.raw)} frames\n"
+            f"  Frames requested: {self.nframes}\n"
+            f"  Skipping first:   {self.frame_start} frames"
         )
 
     def _attach_metadata(self, metadata: dict) -> None:

--- a/hexrd/hedm/preprocess/preprocessors.py
+++ b/hexrd/hedm/preprocess/preprocessors.py
@@ -224,7 +224,7 @@ class PP_Dexela(PP_Base):
 
 
 def preprocess(args: HexrdPPScript_Arguments) -> None:
-    if type(args) == Eiger_Arguments:
+    if isinstance(args, Eiger_Arguments):
         omw = imageseries.omega.OmegaWedges(args.num_frames)
         omw.addwedge(args.ome_start, args.ome_end, args.num_frames)
         ppe = PP_Eiger(
@@ -236,7 +236,7 @@ def preprocess(args: HexrdPPScript_Arguments) -> None:
             eiger_stream_v2_multiplier=args.eiger_stream_v2_multiplier,
         )
         ppe.save_processed(args.output, args.threshold)
-    elif type(args) == Dexelas_Arguments:
+    elif isinstance(args, Dexelas_Arguments):
         omw = imageseries.omega.OmegaWedges(args.num_frames)
         omw.addwedge(args.ome_start, args.ome_end, args.num_frames)
         for file_name in args.file_names:


### PR DESCRIPTION
# Overview

This PR resolves some problems in the Dexela data preprocessing pipeline. Missing functionality is added, and console output is more useful to the end user.

1. Added `ProcessedImageSeries` operations: `add-row`, `add-column`
2. Removed string casting around `json.dumps`, resolves #918 
3. Added missing static typing for the `ArgumentClassesFactory`
4. Improved console logging

# Affected Workflows

This PR clears out the roadblocks to the `preprocess` workflow for Dexela. This feature is now usable.

# Documentation Changes

No documentation changes are required for this PR.