### PR TITLE
Remove the JHE pinhole model

### DIFF
--- a/hexrd/core/instrument/detector.py
+++ b/hexrd/core/instrument/detector.py
@@ -23,9 +23,8 @@ from hexrd.core import matrixutil as mutil
 
 if TYPE_CHECKING:
     from hexrd.hed.xrdutil.phutil import (
-        JHEPinholeDistortion,
         LayerDistortion,
-        RyggPinholeDistortion,
+        PinholeDistortion,
     )
 # TODO: Resolve extra-core-dependency
 from hexrd.hedm import xrdutil
@@ -1231,7 +1230,7 @@ class Detector:
         tvec_c: NDArray[np.float64] = ct.zeros_3,
         full_output: Literal[False] = False,  # TODO: Remove this option completely
         tth_distortion: Optional[
-            RyggPinholeDistortion | JHEPinholeDistortion | LayerDistortion
+            PinholeDistortion | LayerDistortion
         ] = None,
     ) -> tuple[
         list[NDArray[np.float64]], list[NDArray[np.float64]], NDArray[np.float64]
@@ -1251,7 +1250,7 @@ class Detector:
         tvec_c: NDArray[np.float64] = ct.zeros_3,
         full_output: Literal[True] = True,  # TODO: Remove this option completely
         tth_distortion: Optional[
-            RyggPinholeDistortion | JHEPinholeDistortion | LayerDistortion
+            PinholeDistortion | LayerDistortion
         ] = None,
     ) -> tuple[
         list[NDArray[np.float64]],
@@ -1276,7 +1275,7 @@ class Detector:
         tvec_c: NDArray[np.float64] = ct.zeros_3,
         full_output: bool = False,  # TODO: Remove this option completely
         tth_distortion: Optional[
-            RyggPinholeDistortion | JHEPinholeDistortion | LayerDistortion
+            PinholeDistortion | LayerDistortion
         ] = None,
     ) -> (
         tuple[

--- a/hexrd/hed/xrdutil/phutil.py
+++ b/hexrd/hed/xrdutil/phutil.py
@@ -93,53 +93,7 @@ class LayerDistortion:
         )
 
 
-class JHEPinholeDistortion:
-    def __init__(self, panel, pinhole_thickness, pinhole_radius):
-        self._panel = panel
-        self._pinhole_thickness = pinhole_thickness
-        self._pinhole_radius = pinhole_radius
-
-    @property
-    def panel(self):
-        return self._panel
-
-    @panel.setter
-    def panel(self, x):
-        assert isinstance(x, Detector), "input must be a detector"
-        self._panel = x
-
-    @property
-    def pinhole_thickness(self):
-        return self._pinhole_thickness
-
-    @pinhole_thickness.setter
-    def pinhole_thickness(self, x):
-        self._pinhole_thickness = float(x)
-
-    @property
-    def pinhole_radius(self):
-        return self._pinhole_radius
-
-    @pinhole_radius.setter
-    def pinhole_radius(self, x):
-        self._pinhole_radius = float(x)
-
-    def apply(self, xy_pts, return_nominal=True):
-        """ """
-        return tth_corr_pinhole(
-            self.panel,
-            xy_pts,
-            self.pinhole_thickness,
-            self.pinhole_radius,
-            return_nominal=return_nominal,
-        )
-
-
-# Make an alias to the name for backward compatibility
-PinholeDistortion = JHEPinholeDistortion
-
-
-class RyggPinholeDistortion:
+class PinholeDistortion:
     def __init__(
         self,
         panel,
@@ -165,6 +119,12 @@ class RyggPinholeDistortion:
             return_nominal=return_nominal,
             num_phi_elements=self.num_phi_elements,
         )
+
+
+# Backwards-compatible alias: this class was called
+# ``RyggPinholeDistortion`` while a second, now-removed pinhole model was
+# also available.
+RyggPinholeDistortion = PinholeDistortion
 
 
 def tth_corr_layer(
@@ -310,117 +270,6 @@ def tth_corr_map_layer(
 SampleLayerDistortion = LayerDistortion
 tth_corr_sample_layer = tth_corr_layer
 tth_corr_map_sample_layer = tth_corr_map_layer
-
-
-def tth_corr_pinhole(
-    panel, xy_pts, pinhole_thickness, pinhole_radius, return_nominal=True
-):
-    """
-    Compute the Bragg angle distortion associated with the pinhole as a source.
-
-    Parameters
-    ----------
-    panel : hexrd.core.instrument.Detector
-        A detector instance.
-    xy_pts : array_like
-        The (n, 2) array of n (x, y) coordinates to be transformed in the raw
-        detector coordinates (cartesian plane, origin at center).
-    pinhole_thickness : scalar
-        The thickenss (height) of the pinhole (cylinder) in mm
-    pinhole_radius : scalar
-        The radius of the pinhole in mm.
-
-    Returns
-    -------
-    TYPE
-        DESCRIPTION.
-
-    Notes
-    -----
-    The follows a slightly modified version of Jon Eggert's pinhole correction.
-
-    """
-
-    xy_pts = np.atleast_2d(xy_pts)
-    npts = len(xy_pts)
-
-    # first we need the reference etas of the points wrt the pinhole axis
-    cp_det = copy.deepcopy(panel)
-    cp_det.bvec = np.sign(cp_det.bvec[2]) * ct.beam_vec  # !!! [0, 0, -1]
-    ref_angs, _ = cp_det.cart_to_angles(
-        xy_pts, rmat_s=None, tvec_s=None, tvec_c=None, apply_distortion=True
-    )
-    ref_eta = ref_angs[:, 1]
-
-    # These are the nominal tth values
-    nom_angs, _ = panel.cart_to_angles(
-        xy_pts, rmat_s=None, tvec_s=None, tvec_c=None, apply_distortion=True
-    )
-    nom_tth = nom_angs[:, 0]
-
-    pin_tth = np.zeros(npts)
-    for i, (pxy, reta) in enumerate(zip(xy_pts, ref_eta)):
-        # !!! JHE used pinhole center, but the back surface
-        #     seems to hew a bit closer to JRR's solution
-        origin = -pinhole_radius * np.array(
-            [np.cos(reta), np.sin(reta), 0.5 * pinhole_thickness]
-        )
-        angs, _ = panel.cart_to_angles(np.atleast_2d(pxy), tvec_c=origin)
-        pin_tth[i] = angs[:, 0]
-    tth_corr = pin_tth - nom_tth
-    if return_nominal:
-        return np.vstack([nom_tth - tth_corr, nom_angs[:, 1]]).T
-    else:
-        # !!! NEED TO CHECK THIS
-        return np.vstack([-tth_corr, nom_angs[:, 1]]).T
-
-
-def tth_corr_map_pinhole(instrument, pinhole_thickness, pinhole_radius):
-    """
-    Compute the Bragg angle distortion fields for pinhole diffraction.
-
-    Parameters
-    ----------
-    instrument : hexrd.core.instrument.HEDMInstrument
-        The pionhole camera instrument object.
-    pinhole_thickness : scalar
-        The thickenss (height) of the pinhole (cylinder) in mm
-    pinhole_radius : scalar
-        The radius of the pinhole in mm
-
-    Returns
-    -------
-    tth_corr : dict
-        The Bragg angle correction fields for each detector in `instrument`
-        as 2θ_pin - 2θ_nom in radians.
-
-    Notes
-    -----
-    The follows a slightly modified version of Jon Eggert's pinhole correction.
-    """
-    cp_instr = copy.deepcopy(instrument)
-    cp_instr.beam_vector = np.sign(cp_det.bvec[2]) * ct.beam_vec  # !!! [0, 0, -1]
-
-    tth_corr = dict.fromkeys(instrument.detectors)
-    for det_key, panel in instrument.detectors.items():
-        ref_ptth, ref_peta = cp_instr.detectors[det_key].pixel_angles()
-        nom_ptth, _ = panel.pixel_angles()
-
-        dpy, dpx = panel.pixel_coords
-        pcrds = np.ascontiguousarray(np.vstack([dpx.flatten(), dpy.flatten()]).T)
-        ref_peta = ref_peta.flatten()
-
-        new_ptth = np.zeros(len(ref_peta))
-        for i, (pxy, reta) in enumerate(zip(pcrds, ref_peta)):
-            # !!! JHE used pinhole center, but the back surface
-            #     seems to hew a bit closer to JRR's solution
-            origin = -pinhole_radius * np.array(
-                [np.cos(reta), np.sin(reta), 0.5 * pinhole_thickness]
-            )
-            angs, _ = panel.cart_to_angles(np.atleast_2d(pxy), tvec_c=origin)
-            new_ptth[i] = angs[:, 0]
-        tth_corr[det_key] = new_ptth.reshape(panel.shape) - nom_ptth
-    return tth_corr
 
 
 def calc_phi_x(bvec, eHat_l):


### PR DESCRIPTION
# Overview

The JHE approximation disagreed in sign with Eggert's model as implemented in Rygg's own reference script, and its map variant referenced an undefined name, so it could never have run.  The one remaining model is now simply PinholeDistortion, with the old name kept as an alias.

# Affected Workflows

HED

xref: https://github.com/HEXRD/hexrdgui/pull/2051