### PR TITLE
Tds fixes

### DIFF
--- a/hexrd/powder/wppf/WPPF.py
+++ b/hexrd/powder/wppf/WPPF.py
@@ -2505,7 +2505,9 @@ class Rietveld(AbstractWPPF):
     def polfactor_full(self):
         t = np.radians(self.tds_model.tth)
         ctth = np.cos(t)
-        return 1 + self.Ph * ctth**2
+        cth = np.cos(0.5 * t)
+        sth2 = np.sin(0.5 * t) ** 2
+        return (1 + self.Ph * ctth**2) / sth2 / cth
 
     def compute_texture_data(
         self,

--- a/hexrd/powder/wppf/WPPF.py
+++ b/hexrd/powder/wppf/WPPF.py
@@ -2320,12 +2320,9 @@ class Rietveld(AbstractWPPF):
         lp = self.polfactor_full
         pf = self.phases[p][k].pf / self.phases[p][k].vol ** 2
         tds_signal = self.tds_model.TDSmodels[p][k].tds_lineout
-
-        """ weight is already accounted for in the TDS class
-        this was being applied twice. undoing it here
         weight = self.phases.wavelength[k][1]
-        """
-        return self.scale * pf * lp * tds_signal
+
+        return self.scale * weight * pf * lp * tds_signal
 
     @property
     def phases(self):

--- a/hexrd/powder/wppf/WPPF.py
+++ b/hexrd/powder/wppf/WPPF.py
@@ -2320,8 +2320,12 @@ class Rietveld(AbstractWPPF):
         lp = self.polfactor_full
         pf = self.phases[p][k].pf / self.phases[p][k].vol ** 2
         tds_signal = self.tds_model.TDSmodels[p][k].tds_lineout
+
+        """ weight is already accounted for in the TDS class
+        this was being applied twice. undoing it here
         weight = self.phases.wavelength[k][1]
-        return self.scale * weight * pf * lp * tds_signal
+        """
+        return self.scale * pf * lp * tds_signal
 
     @property
     def phases(self):
@@ -2505,9 +2509,7 @@ class Rietveld(AbstractWPPF):
     def polfactor_full(self):
         t = np.radians(self.tds_model.tth)
         ctth = np.cos(t)
-        cth = np.cos(0.5 * t)
-        sth2 = np.sin(0.5 * t) ** 2
-        return (1 + self.Ph * ctth**2) / sth2 / cth
+        return 1 + self.Ph * ctth**2
 
     def compute_texture_data(
         self,

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -378,11 +378,25 @@ class TDS:
     @property
     def tds_lineout(self) -> np.ndarray:
         lineout = np.zeros_like(self.tth)
+        """
+        @note: the elastic scattering intensity has a factor of lambda^3/vol 
+        extra that is not present in the TDS scattering. to convert both
+        of them to the nominal electron units, we need to multiply the inverse
+        of that factor here.
+
+        vol: volume of unit cell
+        lambda: wavelength of x-rays
+        """
         for p in self.phases:
             for l in self.phases.wavelength:
                 if self.TDSmodels.get(p, {}).get(l) is not None:
+                    # pre is the lambda^3/vol factor
+                    pre = (
+                        self.phases[p].vol
+                        / self.phases.wavelength[l][0].getVal("nm") ** 3
+                    )
                     weight = self.phases.wavelength[l][1]
-                    lineout += weight * self.TDSmodels[p][l].tds_lineout
+                    lineout += pre * weight * self.TDSmodels[p][l].tds_lineout
 
         return lineout
 

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -320,7 +320,6 @@ class TDS_material:
         self._smoothing = v
 
 
-# !!!!!NOT USED IN WPPF!!!!!!
 class TDS:
     '''
     >> @AUTHOR:     Saransh Singh,
@@ -387,26 +386,22 @@ class TDS:
 
     @property
     def tds_lineout(self) -> np.ndarray:
-        lineout = np.zeros_like(self.tth)
-        """
-        @note: the elastic scattering intensity has a factor of lambda^3/vol 
-        extra that is not present in the TDS scattering. to convert both
-        of them to the nominal electron units, we need to multiply the inverse
-        of that factor here.
+        """Aggregate TDS signal summed over all phases and wavelengths.
 
-        vol: volume of unit cell
-        lambda: wavelength of x-rays
+        NOT USED: neither WPPF nor hexrdgui call this. Both build the TDS
+        signal per-(phase, wavelength) via Rietveld.calculate_scaled_tds_signal
+        instead. Kept only as a convenience for external callers.
+
+        @note: the vol/lambda^3 normalization that places the TDS signal on
+        the same scale as the elastic scattering is already applied per-material
+        in TDS_material.calcTDS, so it must not be applied again here.
         """
+        lineout = np.zeros_like(self.tth)
         for p in self.phases:
             for l in self.phases.wavelength:
                 if self.TDSmodels.get(p, {}).get(l) is not None:
-                    # pre is the lambda^3/vol factor
-                    pre = (
-                        self.phases[p][l].vol
-                        / self.phases.wavelength[l][0].getVal("nm") ** 3
-                    )
                     weight = self.phases.wavelength[l][1]
-                    lineout += pre * weight * self.TDSmodels[p][l].tds_lineout
+                    lineout += weight * self.TDSmodels[p][l].tds_lineout
 
         return lineout
 

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -132,6 +132,17 @@ class TDS_material:
                 raise ValueError(msg)
 
     def WarrenFunctionalForm(self, x: np.ndarray, xhkl: float) -> np.ndarray:
+        '''@NOTE: Details in Heighway et al., J. Appl. Phys. 138, 155903 (2025)
+        eqn 22 from the paper lists the integral of the Bragg peak shape
+        integrates to Nb*(2*pi)**3/vol_unitcell, where Nb is number of atoms in unit cell.
+        However, in eq. 23 the warren kernel W(q-G) [eq. 27] integrates to
+        q_B**3 * (2*pi)**3/vol_unitcell. I think to make them the same scale, we need to
+        divide the warren kernel q_B**3, but I'm not sure about it.
+
+        The Nb factor is taken care of in the formfactor. The complicating factor is that
+        the Bragg diffraction is per unit cell and TDS is per Brillouin zone with is
+        one atom always
+        '''
         xx = np.abs(x - xhkl)
         xx = self.agm / xx
         mask = xx > 1.0
@@ -140,6 +151,10 @@ class TDS_material:
         return y
 
     def formfactor(self, q: np.ndarray) -> dict[str, np.ndarray]:
+        '''this function returns the form factors scaled by the number
+        of atoms in the unit cell to have it on the same footing as
+        the coherent bragg scattering intensities
+        '''
         s = (q / 4 / np.pi) ** 2
 
         f_anomalous_data = self.mat.f_anomalous_data
@@ -154,11 +169,11 @@ class TDS_material:
             frel_k = np.array([frel[k]])
 
         formfact = {}
-        for i, a in enumerate(self.mat.atom_type):
+        for i, (a, nat) in enumerate(zip(self.mat.atom_type, self.mat.numat)):
             k = ptableinverse[a]
             formfact[k] = np.zeros_like(s)
             for ii, ss in enumerate(s):
-                formfact[k][ii] = (
+                formfact[k][ii] = nat * (
                     np.squeeze(
                         np.abs(
                             _calcxrayformfactor(
@@ -276,8 +291,8 @@ class TDS_material:
     @property
     def tds_lineout(self) -> np.ndarray:
         lo = self.calcTDS()
-        if self.smoothing is not None:
-            lo = gaussian_filter1d(lo, self.smoothing)
+        # if self.smoothing is not None:
+        #     lo = gaussian_filter1d(lo, self.smoothing)
         return lo
 
     @property

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -132,17 +132,6 @@ class TDS_material:
                 raise ValueError(msg)
 
     def WarrenFunctionalForm(self, x: np.ndarray, xhkl: float) -> np.ndarray:
-        '''@NOTE: Details in Heighway et al., J. Appl. Phys. 138, 155903 (2025)
-        eqn 22 from the paper lists the integral of the Bragg peak shape
-        integrates to Nb*(2*pi)**3/vol_unitcell, where Nb is number of atoms in unit cell.
-        However, in eq. 23 the warren kernel W(q-G) [eq. 27] integrates to
-        q_B**3 * (2*pi)**3/vol_unitcell. I think to make them the same scale, we need to
-        divide the warren kernel q_B**3, but I'm not sure about it.
-
-        The Nb factor is taken care of in the formfactor. The complicating factor is that
-        the Bragg diffraction is per unit cell and TDS is per Brillouin zone with is
-        one atom always
-        '''
         xx = np.abs(x - xhkl)
         xx = self.agm / xx
         mask = xx > 1.0
@@ -151,10 +140,18 @@ class TDS_material:
         return y
 
     def formfactor(self, q: np.ndarray) -> dict[str, np.ndarray]:
-        '''this function returns the form factors scaled by the number
+        """this function returns the form factors scaled by the number
         of atoms in the unit cell to have it on the same footing as
         the coherent bragg scattering intensities
-        '''
+
+        @NOTE: Details on Pg. 59 and Pg. 210 of Warren, X-Ray diffraction.
+
+        The Nb factor is taken care of in the formfactor. this is the extra
+        "nat" factor!
+
+        The powder diffraction is per unit cell and TDS is per Brillouin zone with is
+        one atom always. so make sure they both are per unit cell quantities\
+        """
         s = (q / 4 / np.pi) ** 2
 
         f_anomalous_data = self.mat.f_anomalous_data
@@ -212,6 +209,16 @@ class TDS_material:
         return C
 
     def calcTDS(self) -> np.ndarray:
+        """@NOTE: Details on Pg. 59 and Pg. 210 of Warren, X-Ray diffraction.
+
+        based on the scattered intensity expression derived in Warren, the powder
+        diffraction intenisty has an additional wavelength^3/volume of unit cell
+        factor multiplied to it. To make sure TDS signal and powder signal are both
+        in the same units, the inverse of the factor is multiplied to the TDS signal.
+
+        We have tested this with results from Patrick Heighway, University of Oxford
+        and also checked that the factor conserves scattered intensity due
+        """
         thr = np.radians(self.tth * 0.5)
 
         q = self.q

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -313,6 +313,7 @@ class TDS_material:
         self._smoothing = v
 
 
+# !!!!!NOT USED IN WPPF!!!!!!
 class TDS:
     '''
     >> @AUTHOR:     Saransh Singh,

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -291,8 +291,8 @@ class TDS_material:
     @property
     def tds_lineout(self) -> np.ndarray:
         lo = self.calcTDS()
-        # if self.smoothing is not None:
-        #     lo = gaussian_filter1d(lo, self.smoothing)
+        if self.smoothing is not None:
+            lo = gaussian_filter1d(lo, self.smoothing)
         return lo
 
     @property

--- a/hexrd/powder/wppf/tds.py
+++ b/hexrd/powder/wppf/tds.py
@@ -248,7 +248,9 @@ class TDS_material:
                 (1 - exp2M[k]) + exp2M[k] * (2 * Ms[k] + Ms[k] ** 2) * (C - 1)
             )
 
-        return thermal_diffuse
+        pre = self.mat.vol / self.mat.wavelength**3
+
+        return pre * thermal_diffuse
 
     @property
     def Mdict(self) -> dict[str, float]:
@@ -392,7 +394,7 @@ class TDS:
                 if self.TDSmodels.get(p, {}).get(l) is not None:
                     # pre is the lambda^3/vol factor
                     pre = (
-                        self.phases[p].vol
+                        self.phases[p][l].vol
                         / self.phases.wavelength[l][0].getVal("nm") ** 3
                     )
                     weight = self.phases.wavelength[l][1]

--- a/tests/powder/wppf/test_tds.py
+++ b/tests/powder/wppf/test_tds.py
@@ -80,26 +80,26 @@ def test_wppf_tds(tds_material_file: Path, tds_expt_spectrum: np.ndarray):
     R.params["scale"].vary = True
     R.Refine()
 
-    assert R.Rwp < 1
+    assert R.Rwp < 0.6
 
     R.params["V"].vary = True
     R.params["W"].vary = True
     R.params["Ti_beta_Y"].vary = True
     R.Refine()
 
-    assert R.Rwp < 0.6
-
-    R.params["Ti_beta_Ti1_dw"].vary = True
-    R.Refine()
-
-    assert R.Rwp < 0.1
+    assert R.Rwp < 0.5
 
     R.params["bkg_0"].vary = True
     R.params["bkg_1"].vary = True
 
     R.Refine()
 
-    assert R.Rwp < 0.05
+    assert R.Rwp < 0.2
+
+    R.params["Ti_beta_Ti1_dw"].vary = True
+    R.Refine()
+
+    assert R.Rwp < 0.01
 
     # Now try the experimental model.
     # It shouldn't have a big impact. We'll just verify it runs.
@@ -119,5 +119,5 @@ def test_wppf_tds(tds_material_file: Path, tds_expt_spectrum: np.ndarray):
     assert R.Rwp < 0.05
 
     # Test calculating the equivalent temperatures
-    equiv_temp_dict = m_r.calc_temperature({'Ti': 200})
-    assert np.isclose(equiv_temp_dict['Ti'], 3607, atol=10)
+    equiv_temp_dict = m_r.calc_temperature({'Ti': 380})
+    assert np.isclose(equiv_temp_dict['Ti'], 3581, atol=10)

--- a/tests/powder/wppf/test_tds.py
+++ b/tests/powder/wppf/test_tds.py
@@ -121,3 +121,48 @@ def test_wppf_tds(tds_material_file: Path, tds_expt_spectrum: np.ndarray):
     # Test calculating the equivalent temperatures
     equiv_temp_dict = m_r.calc_temperature({'Ti': 380})
     assert np.isclose(equiv_temp_dict['Ti'], 3581, atol=10)
+
+
+def test_tds_aggregate_lineout_no_double_scaling(
+    tds_material_file: Path, tds_expt_spectrum: np.ndarray
+):
+    # The vol/lambda^3 normalization is applied per-material in
+    # TDS_material.calcTDS, so the aggregate TDS.tds_lineout must only sum the
+    # weighted per-material lineouts (no extra factor). WPPF/hexrdgui don't call
+    # this aggregate, so this guards it for any external caller that does.
+    m = Material(
+        name="Ti_beta",
+        material_file=tds_material_file,
+        kev=_kev(10.2505),
+        dmin=_nm(0.05),
+    )
+    m.planeData.exclusions = np.zeros_like(m.planeData.exclusions).astype(bool)
+
+    kwargs = {
+        "expt_spectrum": tds_expt_spectrum,
+        "wavelength": {"XFEL": [_angstrom(keVToAngstrom(10.2505)), 1.0]},
+        "bkgmethod": {"chebyshev": 1},
+        "peakshape": "pvtch",
+        "phases": [m],
+    }
+    R = Rietveld(**kwargs)
+
+    tds_model = TDS(
+        model_type="warren",
+        phases=R.phases,
+        tth=R.tth_list,
+        model_data=None,
+        scale=None,
+        shift=None,
+    )
+
+    expected = np.zeros_like(tds_model.tth)
+    for p in tds_model.phases:
+        for wlen in tds_model.phases.wavelength:
+            mat = tds_model.TDSmodels.get(p, {}).get(wlen)
+            if mat is None:
+                continue
+            weight = tds_model.phases.wavelength[wlen][1]
+            expected += weight * mat.tds_lineout
+
+    np.testing.assert_allclose(tds_model.tds_lineout, expected)


### PR DESCRIPTION
There were some important factors that were missing in the TDS signal calculation such that the elastic scattering and the TDS scattering were not on the same scale. This has been fixed using this PR. Two important factors are:

- powder diffraction is per unit cell while TDS was being calculated per atom. This is fixed
- there was a missing multiplicative factor of `V_unitcell/wavelength^3` in the TDS signal which has been added

This affects the wppf workflow for temperature determination.