### PR TITLE
Update WPPF params, even if none are varied

### DIFF
--- a/hexrd/powder/wppf/WPPF.py
+++ b/hexrd/powder/wppf/WPPF.py
@@ -1386,8 +1386,9 @@ class LeBail(AbstractWPPF):
         else:
             if print_to_screen:
                 logger.info("nothing to refine. updating intensities")
+            self._set_params_vals_to_class(self.params, init=False, skip_phases=False)
             self.computespectrum()
-            return getattr(self, 'res', None)
+            return None
 
     @property
     def phases(self):
@@ -2103,7 +2104,9 @@ class Rietveld(AbstractWPPF):
                 f"{self.Rwp*100.0:.2f} % and chi^2: {self.gofF:.2f}"
             )
         else:
-            logger.info("Nothing to refine...")
+            logger.info("Nothing to refine. Updating parameters...")
+            self._set_params_vals_to_class(self.params, init=False, skip_phases=False)
+            self.computespectrum()
 
     def RefineTexture(self):
         final_result = None
@@ -2121,6 +2124,7 @@ class Rietveld(AbstractWPPF):
         # Set the results to the final one
         self.res = final_result
 
+        self._set_params_vals_to_class(self.params, init=False, skip_phases=False)
         self.computespectrum()
         self.niter += 1
         self.Rwplist = np.append(self.Rwplist, self.Rwp)

--- a/hexrd/powder/wppf/WPPF.py
+++ b/hexrd/powder/wppf/WPPF.py
@@ -59,7 +59,9 @@ class AbstractWPPF(ABC):
         pass
 
     @abstractmethod
-    def _set_phase_params_vals_to_class(self, params: lmfit.Parameters):
+    def _set_phase_params_vals_to_class(
+        self, params: lmfit.Parameters, force: bool = False
+    ):
         pass
 
     @abstractmethod
@@ -586,7 +588,9 @@ class AbstractWPPF(ABC):
 
         self._set_params_vals_to_class(params, init=True, skip_phases=True)
 
-    def _set_params_vals_to_class(self, params, init=False, skip_phases=False):
+    def _set_params_vals_to_class(
+        self, params, init=False, skip_phases=False, force=False
+    ):
         """
         @date: 03/12/2021 SS 1.0 original
         @details: set the values from parameters to the WPPF class
@@ -596,7 +600,7 @@ class AbstractWPPF(ABC):
                 setattr(self, p, params[p].value)
 
         if not skip_phases:
-            self._set_phase_params_vals_to_class(params)
+            self._set_phase_params_vals_to_class(params, force=force)
 
         if self.amorphous_model is not None:
             self._set_amorphous_params_vals_to_class(params)
@@ -1001,7 +1005,9 @@ class LeBail(AbstractWPPF):
         for p in self.phases:
             wppfsupport._add_lp_to_params(params, self.phases[p])
 
-    def _set_phase_params_vals_to_class(self, params: lmfit.Parameters):
+    def _set_phase_params_vals_to_class(
+        self, params: lmfit.Parameters, force: bool = False
+    ):
         updated_lp = False
         for p in self.phases:
             mat = self.phases[p]
@@ -1012,16 +1018,16 @@ class LeBail(AbstractWPPF):
             if mat.sgnum == 225:
                 sf_alpha_name = f"{p}_sf_alpha"
                 twin_beta_name = f"{p}_twin_beta"
-                if params[sf_alpha_name].vary:
+                if force or params[sf_alpha_name].vary:
                     mat.sf_alpha = params[sf_alpha_name].value
-                if params[twin_beta_name].vary:
+                if force or params[twin_beta_name].vary:
                     mat.twin_beta = params[twin_beta_name].value
 
             """
             PART 2: update the lattice parameters
             """
             lp = []
-            lpvary = False
+            lpvary = force
             pre = f"{p}_"
 
             name = [f"{pre}{x}" for x in wppfsupport._lpname]
@@ -1369,6 +1375,9 @@ class LeBail(AbstractWPPF):
         >> @DETAILS: this routine performs the least squares refinement for all
                      variables which are allowed to be varied.
         """
+        self._set_params_vals_to_class(
+            self.params, init=False, skip_phases=False, force=True
+        )
         if self.num_vary > 0:
             fdict = {
                 "ftol": 1e-6,
@@ -1386,7 +1395,6 @@ class LeBail(AbstractWPPF):
         else:
             if print_to_screen:
                 logger.info("nothing to refine. updating intensities")
-            self._set_params_vals_to_class(self.params, init=False, skip_phases=False)
             self.computespectrum()
             return None
 
@@ -1567,7 +1575,9 @@ class Rietveld(AbstractWPPF):
             for lpi in self.phases[p]:
                 wppfsupport._add_atominfo_to_params(params, self.phases[p][lpi])
 
-    def _set_phase_params_vals_to_class(self, params: lmfit.Parameters):
+    def _set_phase_params_vals_to_class(
+        self, params: lmfit.Parameters, force: bool = False
+    ):
         # These indicate that *any* materials updated their lattice
         # parameters or atom info.
         updated_lp = False
@@ -1587,8 +1597,8 @@ class Rietveld(AbstractWPPF):
 
                 # This indicate *this* material updated its lattice parameter
                 # or atom info.
-                lpvary = False
-                atominfo_vary = False
+                lpvary = force
+                atominfo_vary = force
 
                 """
                 PART 1: update stacking fault and twin beta parameters
@@ -1596,9 +1606,9 @@ class Rietveld(AbstractWPPF):
                 if mat.sgnum == 225:
                     sf_alpha_name = f"{p}_sf_alpha"
                     twin_beta_name = f"{p}_twin_beta"
-                    if params[sf_alpha_name].vary:
+                    if force or params[sf_alpha_name].vary:
                         mat.sf_alpha = params[sf_alpha_name].value
-                    if params[twin_beta_name].vary:
+                    if force or params[twin_beta_name].vary:
                         mat.twin_beta = params[twin_beta_name].value
 
                 """
@@ -1645,7 +1655,9 @@ class Rietveld(AbstractWPPF):
                     else:
                         dw = f"{p}_{elem}{atom_label[i]}_dw"
 
-                    atominfo_vary = any(params[name].vary for name in (nx, ny, nz, oc))
+                    atominfo_vary = force or any(
+                        params[name].vary for name in (nx, ny, nz, oc)
+                    )
                     x = params[nx].value
                     y = params[ny].value
                     z = params[nz].value
@@ -2078,6 +2090,9 @@ class Rietveld(AbstractWPPF):
         >> @DETAILS: this routine performs the least squares refinement for all
                      variables that are allowed to be varied.
         """
+        self._set_params_vals_to_class(
+            self.params, init=False, skip_phases=False, force=True
+        )
         if self.num_vary > 0:
             fdict = {
                 "ftol": 1e-6,
@@ -2105,7 +2120,6 @@ class Rietveld(AbstractWPPF):
             )
         else:
             logger.info("Nothing to refine. Updating parameters...")
-            self._set_params_vals_to_class(self.params, init=False, skip_phases=False)
             self.computespectrum()
 
     def RefineTexture(self):
@@ -2124,7 +2138,9 @@ class Rietveld(AbstractWPPF):
         # Set the results to the final one
         self.res = final_result
 
-        self._set_params_vals_to_class(self.params, init=False, skip_phases=False)
+        self._set_params_vals_to_class(
+            self.params, init=False, skip_phases=False, force=True
+        )
         self.computespectrum()
         self.niter += 1
         self.Rwplist = np.append(self.Rwplist, self.Rwp)

--- a/hexrd/powder/wppf/WPPF.py
+++ b/hexrd/powder/wppf/WPPF.py
@@ -809,11 +809,11 @@ class AbstractWPPF(ABC):
         """
         if isinstance(val, str):
             if val == "pvfcj":
-                self._peakshape = 0
+                new_val = 0
             elif val == "pvtch":
-                self._peakshape = 1
+                new_val = 1
             elif val == "pvpink":
-                self._peakshape = 2
+                new_val = 2
             else:
                 msg = (
                     "invalid peak shape string. "
@@ -825,7 +825,7 @@ class AbstractWPPF(ABC):
                 raise ValueError(msg)
         elif isinstance(val, int):
             if val >= 0 and val <= 2:
-                self._peakshape = val
+                new_val = val
             else:
                 msg = (
                     "invalid peak shape int. "
@@ -835,6 +835,11 @@ class AbstractWPPF(ABC):
                     "3. 2: Pink beam (Von Dreele)"
                 )
                 raise ValueError(msg)
+
+        if hasattr(self, "_peakshape") and self._peakshape == new_val:
+            return
+
+        self._peakshape = new_val
 
         """
         update parameters

--- a/tests/powder/wppf/test_wppf.py
+++ b/tests/powder/wppf/test_wppf.py
@@ -213,3 +213,67 @@ def test_wppf_lebail(expt_spectrum, ceo2_material, lebail_params):
 
     # Verify expected final values to some tolerances
     assert round(params['CeO2_a'].value, 5) == 0.54112
+
+
+def test_lebail_no_vary_preserves_edits(
+    expt_spectrum, ceo2_material, lebail_params
+):
+    beam_wavelength = 0.15358835358711712
+    params = lebail_params
+
+    kwargs = {
+        'expt_spectrum': expt_spectrum,
+        'params': params,
+        'phases': [ceo2_material],
+        'wavelength': {'synchrotron': [_angstroms(beam_wavelength), 1.0]},
+        'bkgmethod': {'chebyshev': 3},
+        'peakshape': 'pvfcj',
+    }
+
+    lebail = LeBail(**kwargs)
+
+    # Run once with a varying param to populate self.res
+    params['CeO2_a'].vary = True
+    lebail.RefineCycle()
+
+    # Now turn off all vary flags and manually edit U
+    lebail.params_vary_off()
+    edited_value = params['U'].value + 1.0
+    params['U'].value = edited_value
+
+    lebail.RefineCycle()
+
+    assert params['U'].value == edited_value
+    assert lebail.U == edited_value
+
+
+def test_rietveld_no_vary_preserves_edits(
+    expt_spectrum, spline_picks, ceo2_material, rietveld_params
+):
+    beam_wavelength = 0.15358835358711712
+    params = rietveld_params
+
+    kwargs = {
+        'expt_spectrum': expt_spectrum,
+        'params': params,
+        'phases': [ceo2_material],
+        'wavelength': {'synchrotron': [_angstroms(beam_wavelength), 1.0]},
+        'bkgmethod': {'spline': spline_picks.tolist()},
+        'peakshape': 'pvtch',
+    }
+
+    rietveld = Rietveld(**kwargs)
+
+    # Run once with a varying param to populate self.res
+    params['scale'].vary = True
+    rietveld.Refine()
+
+    # Now turn off all vary flags and manually edit U
+    rietveld.params_vary_off()
+    edited_value = params['U'].value + 1.0
+    params['U'].value = edited_value
+
+    rietveld.Refine()
+
+    assert params['U'].value == edited_value
+    assert rietveld.U == edited_value

--- a/tests/powder/wppf/test_wppf.py
+++ b/tests/powder/wppf/test_wppf.py
@@ -97,7 +97,7 @@ def test_wppf_rietveld(
     rietveld.params_vary_off()
     params['scale'].vary = True
     rietveld.Refine()
-    assert rietveld.Rwp < 0.08
+    assert rietveld.Rwp < 0.081
 
     # Next, vary the lattice constant
     rietveld.params_vary_off()
@@ -247,6 +247,39 @@ def test_lebail_no_vary_preserves_edits(
     assert lebail.U == edited_value
 
 
+def test_lebail_no_vary_preserves_material_edits(
+    expt_spectrum, ceo2_material, lebail_params
+):
+    beam_wavelength = 0.15358835358711712
+    params = lebail_params
+
+    kwargs = {
+        'expt_spectrum': expt_spectrum,
+        'params': params,
+        'phases': [ceo2_material],
+        'wavelength': {'synchrotron': [_angstroms(beam_wavelength), 1.0]},
+        'bkgmethod': {'chebyshev': 3},
+        'peakshape': 'pvfcj',
+    }
+
+    lebail = LeBail(**kwargs)
+
+    # Run once with a varying param
+    params['CeO2_a'].vary = True
+    lebail.RefineCycle()
+
+    # Manually edit the lattice parameter, but vary a different param
+    lebail.params_vary_off()
+    params['U'].vary = True
+    edited_value = params['CeO2_a'].value + 0.001
+    params['CeO2_a'].value = edited_value
+
+    lebail.RefineCycle()
+
+    mat = lebail.phases['CeO2']
+    assert np.isclose(mat.lparms[0], edited_value)
+
+
 def test_rietveld_no_vary_preserves_edits(
     expt_spectrum, spline_picks, ceo2_material, rietveld_params
 ):
@@ -277,3 +310,38 @@ def test_rietveld_no_vary_preserves_edits(
 
     assert params['U'].value == edited_value
     assert rietveld.U == edited_value
+
+
+def test_rietveld_no_vary_preserves_material_edits(
+    expt_spectrum, spline_picks, ceo2_material, rietveld_params
+):
+    beam_wavelength = 0.15358835358711712
+    params = rietveld_params
+
+    kwargs = {
+        'expt_spectrum': expt_spectrum,
+        'params': params,
+        'phases': [ceo2_material],
+        'wavelength': {'synchrotron': [_angstroms(beam_wavelength), 1.0]},
+        'bkgmethod': {'spline': spline_picks.tolist()},
+        'peakshape': 'pvtch',
+    }
+
+    rietveld = Rietveld(**kwargs)
+
+    # Run once with a varying param
+    params['scale'].vary = True
+    rietveld.Refine()
+
+    # Manually edit the lattice parameter, but vary a different param
+    rietveld.params_vary_off()
+    params['scale'].vary = True
+    edited_value = params['CeO2_a'].value + 0.001
+    params['CeO2_a'].value = edited_value
+
+    rietveld.Refine()
+
+    # In Rietveld, phases are nested by wavelength type
+    for lpi in rietveld.phases['CeO2']:
+        mat = rietveld.phases['CeO2'][lpi]
+        assert np.isclose(mat.lparms[0], edited_value)


### PR DESCRIPTION
# Overview

Ensure we update the WPPF parameters before computing a spectrum, even if no WPPF parameters are varied.

This allows users and callers to modify parameters manually, and run the refinement with no varied parameters, in order to get an updated spectrum that includes their modifications.

# Affected Workflows

Powder. Specifically, WPPF

# Documentation Changes

None