### PR TITLE
Fix stats buffer shape for fch5 caches

### DIFF
--- a/hexrd/core/imageseries/stats.py
+++ b/hexrd/core/imageseries/stats.py
@@ -314,7 +314,9 @@ def _toarray(
 
 def _alloc_buffer(ims: ImageInput, nf: int) -> np.ndarray:
     """Allocate buffer to save as many full frames as possible"""
-    shp, dt = ims.shape, ims.dtype
+    # Some adapters (e.g. fch5) report shape as an ndarray, which would
+    # broadcast-add with (nf,) instead of concatenating.
+    shp, dt = tuple(ims.shape), ims.dtype
     framesize = shp[0] * shp[1] * dt.itemsize
     nf = np.minimum(nf, np.floor(STATS_BUFFER / framesize).astype(int))
     bshp = (nf,) + shp

--- a/tests/core/imageseries/test_stats.py
+++ b/tests/core/imageseries/test_stats.py
@@ -195,6 +195,13 @@ def test_alloc_buffer(mock_ims):
         buf = stats._alloc_buffer(mock_ims, 10)
         assert buf.shape == (10, 4, 4)
 
+    # An ndarray shape (as the fch5 adapter reports) must concatenate,
+    # not broadcast-add
+    mock_ims.shape = np.array([4, 4])
+    with patch('hexrd.core.imageseries.stats.STATS_BUFFER', 1000):
+        buf = stats._alloc_buffer(mock_ims, 10)
+        assert buf.shape == (10, 4, 4)
+
 
 def test_toarray_buffering(mock_ims):
     arr = stats._toarray(mock_ims, 10)


### PR DESCRIPTION
# Overview

The fch5 adapter reports its shape as an ndarray, so the buffer allocation in the stats module broadcast-added it to (nf,) instead of concatenating, breaking median/percentile on fch5 frame caches.

# Affected Workflows

Core

# Documentation Changes

None (bug fix)