### PR TITLE
Stop installing conda-libmamba-solver in the package workflows

### DIFF
--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -16,9 +16,6 @@ chmod a+x Miniconda3-latest-Linux-x86_64.sh
 # Activate conda
 source $HOME/miniconda3/bin/activate
 
-# The base needs to have the same python version (3.11, right now)
-conda install --override-channels -c conda-forge python=3.11 -y
-
 # Set up the hexrd channel
 conda create --override-channels -c conda-forge -y -n hexrd python=3.11
 conda activate hexrd

--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -23,9 +23,6 @@ conda install --override-channels -c conda-forge python=3.11 -y
 conda create --override-channels -c conda-forge -y -n hexrd python=3.11
 conda activate hexrd
 
-# Install the libmamba solver (it is much faster)
-conda install -n base -c conda-forge conda-libmamba-solver
-conda config --set solver libmamba
 conda config --set conda_build.pkg_format 1 # force tar.bz2 files
 
 

--- a/.github/workflows/container_build.sh
+++ b/.github/workflows/container_build.sh
@@ -28,6 +28,14 @@ conda remove -n base conda-anaconda-telemetry
 
 # Install conda build and create output directory
 conda install --override-channels -c conda-forge conda-build -y
+
+# conda-forge builds conda in an over-long placeholder prefix, so its `conda`
+# entry point ships with a "#!/usr/bin/env python" shebang instead of an
+# absolute one. During conda-build the host env (which has no conda) is first
+# on PATH, so `conda` runs under that python and dies with "No module named
+# 'conda'". Pin the shebang to this env's interpreter.
+sed -i "1s|^#!/usr/bin/env python.*|#!${CONDA_PREFIX}/bin/python|" "${CONDA_PREFIX}/bin/conda"
+
 mkdir output
 
 # Build the package

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,10 +45,6 @@ jobs:
 
     - name: Install build requirements
       run: |
-          # Change default solver to be libmamba, so that it runs much faster
-          conda install -n base --override-channels -c conda-forge conda-libmamba-solver
-          conda config --set solver libmamba
-
           conda activate hexrd
           conda install --override-channels -c conda-forge anaconda-client conda-build conda
 
@@ -63,19 +59,10 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: '11.0'
       run: |
           conda activate hexrd
-          # For some reason, we need to set this in the environment as well.
-          # It seems conda build sometimes needs the solver in the environment
-          # and sometimes in the base environment. I don't know why.
-          conda install --override-channels -c conda-forge conda-libmamba-solver
-          conda config --env --set solver libmamba
           conda config --set conda_build.pkg_format 1 # force tar.bz2 files
           conda list
 
           mkdir output
-          # Conda build is ignoring the .condarc for some reason, so we need to
-          # set this environment variable instead.
-          # Setting this variable via `env` did not seem to work for some reason.
-          export CONDA_SOLVER=libmamba
           # Retry conda build up to N times to handle transient checksum
           # mismatch failures caused by stale cached repodata.
           max_attempts=5

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,6 +42,12 @@ jobs:
         python-version: 3.11
         activate-environment: hexrd
         auto-activate-base: false
+        # Create the env from conda-forge only. Otherwise setup-miniconda mixes
+        # the Anaconda "defaults" channel in, and the incompatible python
+        # packaging breaks conda with "No module named 'conda'" (macOS).
+        channels: conda-forge
+        channel-priority: strict
+        conda-remove-defaults: true
 
     - name: Install build requirements
       run: |


### PR DESCRIPTION
# Overview

Installing conda-libmamba-solver into the base env pulled in conda 26.5.3 (requires Python 3.13), corrupting base conda and failing the Linux build with `ModuleNotFoundError: No module named 'conda'`.

libmamba has been the default solver since conda 23.10, so drop the explicit install/config from package.yml and container_build.sh.

# Affected Workflows

None (packaging only)

# Documentation Changes

None