### PR TITLE
Fix cylindrical detector helper imports broken by the subpackage split

### DIFF
--- a/hexrd/core/instrument/cylindrical_detector.py
+++ b/hexrd/core/instrument/cylindrical_detector.py
@@ -6,7 +6,13 @@ from hexrd.core import constants as ct
 
 # TODO: Resolve extra-core dependency
 from hexrd.hedm import xrdutil
-from hexrd.hed.xrdutil.utils import _warp_to_cylinder
+from hexrd.hed.xrdutil.utils import (
+    _clip_to_cylindrical_detector,
+    _dewarp_from_cylinder,
+    _project_on_detector_cylinder,
+    _unitvec_to_cylinder,
+    _warp_to_cylinder,
+)
 from hexrd.core.utils.decorators import memoize
 
 from .detector import Detector
@@ -112,7 +118,7 @@ class CylindricalDetector(Detector):
             self.distortion,
         )
 
-        proj_func = xrdutil.utils._project_on_detector_cylinder
+        proj_func = _project_on_detector_cylinder
         valid_xy, rMat_ss, valid_mask = proj_func(*args, **kwargs)
         xy_det = np.empty([angs.shape[0], 2])
         xy_det.fill(np.nan)
@@ -297,7 +303,7 @@ class CylindricalDetector(Detector):
             self.radius,
             self.tvec,
         )
-        pt_on_cylinder = xrdutil.utils._unitvec_to_cylinder(*args)
+        pt_on_cylinder = _unitvec_to_cylinder(*args)
 
         args = (
             pt_on_cylinder,
@@ -308,10 +314,10 @@ class CylindricalDetector(Detector):
             self.physical_size,
             self.angle_extent,
         )
-        pt_on_cylinder, _ = xrdutil.utils._clip_to_cylindrical_detector(*args)
+        pt_on_cylinder, _ = _clip_to_cylindrical_detector(*args)
 
         args = (pt_on_cylinder, self.tvec, self.caxis, self.paxis, self.radius)
-        output = xrdutil.utils._dewarp_from_cylinder(*args)
+        output = _dewarp_from_cylinder(*args)
         return output
 
     @property

--- a/tests/core/instrument/test_cylindrical_detector.py
+++ b/tests/core/instrument/test_cylindrical_detector.py
@@ -22,7 +22,17 @@ def mock_warp():
 
 @pytest.fixture
 def mock_xrdutil():
-    with patch('hexrd.core.instrument.cylindrical_detector.xrdutil') as m:
+    prefix = 'hexrd.core.instrument.cylindrical_detector.'
+    with patch(prefix + 'xrdutil') as m, \
+            patch(prefix + '_project_on_detector_cylinder') as m_proj, \
+            patch(prefix + '_unitvec_to_cylinder') as m_unit, \
+            patch(prefix + '_clip_to_cylindrical_detector') as m_clip, \
+            patch(prefix + '_dewarp_from_cylinder') as m_dewarp:
+        m.utils._project_on_detector_cylinder = m_proj
+        m.utils._unitvec_to_cylinder = m_unit
+        m.utils._clip_to_cylindrical_detector = m_clip
+        m.utils._dewarp_from_cylinder = m_dewarp
+
         m.utils._dvec_to_angs.return_value = (np.array([0.1]), np.array([0.2]))
 
         m.utils._project_on_detector_cylinder.return_value = (
@@ -250,3 +260,48 @@ def test_branch_cut_fix():
     arr_cut = np.array([np.pi])
     res_cut = _fix_branch_cut_in_gradients(arr_cut)
     assert np.isclose(res_cut, 0.0, atol=1e-6)
+
+
+def test_angle_round_trip():
+    """Forward-project random diffraction directions onto a tilted
+    cylindrical panel and invert; no mocks, so this exercises the real
+    helper imports (regression test for the subpackage-split breakage)."""
+    from hexrd.core import instrument
+
+    config = {
+        'beam': {'energy': 30.0,
+                 'vector': {'azimuth': 90.0, 'polar_angle': 90.0}},
+        'oscillation_stage': {'chi': 0.0, 'translation': [0.0, 0.0, 0.0]},
+        'detectors': {'cyl': {
+            'detector_type': 'cylindrical',
+            'pixels': {'rows': 3000, 'columns': 5000, 'size': [0.1, 0.1]},
+            'transform': {'tilt': [0.31, -0.22, 0.13],
+                          'translation': [5.0, -3.0, -250.0]},
+            'radius': 300.0,
+        }},
+    }
+    instr = instrument.HEDMInstrument(instrument_config=config)
+    panel = instr.detectors['cyl']
+
+    rng = np.random.default_rng(7)
+    n = 200000
+    tth = np.radians(rng.uniform(5.0, 70.0, n))
+    eta = np.radians(rng.uniform(-180.0, 180.0, n))
+
+    xy = panel.angles_to_cart(np.column_stack([tth, eta]))
+    if isinstance(xy, tuple):
+        xy = xy[0]
+
+    on_panel = np.isfinite(xy).all(axis=1)
+    on_panel &= np.abs(xy[:, 0]) <= panel.col_dim / 2
+    on_panel &= np.abs(xy[:, 1]) <= panel.row_dim / 2
+    # a healthy fraction of the random directions must hit the panel
+    assert on_panel.sum() > n // 10
+
+    back, _ = panel.cart_to_angles(xy[on_panel])
+    d_tth = np.degrees(np.abs(back[:, 0] - tth[on_panel]))
+    d_eta = np.degrees(
+        np.abs(np.angle(np.exp(1j * (back[:, 1] - eta[on_panel]))))
+    )
+    assert d_tth.max() < 1e-7
+    assert d_eta.max() < 1e-7


### PR DESCRIPTION
# Overview

`angles_to_cart`, `cart_to_dvecs`, and `beam_position` on `CylindricalDetector` looked up the cylinder helpers (`_project_on_detector_cylinder`, `_unitvec_to_cylinder`, `_clip_to_cylindrical_detector`, `_dewarp_from_cylinder`) on `hexrd.hedm.xrdutil`, but they live in `hexrd.hed.xrdutil`, so these methods raised `AttributeError`. The polar-view path was unaffected because `core/projections/polar.py` imports from the correct subpackage.

The existing tests mocked the whole `xrdutil` module and therefore could not catch this; the mocks now patch the directly imported names, and an unmocked angle round-trip regression test is added (123k random directions forward-projected onto a tilted cylindrical panel and inverted recover the input angles to below 1e-7 deg).

# Affected Workflows

Anything calling `angles_to_cart`/`cart_to_dvecs`/`beam_position` on a cylindrical detector, e.g. overlay simulation on cylindrical panels.
