### PR TITLE
Avoid converting 1D array to scalar

### DIFF
--- a/hexrd/core/fitting/calibration/laue.py
+++ b/hexrd/core/fitting/calibration/laue.py
@@ -561,14 +561,13 @@ def gaussian_2d(p, data):
 
 
 def gaussian_2d_int(y, x, *p):
-    func = p[0] * np.exp(
+    return p[0] * np.exp(
         -(
             p[1] * (x - p[4]) * (x - p[4])
             + p[2] * (x - p[4]) * (y - p[5])
             + p[3] * (y - p[5]) * (y - p[5])
         )
     )
-    return func.flatten()
 
 
 reflInfo_dtype = [

--- a/hexrd/core/fitting/spectrum.py
+++ b/hexrd/core/fitting/spectrum.py
@@ -388,13 +388,14 @@ class SpectrumModel(object):
 
         xdata, ydata = data.T
         window_range = (np.min(xdata), np.max(xdata))
+        window_width = window_range[1] - window_range[0]
         ymax = np.max(ydata)
 
         self._tth0 = peak_centers
         num_peaks = len(peak_centers)
 
         if fwhm_init is None:
-            fwhm_init = np.diff(window_range) / (20.0 * num_peaks)
+            fwhm_init = window_width / (20.0 * num_peaks)
 
         self._min_pk_sep = min_pk_sep
 
@@ -427,7 +428,7 @@ class SpectrumModel(object):
         _set_width_mixing_bounds(
             initial_params_pks,
             min_w=fwhm_min,
-            max_w=0.9 * float(np.diff(window_range)),
+            max_w=0.9 * window_width,
         )
         _set_bound_constraints(
             initial_params_pks, 'amp', min_val=min_ampl, max_val=1.5 * ymax
@@ -507,6 +508,7 @@ class SpectrumModel(object):
     def fit(self):
         xdata, ydata = self.data.T
         window_range = (np.min(xdata), np.max(xdata))
+        window_width = window_range[1] - window_range[0]
         if self.pktype == 'pink_beam_dcs':
             for pname, param in self.peak_params.items():
                 if 'alpha' in pname or 'beta' in pname or 'fwhm' in pname:
@@ -525,7 +527,7 @@ class SpectrumModel(object):
                 _set_width_mixing_bounds(
                     new_p,
                     min_w=fwhm_min,
-                    max_w=0.9 * float(np.diff(window_range)),
+                    max_w=0.9 * window_width,
                 )
                 # !!! not sure on this, but it seems
                 #     to give more stable results with many peaks

--- a/hexrd/laue/fitting/calibration/laue.py
+++ b/hexrd/laue/fitting/calibration/laue.py
@@ -569,14 +569,13 @@ def gaussian_2d(p, data):
 
 
 def gaussian_2d_int(y, x, *p):
-    func = p[0] * np.exp(
+    return p[0] * np.exp(
         -(
             p[1] * (x - p[4]) * (x - p[4])
             + p[2] * (x - p[4]) * (y - p[5])
             + p[3] * (y - p[5]) * (y - p[5])
         )
     )
-    return func.flatten()
 
 
 reflInfo_dtype = [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_reqs = [
     'lmfit',
     'matplotlib',
     'numba',
-    'numpy<2.4',  # noqa NOTE: bump this to support the latest version numba supports
+    'numpy',
     'psutil',
     'pycifrw',
     'pyyaml',


### PR DESCRIPTION
# Overview

`np.diff()` is returning a 1D array. In older versions of numpy, we used to be able to convert a 1D array to a scalar, but new versions of numpy do not allow it.

Instead, manually compute the window_width. It is simpler and easier to read, anyways.

Fixes: https://github.com/HEXRD/hexrdgui/issues/2016

# Affected Workflows

Powder

# Documentation Changes

None