### PR TITLE
Clarify mean reflections per grain is estimated

### DIFF
--- a/hexrd/hedm/findorientations.py
+++ b/hexrd/hedm/findorientations.py
@@ -856,7 +856,7 @@ def find_orientations(
     else:
         min_samples, mean_rpg = create_clustering_parameters(cfg, eta_ome)
 
-    logger.info("\tmean reflections per grain: %d", mean_rpg)
+    logger.info("\testimated mean number of reflections per grain: %d", mean_rpg)
     logger.info("\tneighborhood size: %d", min_samples)
 
     qbar, cl = run_cluster(


### PR DESCRIPTION
# Overview

This just clarifies the language. It is not always deterministic because a random number generator is being used in `create_clustering_parameters()`. It is just an estimate, and we needed langugage to clarify that is the case.

Fixes: #913

# Affected Workflows

HEDM
