### PR TITLE
Add old "_newton" variants of ge_41rt

### DIFF
--- a/hexrd/core/distortion/ge_41rt.py
+++ b/hexrd/core/distortion/ge_41rt.py
@@ -47,6 +47,60 @@ def _ge_41rt_inverse_distortion(
 
 
 @numba.njit(nogil=True, cache=True)
+def _ge_41rt_inverse_distortion_newton(out, in_, rhoMax, params):
+    """Newton solve of the forward model, per point.
+
+    This is the inverse hexrd used prior to the closed-form cubic solver, kept
+    verbatim so ``GE_41RT_newton`` reproduces the historical results exactly.
+    Unlike the closed form it uses all six parameters and makes no assumption
+    about the radial exponents.
+    """
+    maxiter = 100
+    prec = cnst.epsf
+
+    p0, p1, p2, p3, p4, p5 = params[0:6]
+    rxi = 1.0 / rhoMax
+    for el in range(len(in_)):
+        xi, yi = in_[el, 0:2]
+        ri = np.sqrt(xi * xi + yi * yi)
+        if ri < cnst.sqrt_epsf:
+            ri_inv = 0.0
+        else:
+            ri_inv = 1.0 / ri
+        sinni = yi * ri_inv
+        cosni = xi * ri_inv
+        ro = ri
+        cos2ni = cosni * cosni - sinni * sinni
+        sin2ni = 2 * sinni * cosni
+        cos4ni = cos2ni * cos2ni - sin2ni * sin2ni
+        # newton solver iteration
+        for i in range(maxiter):
+            ratio = ri * rxi
+            fx = (
+                p0 * ratio**p3 * cos2ni + p1 * ratio**p4 * cos4ni + p2 * ratio**p5 + 1
+            ) * ri - ro  # f(x)
+            fxp = (
+                p0 * ratio**p3 * cos2ni * (p3 + 1)
+                + p1 * ratio**p4 * cos4ni * (p4 + 1)
+                + p2 * ratio**p5 * (p5 + 1)
+                + 1
+            )  # f'(x)
+
+            delta = fx / fxp
+            ri = ri - delta
+            # convergence check for newton
+            if np.abs(delta) <= prec * np.abs(ri):
+                break
+
+        xi = ri * cosni
+        yi = ri * sinni
+        out[el, 0] = xi
+        out[el, 1] = yi
+
+    return out
+
+
+@numba.njit(nogil=True, cache=True)
 def _ge_41rt_distortion(out, in_, rhoMax, params):
     p0, p1, p2, p3, p4, p5 = params[0:6]
     rxi = 1.0 / rhoMax
@@ -140,5 +194,34 @@ class GE_41RT(DistortionABC, metaclass=_RegisterDistortionClass):
             xy_in = np.asarray(xy_in, dtype=float)
             xy_out = inverse_distortion.ge_41rt_inverse_distortion(
                 xy_in, float(RHO_MAX), np.asarray(self.params[:3])
+            )
+            return xy_out
+
+
+class GE_41RT_newton(GE_41RT, metaclass=_RegisterDistortionClass):
+    """GE41RT distortion using the iterative Newton inverse.
+
+    Identical to :class:`GE_41RT` in the forward direction. The difference is
+    ``apply_inverse``, which solves the forward model numerically instead of
+    using the closed-form cubic in ``inverse_distortion``.
+
+    The closed form is only exact for radial exponents ``(p3, p4, p5) ==
+    (2, 2, 2)``; for any other exponents (the canonical GE values are
+    ``(2, 4, 2)``) it silently treats them as 2, so the inverse no longer
+    inverts the forward map. It also uses only ``params[:3]``, and returns NaN
+    where the cubic has no valid root. Newton handles all six parameters and
+    the full parameter range, at the cost of speed.
+    """
+
+    maptype = "GE_41RT_newton"
+
+    def apply_inverse(self, xy_in):
+        if self.is_trivial:
+            return xy_in
+        else:
+            xy_in = np.asarray(xy_in, dtype=float)
+            xy_out = np.empty_like(xy_in)
+            _ge_41rt_inverse_distortion_newton(
+                xy_out, xy_in, float(RHO_MAX), np.asarray(self.params)
             )
             return xy_out

--- a/tests/core/distortion/test_distortion_ge_41rt.py
+++ b/tests/core/distortion/test_distortion_ge_41rt.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+
+import hexrd.core.distortion as distortion
+from hexrd.core.distortion.ge_41rt import RHO_MAX, inverse_distortion_numpy
+
+# Canonical GE exponents are (2, 4, 2). These are the ge3 parameters from
+# examples/state_examples/GE_WPPF/ge_wppf.h5
+GE_WPPF_PARAMS = [
+    -5.24127372e-07,
+    -7.14809975e-05,
+    -5.18806621e-04,
+    2.0,
+    4.0,
+    2.0,
+]
+
+# Same magnitudes, but positive, so B(eta) > 0 (pincushion). The closed-form
+# inverse takes sqrt(-B) here and returns NaN.
+PINCUSHION_PARAMS = [5.24e-07, 7.15e-05, 5.19e-04, 2.0, 2.0, 2.0]
+
+
+def _panel_points(n=64):
+    """Points spanning a 2048x2048 GE panel, in mm.
+
+    The corners reach rho ~ 290 mm, well past RHO_MAX (204.8), which is where
+    the closed-form inverse's exponent assumption diverges the most.
+    """
+    c = np.linspace(-204.8, 204.8, n)
+    x, y = np.meshgrid(c, c)
+    return np.column_stack((x.ravel(), y.ravel()))
+
+
+def test_newton_is_registered_and_shares_the_forward_map():
+    assert 'GE_41RT_newton' in distortion.maptypes()
+
+    xy = _panel_points()
+    old = distortion.get_mapping('GE_41RT', GE_WPPF_PARAMS)
+    new = distortion.get_mapping('GE_41RT_newton', GE_WPPF_PARAMS)
+
+    assert new.maptype == 'GE_41RT_newton'
+    assert len(new.params) == 6
+    # Only the inverse differs; the forward model must be untouched.
+    assert np.array_equal(old.apply(xy), new.apply(xy))
+
+    # Trivial parameters still short-circuit.
+    trivial = distortion.get_mapping('GE_41RT_newton', [0, 0, 0, 2, 4, 2])
+    assert trivial.is_trivial
+    assert trivial.apply_inverse(xy) is xy
+
+
+@pytest.mark.parametrize('params', [GE_WPPF_PARAMS, PINCUSHION_PARAMS])
+def test_newton_inverse_actually_inverts(params):
+    """apply_inverse(apply(x)) == x, for exponents and signs the closed form
+    cannot handle."""
+    xy = _panel_points()
+    dc = distortion.get_mapping('GE_41RT_newton', params)
+
+    result = dc.apply_inverse(dc.apply(xy))
+    assert not np.isnan(result).any()
+    assert np.allclose(result, xy, atol=1e-9)
+
+    # Equivalent to the legacy helper, up to the polar round trip's roundoff.
+    fwd = dc.apply(xy)
+    expected = inverse_distortion_numpy(
+        np.hypot(fwd[:, 0], fwd[:, 1]),
+        np.arctan2(fwd[:, 1], fwd[:, 0]),
+        RHO_MAX,
+        np.asarray(params, dtype=float),
+    )
+    assert np.allclose(np.hypot(result[:, 0], result[:, 1]), expected, atol=1e-12)
+
+
+def test_newton_fixes_what_the_closed_form_gets_wrong():
+    """Regression guard for hexrd#946: this is the reason the maptype exists."""
+    xy = _panel_points()
+    old = distortion.get_mapping('GE_41RT', GE_WPPF_PARAMS)
+    new = distortion.get_mapping('GE_41RT_newton', GE_WPPF_PARAMS)
+    fwd = old.apply(xy)
+
+    def radial_error(dc):
+        out = dc.apply_inverse(fwd)
+        return np.hypot(out[:, 0], out[:, 1]) - np.hypot(xy[:, 0], xy[:, 1])
+
+    # Exponents (2, 4, 2): the closed form assumes 2 and is off by tens of
+    # microns in the corners, where Newton is exact.
+    assert np.nanmax(np.abs(radial_error(old))) > 1e-2  # mm
+    assert np.nanmax(np.abs(radial_error(new))) < 1e-9  # mm
+
+    # Pincushion: the closed form is all NaN, Newton is finite everywhere.
+    old_pin = distortion.get_mapping('GE_41RT', PINCUSHION_PARAMS)
+    new_pin = distortion.get_mapping('GE_41RT_newton', PINCUSHION_PARAMS)
+    fwd_pin = old_pin.apply(xy)
+    assert np.isnan(old_pin.apply_inverse(fwd_pin)).all()
+    assert np.isfinite(new_pin.apply_inverse(fwd_pin)).all()


### PR DESCRIPTION
If a user specifies "_newton" at the end of the ge_41rt name, the old newton methods will be used.

We actually really need the old newton method in some cases, including a GE detector at APS, which appears to have a pincushion effect. The new ge_41rt closed-form cubic solver method **cannot** model the pincushion effect, so we must use the old newton method for it.