### PR TITLE
Try unpinning setuptools

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,8 +50,7 @@ jobs:
           conda config --set solver libmamba
 
           conda activate hexrd
-          # anaconda-client needs pkg_resources, which was removed in setuptools 82.
-          conda install --override-channels -c conda-forge anaconda-client conda-build conda "setuptools<82"
+          conda install --override-channels -c conda-forge anaconda-client conda-build conda
 
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.


### PR DESCRIPTION
# Overview

We hopefully don't need to pin setuptools anymore...

Crossref: https://github.com/anaconda/anaconda-client/issues/862

# Affected Workflows

Just the packaging

# Documentation Changes

None
