### PR TITLE
Fix exclusion ordering on lattice param change

### DIFF
--- a/hexrd/core/material/crystallography.py
+++ b/hexrd/core/material/crystallography.py
@@ -900,7 +900,7 @@ class PlaneData(object):
         retval = np.zeros(self.getNhklRef(), dtype=bool)
         if self._exclusions is not None:
             # report in current hkl ordering
-            retval[:] = self._exclusions[self.tThSortInv]
+            retval[:] = self._exclusions[self.tThSort]
         if self._tThMax is not None:
             for iHKLr, hklData in enumerate(self.hklDataList):
                 if hklData['tTheta'] > self._tThMax:
@@ -917,15 +917,15 @@ class PlaneData(object):
                     exclusions.dtype == 'bool'
                 ), 'Exclusions should be bool if full length'
                 # convert from current hkl ordering to _hkl ordering
-                excl[:] = exclusions[self.tThSort]
+                excl[:] = exclusions[self.tThSortInv]
             else:
                 if len(exclusions.shape) == 1:
                     # treat exclusions as indices
-                    excl[self.tThSort[exclusions]] = True
+                    excl[self.tThSortInv[exclusions]] = True
                 elif len(exclusions.shape) == 2:
                     # treat exclusions as ranges of indices
                     for r in exclusions:
-                        excl[self.tThSort[r[0] : r[1]]] = True
+                        excl[self.tThSortInv[r[0] : r[1]]] = True
                 else:
                     raise RuntimeError(f'Unclear behavior for shape {exclusions.shape}')
         self._exclusions = excl

--- a/tests/planedata/test_exclusion.py
+++ b/tests/planedata/test_exclusion.py
@@ -29,3 +29,28 @@ def test_exclusion():
     pd.exclusions = [[0, 2]]
     assert pd.nHKLs == 1
     assert pd.getNhklRef() == 3
+
+
+def test_exclusions_survive_lparms_change():
+    pd = PlaneData(
+        np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        np.array([2.0, 3.0, 4.0, 90.0, 90.0, 90.0]),
+        'D2h',
+        0.5,
+        0.01,
+    )
+
+    # Select only the second hkl in sorted order
+    excl = np.ones(pd.getNhklRef(), dtype=bool)
+    excl[1] = False
+    pd.exclusions = excl
+    selected_hkl = pd.getHKLs(allHKLs=True)[1].tolist()
+
+    # Change lparms enough to re-sort
+    pd.lparms = [2.0, 3.0, 1.5, 90.0, 90.0, 90.0]
+
+    # The same hkl should still be selected
+    all_hkls = pd.getHKLs(allHKLs=True)
+    new_excl = pd.exclusions
+    new_selected = [all_hkls[i].tolist() for i, e in enumerate(new_excl) if not e]
+    assert new_selected == [selected_hkl]


### PR DESCRIPTION
# Overview

Previously, `tThSort` and `tThSortInv` would effectively cancel each other out, as long as the two theta ordering stayed constant (which is usually true for high symmetry systems). This issue would not be encountered by most users, since most users are dealing with high symmetry systems.

In low symmetry systems, the two theta ordering can be more easily re-arranged on lattice parameter changes, so this would land the exclusions at incorrect indices.

An example of this issue in the GUI: if you had a triclinic material and selected HKL `002`, then changed the `c` lattice parameter, the selected HKL could be changed to something else, like `-1 -1 2`.

A simple test was added that reproduced the issue, and that also verifies that the issue is fixed.

# Affected Workflows

All

# Documentation Changes

None