### PR TITLE
Fix all deprecation warnings from the tests

### DIFF
--- a/hexrd/core/gridutil.py
+++ b/hexrd/core/gridutil.py
@@ -178,7 +178,9 @@ def computeArea(polygon):
     area = 0
     for [s1, s2] in triv:
         tvp = np.diff(np.hstack([polygon[s1, :], polygon[s2, :]]), axis=0).flatten()
-        area += 0.5 * np.cross(tvp[:2], tvp[2:])
+        # 2D cross product (z-component); np.cross on 2-vectors is
+        # deprecated in NumPy 2.0
+        area += 0.5 * (tvp[0] * tvp[3] - tvp[1] * tvp[2])
     return area
 
 

--- a/hexrd/core/imageseries/load/framecache.py
+++ b/hexrd/core/imageseries/load/framecache.py
@@ -61,7 +61,7 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
 
     def _load_yml(self) -> None:
         with open(self._fname, "r") as f:
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         datad = d['data']
         self._cache = datad['file']
         self._nframes: int = datad['nframes']

--- a/hexrd/core/material/utils.py
+++ b/hexrd/core/material/utils.py
@@ -93,33 +93,33 @@ def calculate_linear_absorption_length(density, formula, energy_vector):
         the attenuation length in microns
 
     """
-    data = importlib.resources.open_binary(hexrd.core.resources, 'mu_en.h5')
-    fid = h5py.File(data, 'r')
-
     formula_dict = interpret_formula(formula)
     molecular_mass = calculate_molecular_mass(formula)
 
     density_conv = density
 
+    resource = importlib.resources.files(hexrd.core.resources) / 'mu_en.h5'
     mu_rho = 0.0
-    for k, v in formula_dict.items():
-        wi = v * ATOM_WEIGHTS_DICT[k] / molecular_mass
+    with importlib.resources.as_file(resource) as data_path, \
+            h5py.File(data_path, 'r') as fid:
+        for k, v in formula_dict.items():
+            wi = v * ATOM_WEIGHTS_DICT[k] / molecular_mass
 
-        d = np.array(fid[f"/{k}/data"])
+            d = np.array(fid[f"/{k}/data"])
 
-        E = d[:, 0]
-        mu_rho_tab = d[:, 1]
+            E = d[:, 0]
+            mu_rho_tab = d[:, 1]
 
-        val = np.interp(
-            np.log(energy_vector),
-            np.log(E),
-            np.log(mu_rho_tab),
-            left=0.0,
-            right=0.0,
-        )
+            val = np.interp(
+                np.log(energy_vector),
+                np.log(E),
+                np.log(mu_rho_tab),
+                left=0.0,
+                right=0.0,
+            )
 
-        val = np.exp(val)
-        mu_rho += wi * val
+            val = np.exp(val)
+            mu_rho += wi * val
 
     mu = mu_rho * density_conv  # this is in cm^-1
     mu = mu * 1e-4  # this is in mm^-1
@@ -156,33 +156,33 @@ def calculate_energy_absorption_length(density, formula, energy_vector):
         the attenuation length in microns
 
     """
-    data = importlib.resources.open_binary(hexrd.core.resources, 'mu_en.h5')
-    fid = h5py.File(data, 'r')
-
     formula_dict = interpret_formula(formula)
     molecular_mass = calculate_molecular_mass(formula)
 
     density_conv = density
 
+    resource = importlib.resources.files(hexrd.core.resources) / 'mu_en.h5'
     mu_rho = 0.0
-    for k, v in formula_dict.items():
-        wi = v * ATOM_WEIGHTS_DICT[k] / molecular_mass
+    with importlib.resources.as_file(resource) as data_path, \
+            h5py.File(data_path, 'r') as fid:
+        for k, v in formula_dict.items():
+            wi = v * ATOM_WEIGHTS_DICT[k] / molecular_mass
 
-        d = np.array(fid[f"/{k}/data"])
+            d = np.array(fid[f"/{k}/data"])
 
-        E = d[:, 0]
-        mu_rho_tab = d[:, 2]
+            E = d[:, 0]
+            mu_rho_tab = d[:, 2]
 
-        val = np.interp(
-            np.log(energy_vector),
-            np.log(E),
-            np.log(mu_rho_tab),
-            left=0.0,
-            right=0.0,
-        )
-        val = np.exp(val)
+            val = np.interp(
+                np.log(energy_vector),
+                np.log(E),
+                np.log(mu_rho_tab),
+                left=0.0,
+                right=0.0,
+            )
+            val = np.exp(val)
 
-        mu_rho += wi * val
+            mu_rho += wi * val
 
     mu = mu_rho * density_conv  # this is in cm^-1
     mu = mu * 1e-4  # this is in microns^-1
@@ -247,11 +247,9 @@ def calculate_incoherent_scattering_factor(
     Q: NDArray[np.float64],
 ) -> NDArray[np.float64]:
 
-    with importlib.resources.open_binary(
-        hexrd.resources,
-        'Anomalous.h5',
-    ) as data:
-        with h5py.File(data, 'r') as f:
+    resource = importlib.resources.files(hexrd.resources) / 'Anomalous.h5'
+    with importlib.resources.as_file(resource) as data_path:
+        with h5py.File(data_path, 'r') as f:
             compton_table = f[element]['compton'][()]
 
     interp = interp1d(

--- a/hexrd/core/matrixutil.py
+++ b/hexrd/core/matrixutil.py
@@ -260,8 +260,8 @@ def rankOneMatrix(vec1, *args):
         if len(vec1.shape) > 2:
             raise RuntimeError("input vec2 is the wrong shape")
 
-    m1, n1 = np.asmatrix(vec1).shape
-    m2, n2 = np.asmatrix(vec2).shape
+    m1, n1 = np.atleast_2d(vec1).shape
+    m2, n2 = np.atleast_2d(vec2).shape
 
     if n1 != n2:
         raise RuntimeError("Number of vectors differ in arguments.")

--- a/hexrd/core/rotations.py
+++ b/hexrd/core/rotations.py
@@ -1118,7 +1118,7 @@ def mapAngle(
     else:
         raise RuntimeError("unknown angular units: " + units)
 
-    ang = np.nan_to_num(np.atleast_1d(np.float64(ang)))
+    ang = np.nan_to_num(np.atleast_1d(np.asarray(ang, dtype=np.float64)))
 
     min_val = -period / 2
     max_val = period / 2

--- a/hexrd/core/utils/profiler.py
+++ b/hexrd/core/utils/profiler.py
@@ -79,7 +79,7 @@ def parse_file(filename):
         import yaml
 
         with open(filename, 'r') as f:
-            cfg = yaml.load(f)
+            cfg = yaml.safe_load(f)
 
         if 'profile' not in cfg:
             msg = 'profile file "{0}" missing a profile section'

--- a/hexrd/powder/wppf/phase.py
+++ b/hexrd/powder/wppf/phase.py
@@ -738,8 +738,9 @@ class Material_Rietveld(Material_LeBail):
 
     def InitializeInterpTable(self):
         f_anomalous_data = []
-        data = importlib.resources.open_binary(hexrd.core.resources, 'Anomalous.h5')
-        with h5py.File(data, 'r') as fid:
+        resource = importlib.resources.files(hexrd.core.resources) / 'Anomalous.h5'
+        with importlib.resources.as_file(resource) as data_path, \
+                h5py.File(data_path, 'r') as fid:
             for i in range(0, self.atom_ntype):
                 Z = self.atom_type[i]
                 elem = constants.ptableinverse[Z]


### PR DESCRIPTION
# Overview

* material/utils.py & wppf/phase.py — importlib.resources.open_binary -> files()/as_file(): clears open_binary `DeprecationWarning` and the unclosed-file `ResourceWarning` (mu_en.h5 / Anomalous.h5).
* rotations.py — np.float64(array) -> np.asarray(...): clears the NumPy "conversion of an array with ndim > 0 to a scalar is deprecated" `DeprecationWarning`.
* matrixutil.py — np.asmatrix -> np.atleast_2d: clears the np.matrix subclass `PendingDeprecationWarning`.
* gridutil.py — np.cross on 2-vectors -> explicit scalar form: clears the NumPy 2.0 "arrays of 2-dimensional vectors are deprecated" `DeprecationWarning`.

# Affected Workflows

None

# Documentation Changes

None