### PR TITLE
Avoid overflow in eta-omega histograms

### DIFF
--- a/hexrd/core/instrument/hedm_instrument.py
+++ b/hexrd/core/instrument/hedm_instrument.py
@@ -2553,7 +2553,11 @@ def _run_histograms(rows, ims, tth_ranges, ring_maps, ring_params, threshold):
 
             # Unpack the params
             pixel_etas, eta_edges, pixel_ids, bins_on_detector = params
-            result = histogram(pixel_etas, bins=eta_edges, weights=image[pixel_ids])[0]
+            result = histogram(
+                pixel_etas,
+                bins=eta_edges,
+                weights=np.asarray(image[pixel_ids], dtype=np.float64),
+            )[0]
 
             # Note that this preserves nan values for bins not on the detector.
             this_map[i_row, bins_on_detector] = result[bins_on_detector]

--- a/tests/core/instrument/test_hedm_instrument.py
+++ b/tests/core/instrument/test_hedm_instrument.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from hexrd.core.instrument.hedm_instrument import (
+    _generate_ring_params,
+    _run_histograms,
+)
+
+
+def test_run_histograms_does_not_overflow_uint16_weights():
+    ptth = np.full((1, 2), 0.1)
+    peta = np.zeros_like(ptth)
+    eta_edges = np.array([-0.5, 0.5])
+    tth_ranges = [(0.05, 0.15)]
+    ring_params = [
+        _generate_ring_params(tth_ranges[0], ptth, peta, eta_edges, 1.0)
+    ]
+
+    images = [np.full((1, 2), 40_000, dtype=np.uint16)]
+    ring_maps = np.full((1, 1, 1), np.nan)
+    _run_histograms((0, 1), images, tth_ranges, ring_maps, ring_params, None)
+
+    assert ring_maps[0, 0, 0] == 80_000


### PR DESCRIPTION
# Overview

Promote selected histogram weights to float64 before accumulation. Add a regression test for uint16 bin totals above 65,535.

# Affected Workflows

HEDM

Fixes: #964 