### PR TITLE
Read the space-group setting from CIF files

### DIFF
--- a/hexrd/core/material/material.py
+++ b/hexrd/core/material/material.py
@@ -72,10 +72,14 @@ def _key(x):
 
 
 def get_default_sgsetting(sgnum):
-    if sgnum in two_origin_choice:
-        return 1
-    else:
-        return 0
+    """Setting to assume when a space group admits more than one and the
+    source does not say which.
+
+    There is no reliable way to guess, so this returns the same default
+    the rest of hexrd uses (Material.DFLT_SGSETTING, unitcell), which is
+    origin choice 1.  Callers that can detect the ambiguity should warn.
+    """
+    return Material.DFLT_SGSETTING
 
 
 #
@@ -599,17 +603,21 @@ class Material(object):
             raise RuntimeError(' No space group information in CIF file! ')
 
         sgnum = 0
+        hm_setting_code = None
         if skey is sgkey[0]:
             sgnum = int(cifdata[sgkey[0]])
         elif skey is sgkey[1]:
             HM = cifdata[sgkey[1]]
             HM = HM.replace(" ", "")
             HM = HM.replace("_", "")
+            if ':' in HM:
+                # e.g. "F d -3 m :2"; the suffix names the setting
+                HM, _, hm_setting_code = HM.partition(':')
             sgnum = HM_to_sgnum[HM]
         elif skey is sgkey[2]:
             hall = cifdata[sgkey[2]]
             hall = hall.replace(" ", "")
-            sgnum = Hall_to_sgnum[HM]
+            sgnum = Hall_to_sgnum[hall]
         elif skey is sgkey[3]:
             sgnum = int(cifdata[sgkey[3]])
 
@@ -638,7 +646,41 @@ class Material(object):
                 lparms[i] = _degrees(lparms[i])
 
         self._lparms = lparms
-        self._sgsetting = get_default_sgsetting(sgnum)
+
+        # Space-group setting.  hexrd supports the standard descriptions
+        # only: origin choices 1 and 2 for the 24 space groups with two
+        # origins, hexagonal axes for rhombohedral groups, and unique
+        # axis b, cell choice 1 for monoclinic groups.
+        sgsetting = get_default_sgsetting(sgnum)
+        code = hm_setting_code
+        key = '_space_group_IT_coordinate_system_code'
+        if key in cifdata:
+            code = str(cifdata[key]).strip()
+        if code:
+            code = code.lower()
+            if code in ('1', '2'):
+                if sgnum in two_origin_choice:
+                    sgsetting = 0 if code == '1' else 1
+            elif code in ('h', 'b1'):
+                # hexagonal axes / unique axis b, cell choice 1: these
+                # are the descriptions hexrd already assumes
+                pass
+            else:
+                raise RuntimeError(
+                    f"The CIF file uses space-group setting '{code}', "
+                    "which hexrd does not support. Only the standard "
+                    "settings are available: origin choices 1 and 2, "
+                    "hexagonal axes for rhombohedral groups, and unique "
+                    "axis b, cell choice 1 for monoclinic groups."
+                )
+        elif sgnum in two_origin_choice:
+            logger.warning(
+                'The CIF file does not specify a space-group setting, and '
+                'space group %d has two origin choices. Assuming origin '
+                'choice %d; set the material\'s sgsetting if that is not '
+                'correct.', sgnum, sgsetting + 1
+            )
+        self._sgsetting = sgsetting
         self.sgnum = sgnum
 
         # fractional atomic site, occ and vibration amplitude

--- a/tests/material/test_cif_sgsetting.py
+++ b/tests/material/test_cif_sgsetting.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import pytest
+
+from hexrd.material.material import Material
+
+
+# Diamond, space group 227, which has two origin choices.  The atom sits
+# at the origin, so the two settings give genuinely different structures.
+CIF_TEMPLATE = """data_test
+_cell_length_a 3.567
+_cell_length_b 3.567
+_cell_length_c 3.567
+_cell_angle_alpha 90
+_cell_angle_beta 90
+_cell_angle_gamma 90
+{space_group}
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+C1 C 0.0 0.0 0.0 1.0
+"""
+
+
+def write_cif(tmp_path: Path, space_group: str) -> Path:
+    path = tmp_path / 'test.cif'
+    path.write_text(CIF_TEMPLATE.format(space_group=space_group))
+    return path
+
+
+def load(tmp_path: Path, space_group: str) -> Material:
+    path = write_cif(tmp_path, space_group)
+    return Material(name='test', material_file=str(path))
+
+
+@pytest.mark.parametrize(
+    'space_group, expected',
+    [
+        # explicit coordinate system code
+        ('_space_group_IT_number 227\n_space_group_IT_coordinate_system_code 1', 0),
+        ('_space_group_IT_number 227\n_space_group_IT_coordinate_system_code 2', 1),
+        # setting given as a suffix on the Hermann-Mauguin symbol
+        ("_symmetry_space_group_name_H-M 'F d -3 m :2'", 1),
+        # no setting given: fall back to the default
+        ('_space_group_IT_number 227', Material.DFLT_SGSETTING),
+        # an empty code is the same as not giving one
+        (
+            "_space_group_IT_number 227\n_space_group_IT_coordinate_system_code ''",
+            Material.DFLT_SGSETTING,
+        ),
+    ],
+)
+def test_sgsetting_read_from_cif(
+    tmp_path: Path, space_group: str, expected: int
+) -> None:
+    assert load(tmp_path, space_group).sgsetting == expected
+
+
+def test_settings_give_different_structure_factors(tmp_path: Path) -> None:
+    # The whole point of reading the setting: the two origin choices
+    # describe different structures.
+    first = load(
+        tmp_path,
+        '_space_group_IT_number 227\n_space_group_IT_coordinate_system_code 1',
+    )
+    second = load(
+        tmp_path,
+        '_space_group_IT_number 227\n_space_group_IT_coordinate_system_code 2',
+    )
+    assert first.planeData.structFact.tolist() != (second.planeData.structFact.tolist())
+
+
+def test_unsupported_setting_is_rejected(tmp_path: Path) -> None:
+    # hexrd only implements the standard descriptions.
+    with pytest.raises(RuntimeError, match='does not support'):
+        load(
+            tmp_path,
+            '_space_group_IT_number 14\n_space_group_IT_coordinate_system_code -b1',
+        )
+
+
+def test_standard_monoclinic_setting_is_accepted(tmp_path: Path) -> None:
+    # Unique axis b, cell choice 1 is what hexrd already assumes.
+    material = load(
+        tmp_path,
+        '_space_group_IT_number 14\n_space_group_IT_coordinate_system_code b1',
+    )
+    assert material.sgnum == 14


### PR DESCRIPTION
# Overview

The reader discarded the setting and always used the default, so a CIF written in the second origin choice imported with its atoms in the wrong places.  Read it from the coordinate-system code or the Hermann-Mauguin suffix, reject settings hexrd cannot represent, and default consistently with the rest of hexrd when a file omits it.

# Affected Workflows

All. But only for using the second sgsetting, which is somewhat uncommon.
