### PR TITLE
Support reading/writing fch5 frame caches in an h5py group

### DIFF
--- a/hexrd/core/imageseries/load/framecache.py
+++ b/hexrd/core/imageseries/load/framecache.py
@@ -1,6 +1,7 @@
 """Adapter class for frame caches
 """
 
+import contextlib
 import functools
 import os
 from threading import Lock
@@ -34,6 +35,8 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
         *kwargs* - keyword arguments (none required)
         """
         self._fname = fname
+        # Optional group path when reading 'fch5' from an already-open file.
+        self._path = kwargs.get('path')
         self._framelist = []
         self._framelist_was_loaded = False
         self._load_framelist_lock = Lock()
@@ -75,8 +78,19 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
         else:
             self._load_cache_npz()
 
+    def _fch5_group_cm(self) -> contextlib.AbstractContextManager:
+        """Context manager yielding the h5py group holding the fch5 data.
+
+        ``fname`` may be a filename (open the file) or an already-open
+        group/file (use it directly, optionally under ``path``).
+        """
+        if isinstance(self._fname, h5py.Group):
+            group = self._fname[self._path] if self._path else self._fname
+            return contextlib.nullcontext(group)
+        return h5py.File(self._fname, "r")
+
     def _load_cache_fch5(self):
-        with h5py.File(self._fname, "r") as file:
+        with self._fch5_group_cm() as file:
             if 'HEXRD_FRAMECACHE_VERSION' not in file.attrs.keys():
                 raise NotImplementedError(
                     "Unsupported file. " "HEXRD_FRAMECACHE_VERSION " "is missing!"
@@ -127,14 +141,29 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
             self._load_framelist_npz()
 
     def _load_framelist_fch5(self):
+        if isinstance(self._fname, h5py.Group):
+            # Reading from an already-open group (e.g. a state file).
+            with self._fch5_group_cm() as group:
+                self._framelist = _read_framecache_fch5_group(
+                    group,
+                    int(self._nframes),
+                    tuple(self._shape),
+                    self._dtype,
+                    int(self._max_workers),
+                )
+            return
+
         # Perform a memoized load, so that if multiple imageseries are
         # utilizing the same file, they can all share the same csr matrices
+        mtime_ns, size = _stat_identity(str(self._fname))
         self._framelist = _load_framecache_fch5(
             filepath=str(self._fname),
             num_frames=int(self._nframes),
             shape=tuple(self._shape),
             dtype=self._dtype,
             max_workers=int(self._max_workers),
+            mtime_ns=mtime_ns,
+            size=size,
         )
 
     def _load_framelist_npz(self):
@@ -150,11 +179,14 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
 
         # Perform a memoized load, so that if multiple imageseries are
         # utilizing the same file, they can all share the same csr matrices
+        mtime_ns, size = _stat_identity(str(filepath))
         self._framelist = _load_framecache_npz(
             filepath=str(filepath),
             num_frames=int(self._nframes),
             shape=tuple(self._shape),
             dtype=self._dtype,
+            mtime_ns=mtime_ns,
+            size=size,
         )
 
     def get_region(self, frame_idx: int, region: RegionType) -> np.ndarray:
@@ -256,15 +288,36 @@ class FrameCacheImageSeriesAdapter(ImageSeriesAdapter):
         self._load_framelist_lock = Lock()
 
 
+def _stat_identity(filename: str) -> tuple[int, int]:
+    """Return ``(mtime_ns, size)`` for ``filename``, used to invalidate the
+    frame-cache memoization when a file is re-saved in place.
+
+    ``os.stat`` and the ``st_mtime_ns``/``st_size`` fields are available on
+    Windows, macOS and Linux. Falls back to ``(0, 0)`` if the file cannot be
+    stat'd, in which case the entry is effectively keyed by path alone (the
+    prior behavior). Note: filesystems with coarse mtime resolution (e.g. FAT)
+    could miss a same-size rewrite made within one timestamp tick; the size
+    component mitigates but does not fully eliminate this.
+    """
+    try:
+        info = os.stat(filename)
+        return info.st_mtime_ns, info.st_size
+    except OSError:
+        return 0, 0
+
+
 # This is memoized so that if multiple imageseries are sharing the
 # same file (such as 32 subpanel Eiger), all of the imageseries can
-# share the same sparse matrices.
+# share the same sparse matrices. `mtime_ns` and `size` are part of the cache
+# key only (so re-saving the file invalidates the entry); they are not used.
 @functools.lru_cache(maxsize=2)
 def _load_framecache_npz(
     filepath: str,
     num_frames: int,
     shape: tuple[int, int],
     dtype: np.dtype,
+    mtime_ns: int = 0,
+    size: int = 0,
 ) -> list[csr_array]:
 
     framelist = []
@@ -285,7 +338,8 @@ def _load_framecache_npz(
 
 # This is memoized so that if multiple imageseries are sharing the
 # same file (such as 32 subpanel Eiger), all of the imageseries can
-# share the same sparse matrices.
+# share the same sparse matrices. `mtime_ns` and `size` are part of the cache
+# key only (so re-saving the file invalidates the entry); they are not used.
 @functools.lru_cache(maxsize=2)
 def _load_framecache_fch5(
     filepath: str,
@@ -293,32 +347,46 @@ def _load_framecache_fch5(
     shape: tuple[int, int],
     dtype: np.dtype,
     max_workers: int,
+    mtime_ns: int = 0,
+    size: int = 0,
 ) -> list[csr_array]:
+    with h5py.File(filepath, "r") as file:
+        return _read_framecache_fch5_group(
+            file, num_frames, shape, dtype, max_workers
+        )
 
+
+def _read_framecache_fch5_group(
+    file: h5py.Group,
+    num_frames: int,
+    shape: tuple[int, int],
+    dtype: np.dtype,
+    max_workers: int,
+) -> list[csr_array]:
+    """Read a frame cache from an open h5py group (file root or sub-group)."""
     framelist = [None] * num_frames
 
-    with h5py.File(filepath, "r") as file:
-        frame_id = file["frame_ids"]
-        data = file["data"]
-        indices = file["indices"]
+    frame_id = file["frame_ids"]
+    data = file["data"]
+    indices = file["indices"]
 
-        def read_list_arrays_method_thread(i):
-            frame_data = data[frame_id[2 * i] : frame_id[2 * i + 1]]
-            frame_indices = indices[frame_id[2 * i] : frame_id[2 * i + 1]]
-            row = frame_indices[:, 0]
-            col = frame_indices[:, 1]
-            mat_data = frame_data[:, 0]
-            frame = csr_array((mat_data, (row, col)), shape=shape, dtype=dtype)
+    def read_list_arrays_method_thread(i: int) -> None:
+        frame_data = data[frame_id[2 * i] : frame_id[2 * i + 1]]
+        frame_indices = indices[frame_id[2 * i] : frame_id[2 * i + 1]]
+        row = frame_indices[:, 0]
+        col = frame_indices[:, 1]
+        mat_data = frame_data[:, 0]
+        frame = csr_array((mat_data, (row, col)), shape=shape, dtype=dtype)
 
-            # Make the data unwriteable, so we can be sure it won't be modified
-            frame.data.flags.writeable = False
+        # Make the data unwriteable, so we can be sure it won't be modified
+        frame.data.flags.writeable = False
 
-            framelist[i] = frame
+        framelist[i] = frame
 
-        with ThreadPoolExecutor(max_workers) as executor:
-            # Evaluate the results via `list()`, so that if an exception is
-            # raised in a thread, it will be re-raised and visible to the
-            # user.
-            list(executor.map(read_list_arrays_method_thread, range(num_frames)))
+    with ThreadPoolExecutor(max_workers) as executor:
+        # Evaluate the results via `list()`, so that if an exception is
+        # raised in a thread, it will be re-raised and visible to the
+        # user.
+        list(executor.map(read_list_arrays_method_thread, range(num_frames)))
 
     return framelist

--- a/hexrd/core/imageseries/save.py
+++ b/hexrd/core/imageseries/save.py
@@ -2,6 +2,7 @@
 
 import abc
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 import logging
 import multiprocessing
 import os
@@ -93,8 +94,11 @@ class Writer(object, metaclass=_RegisterWriter):
         self._fname = fname
         self._opts = kwargs
 
-        if isinstance(fname, h5py.File):
-            filename = fname.filename
+        if isinstance(fname, h5py.Group):
+            # An h5py.File is a Group too; this covers writing into an
+            # already-open file or a group within it. A Group exposes the
+            # filename via its parent file.
+            filename = fname.file.filename
         else:
             filename = fname
 
@@ -233,6 +237,8 @@ class WriteFrameCache(Writer):
     def __init__(self, ims, fname, style='npz', **kwargs):
         Writer.__init__(self, ims, fname, **kwargs)
         self._thresh = self._opts['threshold']
+        # Optional group path when writing 'fch5' into an already-open file.
+        self._path = self._opts.get('path')
         self._cache, self.cachename = self._set_cache()
 
         ncpus = multiprocessing.cpu_count()
@@ -249,6 +255,10 @@ class WriteFrameCache(Writer):
 
     def _set_cache(self):
         cf = self.opts.get('cache_file')
+
+        if isinstance(self.fname, h5py.Group):
+            # Writing 'fch5' into an already-open file/group; no cache file.
+            return self.fname, self.fname.file.filename
 
         if cf is None:
             cachename = cache = self.fname
@@ -403,8 +413,15 @@ class WriteFrameCache(Writer):
         thread_local = threading.local()
 
         # creating an array in memory will fail if data is too big or threshold
-        # too low, so we write to the file while iterating the frames
-        with h5py.File(self.cache, "w") as h5f:
+        # too low, so we write to the file while iterating the frames. The cache
+        # may be a filename (open a new file) or an already-open h5py group/file
+        # (write into it, optionally under self._path).
+        if isinstance(self.cache, h5py.Group):
+            target = self.cache.create_group(self._path) if self._path else self.cache
+            file_cm = contextlib.nullcontext(target)
+        else:
+            file_cm = h5py.File(self.cache, "w")
+        with file_cm as h5f:
             h5f.attrs['HEXRD_FRAMECACHE_VERSION'] = 1
             h5f["shape"] = shape
             h5f["nframes"] = nframes

--- a/tests/core/imageseries/load/test_framecache.py
+++ b/tests/core/imageseries/load/test_framecache.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.sparse import csr_array
 import pickle
 import os
+from pathlib import Path
 
 from hexrd.core.imageseries.load.framecache import FrameCacheImageSeriesAdapter
 
@@ -136,13 +137,20 @@ def test_yml_paths(mock_open, mock_yaml, mock_loader):
         num_frames=1,
         shape=(1,),
         dtype=np.dtype('f4'),
+        mtime_ns=ANY,
+        size=ANY,
     )
 
     # Absolute
     mock_yaml.return_value['data']['file'] = '/abs/c.npz'
     FrameCacheImageSeriesAdapter("d/t.yml", style="yml")[0]
     mock_loader.assert_called_with(
-        filepath='/abs/c.npz', num_frames=1, shape=(1,), dtype=np.dtype('f4')
+        filepath='/abs/c.npz',
+        num_frames=1,
+        shape=(1,),
+        dtype=np.dtype('f4'),
+        mtime_ns=ANY,
+        size=ANY,
     )
 
 
@@ -186,3 +194,29 @@ def test_pickle(mock_npz):
         ml.return_value.__enter__.return_value = mock_npz
         a = FrameCacheImageSeriesAdapter("t.npz", style="npz")
         assert hasattr(pickle.loads(pickle.dumps(a)), '_load_framelist_lock')
+
+
+def test_fch5_group_roundtrip(tmp_path: Path) -> None:
+    # Round-trip the new capability: write an fch5 frame cache into a group
+    # within an already-open HDF5 file, then read it back from that group.
+    import h5py
+    from hexrd.core import imageseries
+
+    data = np.zeros((4, 16, 16), dtype=np.uint16)
+    data[:, ::4, ::4] = 7  # sparse, non-negative
+    ims = imageseries.open(None, 'array', data=data)
+
+    path = tmp_path / 'state.h5'
+    with h5py.File(path, 'w') as f:
+        imageseries.write(
+            ims, f, 'frame-cache', style='fch5', threshold=0, path='images/det'
+        )
+        assert 'HEXRD_FRAMECACHE_VERSION' in f['images/det'].attrs
+
+    with h5py.File(path, 'r') as f:
+        loaded = imageseries.open(
+            f, 'frame-cache', style='fch5', path='images/det'
+        )
+        assert len(loaded) == len(data)
+        for i in range(len(data)):
+            assert np.array_equal(np.asarray(loaded[i]), data[i])

--- a/tests/core/imageseries/test_save.py
+++ b/tests/core/imageseries/test_save.py
@@ -47,6 +47,8 @@ def mock_h5_env():
             *args, **kwargs
         )
         m_h5.File = FakeH5File
+        # An h5py.File is a Group; the writer type-checks against Group.
+        m_h5.Group = FakeH5File
 
         yield m_h5, constructor_spy, file_instance
 


### PR DESCRIPTION
# Overview

Allows an fch5 frame cache to be written into and read from an already-open HDF5 file or group (e.g. an application state file), rather than only a standalone file.

# Affected Workflows

Core
