### PR TITLE
Pin setuptools to <82 for anaconda-client

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,9 +50,8 @@ jobs:
           conda config --set solver libmamba
 
           conda activate hexrd
-          # Newer versions of anaconda-client expect setuptools to be present, so we need to
-          # install it also.
-          conda install --override-channels -c conda-forge anaconda-client conda-build conda setuptools
+          # anaconda-client needs pkg_resources, which was removed in setuptools 82.
+          conda install --override-channels -c conda-forge anaconda-client conda-build conda "setuptools<82"
 
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.


### PR DESCRIPTION
# Overview

The anaconda-client expects `pkg_resources` to be present, which was removed in setuptools 82. We have to pin setuptools to fix this issue for now...

Should fix the packaging CI

For reference, see https://github.com/anaconda/anaconda-client/issues/862