### PR TITLE
Fix energy_correction wavelength shape bug

### DIFF
--- a/hexrd/core/instrument/hedm_instrument.py
+++ b/hexrd/core/instrument/hedm_instrument.py
@@ -1120,7 +1120,11 @@ class HEDMInstrument(object):
                 raise TypeError("active_hkls must be an iterable with __len__")
 
             # these are all active reflection unique hklIDs
-            active_hklIDs = plane_data.getHKLID(plane_data.hkls, master=True)
+            # np.asarray: getHKLID may return a list, and `list == int` below is
+            # a scalar bool -> np.where(scalar) raises "0d array nonzero".
+            active_hklIDs = np.asarray(
+                plane_data.getHKLID(plane_data.hkls, master=True)
+            )
 
             # find indices
             idx = np.zeros_like(active_hkls, dtype=int)

--- a/hexrd/hedm/xrdutil/utils.py
+++ b/hexrd/hedm/xrdutil/utils.py
@@ -1060,7 +1060,15 @@ def apply_correction_to_wavelength(
     ind = 1 if energy_correction['axis'] == 'y' else 0
 
     # Correct wavelength according to grain position. Position is in mm.
-    position = tvec_c[ind] + tvec_s[ind] - energy_correction['intercept']
+    # tvec_c/tvec_s may be shaped (3, 1) (e.g. objFuncFitGrain reshapes tVec_c
+    # to (3, 1)); ravel so `position` is a scalar. A stray (1,) here makes the
+    # corrected wavelength a length-1 array, which oscill_angles_of_hkls then
+    # treats as a per-reflection wavelength array (1 value vs N hkls) -> NaN ->
+    # "Infeasible parameters for hkls".
+    position = (
+        np.ravel(tvec_c)[ind] + np.ravel(tvec_s)[ind]
+        - energy_correction['intercept']
+    )
 
     # The slope is in eV/mm. Convert to keV.
     adjustment = position * energy_correction['slope'] / 1e3

--- a/tests/core/fitting/test_fitting_grains.py
+++ b/tests/core/fitting/test_fitting_grains.py
@@ -16,6 +16,9 @@ def env():
     det1 = MagicMock(distortion=None)
     instr.detectors = {'det1': det1}
     instr.detector_parameters = {'det1': MagicMock()}
+    # Real arrays (not bare MagicMocks) for values that flow into numpy ops
+    # such as apply_correction_to_wavelength (np.ravel(instr.tvec)).
+    instr.tvec = np.zeros(3)
 
     return {
         'inst': instr,


### PR DESCRIPTION
# Overview

This issue only occurs when a wavelength correction was being applied, via the beam energy correction features.

objFuncFitGrain reshapes tVec_c to (3, 1), so tvec_c[ind] (and tvec_s[ind]) returned a length-1 array rather than a scalar. That made the corrected wavelength a (1,) array, which oscill_angles_of_hkls interpreted as a per-reflection wavelength array (1 value vs N hkls), producing NaN angles and a spurious "Infeasible parameters for hkls" RuntimeError whenever energy_correction was set (even with slope=0). Ravel tvec_c/tvec_s so position is a scalar and the corrected wavelength keeps the input's dimensionality.

# Affected Workflows

HEDM

# Documentation Changes

None