### PR TITLE
Ensure multiprocessing pools are joined

### DIFF
--- a/hexrd/hedm/fitgrains.py
+++ b/hexrd/hedm/fitgrains.py
@@ -472,24 +472,25 @@ def fit_grains(
         )
         start = timeit.default_timer()
         pool = constants.mp_context.Pool(nproc, fit_grain_FF_init, (params,))
+        try:
+            async_result = pool.map_async(
+                fit_grain_FF_reduced,
+                np.array(grains_table[:, 0], dtype=int),
+                chunksize=chunksize,
+            )
+            while not async_result.ready():
+                if check_if_canceled_func and check_if_canceled_func():
+                    logger.info('Fit grains canceled.')
+                    # Perform an early return if we need to cancel.
+                    return None
 
-        async_result = pool.map_async(
-            fit_grain_FF_reduced,
-            np.array(grains_table[:, 0], dtype=int),
-            chunksize=chunksize,
-        )
-        while not async_result.ready():
-            if check_if_canceled_func and check_if_canceled_func():
-                pool.terminate()
-                logger.info('Fit grains canceled.')
-                # Perform an early return if we need to cancel.
-                return None
+                async_result.wait(0.25)
 
-            async_result.wait(0.25)
-
-        fit_results = async_result.get()
-        pool.close()
-        pool.join()
+            fit_results = async_result.get()
+            pool.close()
+        finally:
+            pool.terminate()
+            pool.join()
         elapsed = timeit.default_timer() - start
     logger.info("fitting took %f seconds", elapsed)
     if return_pull_spots_data:

--- a/hexrd/hedm/indexer.py
+++ b/hexrd/hedm/indexer.py
@@ -344,6 +344,7 @@ def paintGrid(
         pool = constants.mp_context.Pool(nCPUs, paintgrid_init, (params,))
         retval = pool.map(paintGridThis, quats.T, chunksize=chunksize)
         pool.close()
+        pool.join()
     else:
         # single process version.
         global paramMP


### PR DESCRIPTION
# Overview

We need to wait until the multiprocessing pools fully finish before returning. We are doing this already in most other places in the code, but not in these places.

This might fix https://github.com/HEXRD/hexrdgui/issues/1996

# Affected Workflows

HEDM

# Documentation Changes

None