### PR TITLE
Allow a custom compression filter in the hdf5 imageseries writer

### DIFF
--- a/hexrd/core/imageseries/save.py
+++ b/hexrd/core/imageseries/save.py
@@ -135,6 +135,10 @@ class WriteH5(Writer):
        number of rows per chunk; default is all
     shuffle: bool
        shuffle HDF5 data
+    compression: mapping, optional
+       an explicit set of ``create_dataset`` compression keyword arguments
+       (e.g. ``hdf5plugin.Blosc(cname='zstd', clevel=5)``). When given, it is
+       used as-is and overrides the ``gzip``/``shuffle`` options above.
     """
 
     fmt = 'hdf5'
@@ -179,17 +183,17 @@ class WriteH5(Writer):
     def h5opts(self):
         d = {}
 
-        # shuffle
-        shuffle = self._opts.pop('shuffle', self.dflt_shuffle)
-        d['shuffle'] = shuffle
-
-        # compression
-        compress = self._opts.pop('gzip', self.dflt_gzip)
-        if compress > 9:
-            raise ValueError('gzip compression cannot exceed 9: %s' % compress)
-        if compress > 0:
-            d['compression'] = 'gzip'
-            d['compression_opts'] = compress
+        # An explicit compression spec (e.g. hdf5plugin.Blosc(...)) is used
+        # as-is (it carries its own shuffle); otherwise fall back to gzip.
+        compression = self._opts.pop('compression', None)
+        if compression is not None:
+            d.update(dict(compression))
+        else:
+            d['shuffle'] = self._opts.pop('shuffle', self.dflt_shuffle)
+            compress = self._opts.pop('gzip', self.dflt_gzip)
+            if compress > 0:
+                d['compression'] = 'gzip'
+                d['compression_opts'] = compress
 
         # chunk size
         s0, s1 = self._shape

--- a/tests/core/imageseries/test_save.py
+++ b/tests/core/imageseries/test_save.py
@@ -123,8 +123,16 @@ def test_writeh5_options(mock_ims):
     assert opts['chunks'] == (1, 2, 10)
     assert opts['shuffle'] is False
 
-    with pytest.raises(ValueError):
-        save.WriteH5(mock_ims, "t.h5", path="p", gzip=10).h5opts
+
+def test_writeh5_compression_option(mock_ims: MagicMock) -> None:
+    import hdf5plugin
+
+    blosc = hdf5plugin.Blosc(cname='zstd', clevel=5)
+    opts = save.WriteH5(mock_ims, "t.h5", path="p", compression=blosc).h5opts
+
+    # The explicit compression spec is used as-is (no gzip, no extra shuffle).
+    assert opts['compression'] == dict(blosc)['compression']
+    assert 'shuffle' not in opts
 
 
 # --- WriteFrameCache Tests ---


### PR DESCRIPTION
# Overview

WriteH5 accepts an optional 'compression' mapping (e.g. an hdf5plugin.Blosc(...) spec) that is passed through to create_dataset, overriding the gzip default. This lets callers use codecs such as blosc-zstd, which compresses sparse detector images far better than gzip.

# Affected Workflows

Core

# Documentation Changes

Docstring updated
