### PR TITLE
Call `conda-build` executable directly

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -37,4 +37,4 @@ conda install --override-channels -c conda-forge conda-build -y
 mkdir output
 
 # Build the package
-conda build --override-channels -c conda-forge --output-folder output/ conda.recipe/
+conda-build --override-channels -c conda-forge --output-folder output/ conda.recipe/


### PR DESCRIPTION
# Overview

I think `conda build` only works if `conda-build` is installed in the base environment. Not sure how it used to work... but `conda-build` as a command will hopefully work.
