### PR TITLE
Add MultiInstrumentCalibrator

### DIFF
--- a/hexrd/core/fitting/calibration/__init__.py
+++ b/hexrd/core/fitting/calibration/__init__.py
@@ -1,4 +1,4 @@
-from .instrument import InstrumentCalibrator
+from .instrument import InstrumentCalibrator, MultiInstrumentCalibrator
 from .laue import LaueCalibrator
 from .lmfit_param_handling import fix_detector_y
 from .powder import PowderCalibrator
@@ -10,6 +10,7 @@ StructureLessCalibrator = StructurelessCalibrator
 __all__ = [
     'fix_detector_y',
     'InstrumentCalibrator',
+    'MultiInstrumentCalibrator',
     'LaueCalibrator',
     'PowderCalibrator',
     'StructurelessCalibrator',

--- a/hexrd/core/fitting/calibration/instrument.py
+++ b/hexrd/core/fitting/calibration/instrument.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 import lmfit
 import numpy as np
+from numpy.typing import NDArray
 
 from .lmfit_param_handling import (
     add_engineering_constraints,
@@ -23,6 +24,20 @@ logger.setLevel('INFO')
 
 def _normalized_ssqr(resd):
     return np.sum(resd * resd) / len(resd)
+
+
+def _params_equal(a: Any, b: Any) -> bool:
+    # Recursively compare relative-constraint params, which may nest dicts of
+    # numpy arrays (a plain ``==`` raises on array truthiness).
+    if isinstance(a, dict) and isinstance(b, dict):
+        if a.keys() != b.keys():
+            return False
+        return all(_params_equal(a[k], b[k]) for k in a)
+
+    if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+        return np.array_equal(a, b)
+
+    return a == b
 
 
 class InstrumentCalibrator:
@@ -198,6 +213,216 @@ class InstrumentCalibrator:
 
         resd1 = self.residual()
 
+        nrm_ssr_1 = _normalized_ssqr(resd1)
+
+        delta_r = 1.0 - nrm_ssr_1 / nrm_ssr_0
+
+        if delta_r > 0:
+            logger.debug('OPTIMIZATION SUCCESSFUL')
+        else:
+            logger.warning('no improvement in residual')
+
+        logger.info('normalized initial ssr: %.4e' % nrm_ssr_0)
+        logger.info('normalized final ssr: %.4e' % nrm_ssr_1)
+        logger.info('change in resdiual: %.4e' % delta_r)
+
+        self.params = result.params
+        self.update_all_from_params(self.params)
+
+        return result
+
+
+class MultiInstrumentCalibrator:
+    """Calibrate several instruments simultaneously with a shared geometry.
+
+    Each entry is an ``InstrumentCalibrator`` describing one dataset (for
+    example, one rotation scan), with its own instrument and its own
+    sub-calibrators (grains, powder rings, ...). The detector geometry (panel
+    tilts/translations/distortion and the beam) is shared across every
+    instrument, while the oscillation stage (``instr.chi`` and ``instr.tvec``)
+    and the sub-calibrator parameters (grains, lattice, ...) remain independent
+    per dataset.
+
+    Sharing is achieved through lmfit parameter names: the geometry parameters
+    are created once (from the first calibrator) and every other instrument
+    reads them by the same name. The stage parameters are created per dataset
+    with a unique prefix so each dataset keeps its own rotation axis and sample
+    offset. All residuals are stacked into a single vector and minimized
+    together.
+    """
+
+    def __init__(
+        self,
+        calibrators: Sequence['InstrumentCalibrator'],
+        labels: Optional[Sequence[str]] = None,
+        engineering_constraints: Optional[str] = None,
+    ):
+        assert len(calibrators) > 0, "must have at least one calibrator"
+        self.calibrators = list(calibrators)
+
+        # The geometry (detectors + beam) is created only from calibrators[0]
+        # and every other instrument reads it back by the same (unprefixed)
+        # detector key / beam name. A mismatch would KeyError deep in the fit,
+        # so require an identical detector layout across all calibrators.
+        reference_detectors = set(self.calibrators[0].instr.detectors)
+        reference_beams = set(self.calibrators[0].instr.beam_dict)
+        for i, calib in enumerate(self.calibrators[1:], start=1):
+            detectors = set(calib.instr.detectors)
+            if detectors != reference_detectors:
+                extra = detectors - reference_detectors
+                missing = reference_detectors - detectors
+                raise ValueError(
+                    f"calibrator {i} has a different detector layout than "
+                    f"calibrator 0; extra detectors: {sorted(extra)}, "
+                    f"missing detectors: {sorted(missing)}"
+                )
+
+            beams = set(calib.instr.beam_dict)
+            if beams != reference_beams:
+                extra = beams - reference_beams
+                missing = reference_beams - beams
+                raise ValueError(
+                    f"calibrator {i} has a different beam layout than "
+                    f"calibrator 0; extra beams: {sorted(extra)}, "
+                    f"missing beams: {sorted(missing)}"
+                )
+
+        # Only calibrators[0]'s relative_constraints actually take effect for
+        # the shared geometry, so require every calibrator to agree on them.
+        reference_constraints = self.calibrators[0].relative_constraints
+        for i, calib in enumerate(self.calibrators[1:], start=1):
+            constraints = calib.relative_constraints
+            if type(constraints) is not type(
+                reference_constraints
+            ) or not _params_equal(
+                constraints.params, reference_constraints.params
+            ):
+                raise ValueError(
+                    f"calibrator {i} has different relative_constraints than "
+                    f"calibrator 0; all calibrators must share the same "
+                    f"relative_constraints"
+                )
+
+        if labels is None:
+            labels = [f'scan_{i}' for i in range(len(self.calibrators))]
+        assert len(labels) == len(self.calibrators), (
+            "must have one label per calibrator"
+        )
+        if len(set(labels)) != len(labels):
+            raise ValueError(f"labels must be unique, got: {labels}")
+        self.labels = list(labels)
+
+        self._engineering_constraints = engineering_constraints
+
+        self.params = self.make_lmfit_params()
+
+        # Sync every instrument to the shared (first calibrator) geometry so
+        # the initial residual is consistent before the first minimizer step.
+        self.update_all_from_params(self.params)
+
+        self.fitter = lmfit.Minimizer(
+            self.minimizer_function, self.params, nan_policy='omit'
+        )
+
+    def _stage_prefix(self, index: int) -> str:
+        return f'{self.labels[index]}_'
+
+    def make_lmfit_params(self) -> lmfit.Parameters:
+        all_params = []
+        for i, calib in enumerate(self.calibrators):
+            # Geometry (beam + detectors) is shared, so it is only created for
+            # the first instrument. Every other instrument references it by the
+            # same parameter names.
+            instr_params = create_instr_params(
+                calib.instr,
+                euler_convention=calib.euler_convention,
+                relative_constraints=calib.relative_constraints,
+                include_geometry=(i == 0),
+                stage_prefix=self._stage_prefix(i),
+            )
+            all_params += instr_params
+
+            # Sub-calibrator params (grains, lattice, ...). Threading the
+            # accumulated list means shared material params dedupe while
+            # per-dataset grain params stay unique.
+            for sub_calibrator in calib.calibrators:
+                all_params += sub_calibrator.create_lmfit_params(all_params)
+
+        validate_params_list(all_params)
+
+        params_dict = lmfit.Parameters()
+        params_dict.add_many(*all_params)
+
+        add_engineering_constraints(params_dict, self.engineering_constraints)
+        return params_dict
+
+    def update_all_from_params(self, params: lmfit.Parameters) -> None:
+        for i, calib in enumerate(self.calibrators):
+            update_instrument_from_params(
+                calib.instr,
+                params,
+                calib.euler_convention,
+                calib.relative_constraints,
+                stage_prefix=self._stage_prefix(i),
+            )
+
+            for sub_calibrator in calib.calibrators:
+                sub_calibrator.update_from_lmfit_params(params)
+
+    def minimizer_function(
+        self, params: lmfit.Parameters
+    ) -> NDArray[np.float64]:
+        self.update_all_from_params(params)
+        return self.residual()
+
+    def residual(self) -> NDArray[np.float64]:
+        return np.hstack([calib.residual() for calib in self.calibrators])
+
+    def minimize(
+        self,
+        method: str = 'least_squares',
+        odict: Optional[dict[str, Any]] = None,
+    ) -> lmfit.minimizer.MinimizerResult:
+        if odict is None:
+            odict = {}
+
+        if method == 'least_squares':
+            odict = {
+                "ftol": 1e-8,
+                "xtol": 1e-8,
+                "gtol": 1e-8,
+                "verbose": 2,
+                "max_nfev": 1000,
+                "x_scale": "jac",
+                "method": "trf",
+                "jac": "3-point",
+                **odict,
+            }
+
+            result = self.fitter.least_squares(self.params, **odict)
+        else:
+            result = self.fitter.scalar_minimize(
+                method=method, params=self.params, max_nfev=50000, **odict
+            )
+
+        return result
+
+    @property
+    def engineering_constraints(self) -> Optional[str]:
+        return self._engineering_constraints
+
+    def reset_lmfit_params(self) -> None:
+        self.params = self.make_lmfit_params()
+
+    def run_calibration(
+        self, odict: Optional[dict[str, Any]] = None
+    ) -> lmfit.minimizer.MinimizerResult:
+        resd0 = self.residual()
+        nrm_ssr_0 = _normalized_ssqr(resd0)
+
+        result = self.minimize(odict=odict)
+
+        resd1 = self.residual()
         nrm_ssr_1 = _normalized_ssqr(resd1)
 
         delta_r = 1.0 - nrm_ssr_1 / nrm_ssr_0

--- a/hexrd/core/fitting/calibration/lmfit_param_handling.py
+++ b/hexrd/core/fitting/calibration/lmfit_param_handling.py
@@ -38,50 +38,79 @@ EULER_CONVENTION_TYPES = dict | tuple | None
 
 
 def create_instr_params(
-    instr, euler_convention=DEFAULT_EULER_CONVENTION, relative_constraints=None
-):
+    instr: HEDMInstrument,
+    euler_convention: EULER_CONVENTION_TYPES = DEFAULT_EULER_CONVENTION,
+    relative_constraints: Optional[RelativeConstraints] = None,
+    include_geometry: bool = True,
+    stage_prefix: str = '',
+) -> list[tuple]:
     # add with tuples: (NAME VALUE VARY MIN  MAX  EXPR  BRUTE_STEP)
+    #
+    # `include_geometry` controls whether the shared geometry parameters (the
+    # beam and the detector tilts/translations/distortion) are emitted. When
+    # several instruments are calibrated together with a shared geometry, these
+    # are created only once (for the first instrument) and every other
+    # instrument references them by name.
+    #
+    # `stage_prefix` is prepended to the oscillation-stage parameters
+    # (`instr_chi` and `instr_tvec_*`). These are kept independent per
+    # instrument so each dataset may have its own rotation axis and sample
+    # offset while still sharing the detector geometry.
     parms_list = []
 
-    # This supports either single beam or multi-beam
-    beam_param_names = create_beam_param_names(instr)
-    for beam_name, beam in instr.beam_dict.items():
-        azim, pol = calc_angles_from_beam_vec(beam['vector'])
-        energy = beam['energy']
+    if include_geometry:
+        # This supports either single beam or multi-beam
+        beam_param_names = create_beam_param_names(instr)
+        for beam_name, beam in instr.beam_dict.items():
+            azim, pol = calc_angles_from_beam_vec(beam['vector'])
+            energy = beam['energy']
 
-        names = beam_param_names[beam_name]
-        parms_list.append((names['beam_polar'], pol, False, pol - 1, pol + 1))
-        parms_list.append((names['beam_azimuth'], azim, False, azim - 1, azim + 1))
-        parms_list.append(
-            (names['beam_energy'], energy, False, energy - 0.2, energy + 0.2)
-        )
-        if beam.get('energy_correction') is not None:
-            base_name = names['beam_energy_correction']
-            intercept = beam['energy_correction']['intercept']
-            slope = beam['energy_correction']['slope']
+            names = beam_param_names[beam_name]
+            parms_list.append((names['beam_polar'], pol, False, pol - 1, pol + 1))
             parms_list.append(
-                (
-                    f'{base_name}_intercept',
-                    intercept,
-                    False,
-                    -np.inf,
-                    np.inf,
-                )
+                (names['beam_azimuth'], azim, False, azim - 1, azim + 1)
             )
-            parms_list.append((f'{base_name}_slope', slope, False, -np.inf, np.inf))
+            parms_list.append(
+                (names['beam_energy'], energy, False, energy - 0.2, energy + 0.2)
+            )
+            if beam.get('energy_correction') is not None:
+                base_name = names['beam_energy_correction']
+                intercept = beam['energy_correction']['intercept']
+                slope = beam['energy_correction']['slope']
+                parms_list.append(
+                    (
+                        f'{base_name}_intercept',
+                        intercept,
+                        False,
+                        -np.inf,
+                        np.inf,
+                    )
+                )
+                parms_list.append(
+                    (f'{base_name}_slope', slope, False, -np.inf, np.inf)
+                )
 
     parms_list.append(
         (
-            'instr_chi',
+            f'{stage_prefix}instr_chi',
             np.degrees(instr.chi),
             False,
             np.degrees(instr.chi) - 1,
             np.degrees(instr.chi) + 1,
         )
     )
-    parms_list.append(('instr_tvec_x', instr.tvec[0], False, -np.inf, np.inf))
-    parms_list.append(('instr_tvec_y', instr.tvec[1], False, -np.inf, np.inf))
-    parms_list.append(('instr_tvec_z', instr.tvec[2], False, -np.inf, np.inf))
+    parms_list.append(
+        (f'{stage_prefix}instr_tvec_x', instr.tvec[0], False, -np.inf, np.inf)
+    )
+    parms_list.append(
+        (f'{stage_prefix}instr_tvec_y', instr.tvec[1], False, -np.inf, np.inf)
+    )
+    parms_list.append(
+        (f'{stage_prefix}instr_tvec_z', instr.tvec[2], False, -np.inf, np.inf)
+    )
+
+    if not include_geometry:
+        return parms_list
 
     if (
         relative_constraints is None
@@ -283,11 +312,12 @@ def fix_detector_y(
 
 
 def update_instrument_from_params(
-    instr,
+    instr: HEDMInstrument,
     params: lmfit.Parameters,
-    euler_convention=DEFAULT_EULER_CONVENTION,
+    euler_convention: EULER_CONVENTION_TYPES = DEFAULT_EULER_CONVENTION,
     relative_constraints: Optional[RelativeConstraints] = None,
-):
+    stage_prefix: str = '',
+) -> None:
     """
     this function updates the instrument from the
     lmfit parameter list. we don't have to keep track
@@ -295,6 +325,10 @@ def update_instrument_from_params(
     variables. this will become the standard in the
     future since bound constraints can be very easily
     implemented.
+
+    `stage_prefix` must match the prefix used when the oscillation-stage
+    parameters (`instr_chi` and `instr_tvec_*`) were created. The beam and
+    detector geometry are always read from their unprefixed (shared) names.
     """
     if not isinstance(params, lmfit.Parameters):
         msg = 'Only lmfit.Parameters is acceptable input. ' f'Received: {params}'
@@ -322,13 +356,13 @@ def update_instrument_from_params(
     # Trigger any needed updates from beam modifications
     instr.beam_dict_modified()
 
-    chi = np.radians(params['instr_chi'].value)
+    chi = np.radians(params[f'{stage_prefix}instr_chi'].value)
     instr.chi = chi
 
     instr_tvec = [
-        params['instr_tvec_x'].value,
-        params['instr_tvec_y'].value,
-        params['instr_tvec_z'].value,
+        params[f'{stage_prefix}instr_tvec_x'].value,
+        params[f'{stage_prefix}instr_tvec_y'].value,
+        params[f'{stage_prefix}instr_tvec_z'].value,
     ]
     instr.tvec = np.r_[instr_tvec]
 

--- a/hexrd/hedm/fitting/calibration/grain.py
+++ b/hexrd/hedm/fitting/calibration/grain.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import numpy as np
 
@@ -31,6 +32,7 @@ class GrainCalibrator(AbstractGrainCalibrator):
         default_refinements=None,
         calibration_picks=None,
         euler_convention=DEFAULT_EULER_CONVENTION,
+        ome_step: Optional[float] = None,
     ):
         super().__init__(
             instr,
@@ -41,6 +43,7 @@ class GrainCalibrator(AbstractGrainCalibrator):
             euler_convention,
         )
         self.ome_period = ome_period
+        self.ome_step = ome_step
         self.index = index
 
     @property
@@ -80,6 +83,7 @@ class GrainCalibrator(AbstractGrainCalibrator):
             pick_hkls_dict,
             self.bmatx,
             self.ome_period,
+            ome_step=self.ome_step,
         )
 
     def model(self):
@@ -92,13 +96,21 @@ class GrainCalibrator(AbstractGrainCalibrator):
             pick_hkls_dict,
             self.bmatx,
             self.ome_period,
+            ome_step=self.ome_step,
             sim_only=True,
         )
 
 
 # Objective function for multigrain fitting
 def sxcal_obj_func(
-    grain_params, instr, xyo_det, hkls_idx, bmat, ome_period, sim_only=False
+    grain_params,
+    instr,
+    xyo_det,
+    hkls_idx,
+    bmat,
+    ome_period,
+    ome_step: Optional[float] = None,
+    sim_only=False,
 ):
     ngrains = len(grain_params)
 
@@ -216,5 +228,10 @@ def sxcal_obj_func(
 
         diff_vecs_xy = calc_xy_all - meas_xy_all
         diff_ome = angularDifference(calc_omes_all, meas_omes_all)
+        if ome_step is not None:
+            # Weight omega so a one-frame error counts the same as a one-pixel xy error
+            # (pixel_size / omega_step); else omega (rad) is ~100x under-weighted vs xy (mm).
+            panel = next(iter(instr.detectors.values()))
+            diff_ome = diff_ome * (panel.pixel_size_row / ome_step)
         retval = np.hstack([diff_vecs_xy, diff_ome.reshape(npts_tot, 1)]).flatten()
     return retval

--- a/tests/calibration/test_hedm_calibration.py
+++ b/tests/calibration/test_hedm_calibration.py
@@ -1,3 +1,5 @@
+import copy
+
 import h5py
 import numpy as np
 import yaml
@@ -8,7 +10,14 @@ import hexrd.core.constants as cnst
 from hexrd.core.material.material import load_materials_hdf5
 from hexrd.core.instrument.hedm_instrument import HEDMInstrument
 
-from hexrd.core.fitting.calibration import fix_detector_y, InstrumentCalibrator
+from hexrd.core.fitting.calibration import (
+    fix_detector_y,
+    InstrumentCalibrator,
+    MultiInstrumentCalibrator,
+)
+from hexrd.core.fitting.calibration.relative_constraints import (
+    RelativeConstraintsType,
+)
 from hexrd.hedm.fitting.calibration import GrainCalibrator
 
 @pytest.fixture
@@ -143,3 +152,173 @@ def test_calibration(
     assert results.success
     assert results.cost < 10
     assert results.optimality < 1e-3
+
+
+def test_multi_instrument_calibration(
+    dexelas_instrument, ruby_material, pull_spots_picks, grain_params
+):
+    # Build two "scans" out of the ruby dataset, each with its own instrument
+    # copy and its own grains, and calibrate them together with a shared
+    # detector geometry but independent oscillation stages.
+    ome_period = np.array([0, 2 * np.pi])
+    euler_convention = {'axes_order': 'xyz', 'extrinsic': True}
+
+    instr_a = copy.deepcopy(dexelas_instrument)
+    instr_b = copy.deepcopy(dexelas_instrument)
+
+    # Give each scan a distinct rotation axis to exercise the per-scan chi.
+    instr_a.chi = np.radians(0.1)
+    instr_b.chi = np.radians(-0.2)
+
+    # Perturb scan B's detector geometry. Because geometry is shared (created
+    # only from the first scan), this should be synced back to scan A's
+    # geometry when the multi-calibrator is constructed.
+    for det in instr_b.detectors.values():
+        det.tvec = det.tvec + np.array([0.5, -0.3, 1.0])
+        det.tilt = det.tilt + np.array([0.01, 0.0, 0.0])
+
+    def make_ic(instr, grain_indices):
+        calibs = []
+        for i in grain_indices:
+            gc = GrainCalibrator(
+                instr=instr,
+                material=ruby_material,
+                grain_params=grain_params[i],
+                ome_period=ome_period,
+                index=i,
+                euler_convention=euler_convention,
+            )
+            gc.data_dict = pull_spots_picks[i]
+            calibs.append(gc)
+        return InstrumentCalibrator(*calibs, euler_convention=euler_convention)
+
+    ic_a = make_ic(instr_a, [0])
+    ic_b = make_ic(instr_b, [1, 2])
+
+    multi = MultiInstrumentCalibrator([ic_a, ic_b], labels=['scanA', 'scanB'])
+    params = multi.params
+
+    # Stage params are per-scan prefixed; there is no unprefixed stage param.
+    assert 'scanA_instr_chi' in params
+    assert 'scanB_instr_chi' in params
+    assert 'scanA_instr_tvec_z' in params
+    assert 'scanB_instr_tvec_z' in params
+    assert 'instr_chi' not in params
+
+    # Detector geometry params exist once (unprefixed, shared).
+    for det_key in instr_a.detectors:
+        name = det_key.replace('-', '_')
+        assert f'{name}_tvec_x' in params
+        assert f'scanA_{name}_tvec_x' not in params
+        assert f'scanB_{name}_tvec_x' not in params
+
+    # Grain params are independent per scan (one grain in A, two in B).
+    assert 'ruby_0_grain_param_0' in params
+    assert 'ruby_1_grain_param_0' in params
+    assert 'ruby_2_grain_param_0' in params
+
+    # On construction, scan B's perturbed geometry is synced to scan A's.
+    for da, db in zip(instr_a.detectors.values(), instr_b.detectors.values()):
+        np.testing.assert_allclose(da.tvec, db.tvec)
+        np.testing.assert_allclose(da.rmat, db.rmat)
+
+    # ... but the per-scan rotation axes stay independent.
+    assert not np.isclose(instr_a.chi, instr_b.chi)
+
+    # Refine each scan's rotation axis independently (the per-scan stage is the
+    # headline feature). These are fixed by default, like the single-instrument
+    # calibrator.
+    multi.params['scanA_instr_chi'].vary = True
+    multi.params['scanB_instr_chi'].vary = True
+
+    x0 = multi.params.valuesdict()
+    resid0 = np.linalg.norm(multi.residual())
+    results = multi.run_calibration()
+    resid1 = np.linalg.norm(multi.residual())
+    x1 = results.params.valuesdict()
+
+    # The combined residual decreased.
+    assert resid1 < resid0
+
+    # The geometry stayed shared through the whole fit: both instruments are
+    # still identical afterward.
+    for da, db in zip(instr_a.detectors.values(), instr_b.detectors.values()):
+        np.testing.assert_allclose(da.tvec, db.tvec)
+        np.testing.assert_allclose(da.rmat, db.rmat)
+
+    # The per-scan rotation axes were refined independently.
+    assert not np.isclose(x0['scanA_instr_chi'], x1['scanA_instr_chi'])
+    assert not np.isclose(x0['scanB_instr_chi'], x1['scanB_instr_chi'])
+
+    # At least one grain parameter moved during the calibration.
+    assert not np.isclose(x0['ruby_0_grain_param_0'], x1['ruby_0_grain_param_0'])
+
+
+def _make_ruby_ic(
+    instr, grain_indices, ruby_material, grain_params, pull_spots_picks,
+    relative_constraints_type=RelativeConstraintsType.none,
+):
+    ome_period = np.array([0, 2 * np.pi])
+    euler_convention = {'axes_order': 'xyz', 'extrinsic': True}
+    calibs = []
+    for i in grain_indices:
+        gc = GrainCalibrator(
+            instr=instr,
+            material=ruby_material,
+            grain_params=grain_params[i],
+            ome_period=ome_period,
+            index=i,
+            euler_convention=euler_convention,
+        )
+        gc.data_dict = pull_spots_picks[i]
+        calibs.append(gc)
+    return InstrumentCalibrator(
+        *calibs,
+        euler_convention=euler_convention,
+        relative_constraints_type=relative_constraints_type,
+    )
+
+
+def test_multi_instrument_mismatched_detectors(
+    dexelas_instrument, ruby_material, pull_spots_picks, grain_params
+):
+    # Each calibrator's instrument must share the same detector layout, since
+    # geometry params are only emitted from calibrators[0] and read back by key.
+    instr_a = copy.deepcopy(dexelas_instrument)
+    instr_b = copy.deepcopy(dexelas_instrument)
+
+    # Give scan B an extra detector key that scan A does not have.
+    existing_key = next(iter(instr_b.detectors))
+    extra_panel = copy.deepcopy(instr_b.detectors[existing_key])
+    instr_b._detectors['extra_panel'] = extra_panel
+
+    ic_a = _make_ruby_ic(
+        instr_a, [0], ruby_material, grain_params, pull_spots_picks
+    )
+    ic_b = _make_ruby_ic(
+        instr_b, [1], ruby_material, grain_params, pull_spots_picks
+    )
+
+    with pytest.raises(ValueError, match='detector layout'):
+        MultiInstrumentCalibrator([ic_a, ic_b])
+
+
+def test_multi_instrument_mismatched_relative_constraints(
+    dexelas_instrument, ruby_material, pull_spots_picks, grain_params
+):
+    # All calibrators must agree on relative_constraints, since only
+    # calibrators[0]'s configuration actually takes effect.
+    instr_a = copy.deepcopy(dexelas_instrument)
+    instr_b = copy.deepcopy(dexelas_instrument)
+
+    ic_a = _make_ruby_ic(
+        instr_a, [0], ruby_material, grain_params, pull_spots_picks,
+        relative_constraints_type=RelativeConstraintsType.none,
+    )
+    ic_b = _make_ruby_ic(
+        instr_b, [1], ruby_material, grain_params, pull_spots_picks,
+        relative_constraints_type=RelativeConstraintsType.system,
+    )
+
+    with pytest.raises(ValueError, match='relative_constraints'):
+        MultiInstrumentCalibrator([ic_a, ic_b])


### PR DESCRIPTION
# Overview

This can calibrate multiple instruments simultaneously, while only allowing a small subset of instrument parameters to vary, or grain/material parameters to vary.

Currently, the HEDM sample stage parameters (sample stage translation and chi) are the only instrument parameters which can vary between instruments. Otherwise, the detector tilts/translations and other parameters are shared and stay fixed between instruments. Even though only the sample stage parameters can currently be varied separately, it is relatively straightforward to extend this to other detector parameters too, as needed (we just need a unique prefix per detector).

This is being used for a particular experiment done at CHESS, where a 3-grain ruby sample was scanned at 50 different sample stage locations. In this case, the detector parameters should all remain constant, and only the sample stage location vary between them. It is actually going to be very helpful for determining a good standard set of relative tilts/translations between subpanels for the Eiger.

# Affected Workflows

Core (new feature only)
