### PR TITLE
Require tth width in HEDM config

### DIFF
--- a/hexrd/core/config/material.py
+++ b/hexrd/core/config/material.py
@@ -66,7 +66,15 @@ class MaterialConfig(Config):
     @property
     def tthw(self):
         """Return the specified tth tolerance."""
-        return self._cfg.get('material:tth_width', TTHW_DFLT)
+        # The HEDM workflow requires a fixed 2-theta width, so fall back to the
+        # default if one is not specified. A material may legitimately have a
+        # tThWidth of None (meaning "no fixed width"), which gets serialized as
+        # `tth_width: null`; treat that the same as an absent key rather than
+        # passing None through (which would crash the workflow).
+        tthw = self._cfg.get('material:tth_width', TTHW_DFLT)
+        if tthw is None:
+            tthw = TTHW_DFLT
+        return tthw
 
     @property
     def fminr(self):

--- a/tests/config/test_material.py
+++ b/tests/config/test_material.py
@@ -1,5 +1,6 @@
 from .common import TestConfig, test_data
-from hexrd.core.config.material import TTHW_DFLT, DMIN_DFLT
+from hexrd.core.config.material import TTHW_DFLT
+from hexrd.core.config.root import RootConfig
 from hexrd.core.config.utils import get_exclusion_parameters
 
 
@@ -70,6 +71,13 @@ class TestMaterialConfig(TestConfig):
         self.assertEqual(self.cfgs[0].material.tthw, TTHW_DFLT)
         self.assertEqual(self.cfgs[1].material.tthw, 0.2)
         self.assertEqual(self.cfgs[2].material.tthw, 0.2)
+
+    def test_two_theta_width_null(self):
+        # A material with no fixed width serializes as `tth_width: null`. This
+        # must fall back to the default rather than passing None through (which
+        # would crash the HEDM workflow).
+        cfg = RootConfig({'material': {'tth_width': None}})
+        self.assertEqual(cfg.material.tthw, TTHW_DFLT)
 
     def test_reset_exclusions(self):
         self.assertEqual(self.cfgs[0].material.reset_exclusions, True)


### PR DESCRIPTION
# Overview

If a material was saved with a tth width of `None`, the HEDM config will return the default tth width of 0.25 degrees, because the HEDM workflow always requires a tth width.

This reflects previous behavior, until recently (#910), which allowed `None` to be properly saved in a materials file. Before that PR, there was always at least a default tth width, and never `None`. Since that PR was merged, materials files can have `None` set in them, so we must make sure a valid tth width is set for the HEDM workflow.

Fixes: https://github.com/HEXRD/hexrdgui/issues/2022

# Affected Workflows

HEDM

# Documentation Changes

None